### PR TITLE
feat: Invite-only alpha gate — allowlist check before magic link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,21 @@
   .auth-sent-icon { width: 52px; height: 52px; border-radius: 50%; background: var(--mint); display: flex; align-items: center; justify-content: center; color: var(--moss); margin: 0 auto 16px; }
   .auth-sent-title { font-family: 'DM Serif Display', serif; font-size: 20px; margin-bottom: 8px; }
   .auth-sent-body { font-size: 14px; color: var(--text-secondary); line-height: 1.6; }
+  .auth-gate { display: none; text-align: center; padding: 24px 0; }
+  .auth-gate-icon { width: 52px; height: 52px; border-radius: 50%; background: var(--mint); display: flex; align-items: center; justify-content: center; color: var(--moss); margin: 0 auto 16px; }
+  .auth-gate-title { font-family: 'DM Serif Display', serif; font-size: 20px; margin-bottom: 8px; }
+  .auth-gate-body { font-size: 14px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 16px; }
+  .auth-gate-input-wrap { margin-bottom: 12px; }
+  .auth-gate-input { width: 100%; padding: 14px 16px; border: 1.5px solid var(--border); border-radius: 12px; font-family: 'DM Sans', sans-serif; font-size: 15px; color: var(--text); background: var(--cream); box-sizing: border-box; }
+  .auth-gate-input:focus { outline: none; border-color: var(--moss); background: #fff; }
+  .auth-gate-success { display: none; text-align: center; padding: 12px 0 0; }
+  .auth-gate-success-icon { width: 44px; height: 44px; border-radius: 50%; background: var(--mint); display: flex; align-items: center; justify-content: center; color: var(--moss); margin: 0 auto 12px; }
+  .auth-gate-success-title { font-family: 'DM Serif Display', serif; font-size: 18px; margin-bottom: 6px; }
+  .auth-gate-success-body { font-size: 13px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 12px; }
+  .auth-gate-link { font-size: 13px; color: var(--moss); text-decoration: none; font-weight: 500; }
+  .auth-gate-link:hover { text-decoration: underline; }
+  .auth-gate-back { background: none; border: none; font-family: 'DM Sans', sans-serif; font-size: 13px; color: var(--moss); cursor: pointer; padding: 0; margin-top: 12px; }
+  .auth-gate-back:hover { text-decoration: underline; }
   .auth-demo-link { display: flex; align-items: center; justify-content: center; gap: 6px; font-size: 14px; color: var(--moss); cursor: pointer; background: transparent; border: 1.5px solid var(--moss); border-radius: 12px; font-family: 'DM Sans', sans-serif; font-weight: 500; padding: 11px 16px; transition: background 0.15s; flex: 1; }
   .auth-demo-link:hover { background: var(--mint); }
   .auth-links-row { display: flex; align-items: center; justify-content: center; gap: 10px; margin-top: 12px; }
@@ -835,6 +850,35 @@
         <i data-lucide="play" style="width:14px;height:14px;"></i>
         Try the demo while you wait
       </button>
+    </div>
+    <div id="auth-gate-state" class="auth-gate">
+      <div class="auth-gate-icon"><i data-lucide="lock" style="width:24px;height:24px;"></i></div>
+      <div class="auth-gate-title">Private alpha</div>
+      <p class="auth-gate-body">Wellet is in private alpha right now. Drop your email below and we'll let you know when it's your turn.</p>
+      <div id="auth-gate-form">
+        <div class="auth-gate-input-wrap">
+          <input type="email" id="auth-gate-email" class="auth-gate-input" placeholder="you@email.com" autocomplete="email">
+        </div>
+        <button class="btn-primary" onclick="submitWaitlistRequest()" id="auth-gate-btn">
+          Request access <i data-lucide="arrow-right" style="width:16px;height:16px;"></i>
+        </button>
+      </div>
+      <div id="auth-gate-success" class="auth-gate-success">
+        <div class="auth-gate-success-icon"><i data-lucide="check" style="width:22px;height:22px;"></i></div>
+        <div class="auth-gate-success-title">You're on the list</div>
+        <p class="auth-gate-success-body">We'll send you a magic link when your spot opens.</p>
+        <a href="https://getwellet.com" target="_blank" rel="noopener" class="auth-gate-link">Learn more about Wellet &rarr;</a>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:8px;margin-top:16px;">
+        <button class="auth-demo-link" style="width:100%;" onclick="enterDemoMode()">
+          <i data-lucide="play-circle" style="width:14px;height:14px;"></i>
+          Try the demo
+        </button>
+        <button class="auth-gate-back" onclick="showAuthFormState()">
+          <i data-lucide="arrow-left" style="width:12px;height:12px;vertical-align:middle;"></i>
+          Back to sign in
+        </button>
+      </div>
     </div>
     <div class="auth-privacy">
     <p>No password required. <button class="auth-privacy-toggle" onclick="togglePrivacyDetail()"><strong>Your data stays private</strong> <i data-lucide="chevron-down" style="width:12px;height:12px;vertical-align:middle;" id="privacy-chevron"></i></button></p>
@@ -2367,8 +2411,17 @@ window.addEventListener('load', function() { initIcons(); initVoiceInput(); });
 // ── AUTH FLOW ────────────────────────────────────────────────────────────────
 async function initApp() {
   try {
-    const { data: { session } } = await db.auth.getSession();
+    var { data: { session } } = await db.auth.getSession();
     if (session) {
+      // Verify the user is still on the alpha allowlist
+      var stillAllowed = await checkAlphaAllowlist(session.user.email);
+      if (!stillAllowed) {
+        console.warn('User removed from alpha allowlist — signing out');
+        await db.auth.signOut();
+        showAuthScreen();
+        showToast('Your alpha access has been revoked');
+        return;
+      }
       currentUser = session.user;
       await loadUserData();
     } else {
@@ -2381,6 +2434,14 @@ async function initApp() {
   // Handle auth state changes (magic link callback)
   db.auth.onAuthStateChange(async (event, session) => {
     if (event === 'SIGNED_IN' && session) {
+      // Verify allowlist on sign-in too
+      var allowed = await checkAlphaAllowlist(session.user.email);
+      if (!allowed) {
+        await db.auth.signOut();
+        showAuthScreen();
+        showToast('Your email is not on the alpha list');
+        return;
+      }
       currentUser = session.user;
       await loadUserData();
     } else if (event === 'SIGNED_OUT') {
@@ -2437,16 +2498,39 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
+async function checkAlphaAllowlist(email) {
+  var normalized = email.toLowerCase().trim();
+  var { data, error } = await db
+    .from('alpha_allowlist')
+    .select('id')
+    .eq('email', normalized)
+    .maybeSingle();
+  if (error) { console.error('Allowlist check error:', error); return false; }
+  return !!data;
+}
+
 async function sendMagicLink() {
-  const email = document.getElementById('auth-email').value.trim();
+  var email = document.getElementById('auth-email').value.trim();
   if (!email) { showToast('Please enter your email'); return; }
+  var btn = document.getElementById('auth-send-btn');
+  btn.disabled = true;
+  btn.textContent = 'Checking…';
+
+  // Alpha gate: check allowlist before sending magic link
+  var allowed = await checkAlphaAllowlist(email);
+  if (!allowed) {
+    btn.disabled = false;
+    btn.innerHTML = 'Send magic link <i data-lucide="arrow-right" style="width:16px;height:16px;"></i>';
+    initIcons();
+    showAlphaGate(email);
+    return;
+  }
+
+  btn.textContent = 'Sending…';
   var sentEmail = document.getElementById('auth-sent-email');
   if (sentEmail) sentEmail.textContent = email;
-  const btn = document.getElementById('auth-send-btn');
-  btn.disabled = true;
-  btn.textContent = 'Sending…';
-  const { error } = await db.auth.signInWithOtp({
-    email,
+  var { error } = await db.auth.signInWithOtp({
+    email: email,
     options: { emailRedirectTo: 'https://mywellet.com' }
   });
   if (error) {
@@ -2457,7 +2541,51 @@ async function sendMagicLink() {
   } else {
     document.getElementById('auth-form-state').style.display = 'none';
     document.getElementById('auth-sent-state').style.display = 'block';
+    document.getElementById('auth-gate-state').style.display = 'none';
   }
+}
+
+function showAlphaGate(email) {
+  document.getElementById('auth-form-state').style.display = 'none';
+  document.getElementById('auth-sent-state').style.display = 'none';
+  document.getElementById('auth-gate-state').style.display = 'block';
+  // Pre-fill the gate email input with what they already typed
+  var gateInput = document.getElementById('auth-gate-email');
+  if (gateInput && email) gateInput.value = email;
+  // Reset to form view (hide success in case they come back)
+  document.getElementById('auth-gate-form').style.display = 'block';
+  document.getElementById('auth-gate-success').style.display = 'none';
+  initIcons();
+}
+
+function showAuthFormState() {
+  document.getElementById('auth-form-state').style.display = 'block';
+  document.getElementById('auth-sent-state').style.display = 'none';
+  document.getElementById('auth-gate-state').style.display = 'none';
+  initIcons();
+}
+
+async function submitWaitlistRequest() {
+  var email = document.getElementById('auth-gate-email').value.trim();
+  if (!email) { showToast('Please enter your email'); return; }
+  var btn = document.getElementById('auth-gate-btn');
+  btn.disabled = true;
+  btn.textContent = 'Submitting…';
+  var { error } = await db.from('waitlist_requests').upsert(
+    { email: email.toLowerCase(), requested_at: new Date().toISOString() },
+    { onConflict: 'email' }
+  );
+  if (error) {
+    showToast('Error: ' + error.message);
+    btn.disabled = false;
+    btn.innerHTML = 'Request access <i data-lucide="arrow-right" style="width:16px;height:16px;"></i>';
+    initIcons();
+    return;
+  }
+  // Show success
+  document.getElementById('auth-gate-form').style.display = 'none';
+  document.getElementById('auth-gate-success').style.display = 'block';
+  initIcons();
 }
 
 async function handleLogout() {
@@ -3759,6 +3887,10 @@ function showAuthScreen() {
   document.getElementById('landing').style.display = 'none';
   document.getElementById('app').style.display = 'none';
   document.getElementById('onboarding').style.display = 'none';
+  // Reset auth sub-states to default (show form, hide sent/gate)
+  document.getElementById('auth-form-state').style.display = 'block';
+  document.getElementById('auth-sent-state').style.display = 'none';
+  document.getElementById('auth-gate-state').style.display = 'none';
   window.scrollTo(0, 0);
   initIcons();
 }

--- a/supabase/functions/manage-allowlist/index.ts
+++ b/supabase/functions/manage-allowlist/index.ts
@@ -1,0 +1,109 @@
+// Supabase Edge Function: manage-allowlist
+// Admin helper to add or remove emails from the alpha allowlist.
+// Protected by service_role key — only callable by Betsy or automation.
+// POST body: { action: "add" | "remove", email: string, notes?: string }
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    // Verify service_role authorization
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+    // Only allow service_role key — reject anon/user JWTs
+    const token = authHeader.replace('Bearer ', '');
+    if (token !== supabaseServiceKey) {
+      return new Response(JSON.stringify({ error: 'Forbidden — service_role key required' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body = await req.json();
+    const { action, email, notes } = body;
+
+    if (!action || !email) {
+      return new Response(JSON.stringify({ error: 'action and email are required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (!['add', 'remove'].includes(action)) {
+      return new Response(JSON.stringify({ error: 'action must be "add" or "remove"' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const adminClient = createClient(supabaseUrl, supabaseServiceKey);
+    const normalizedEmail = email.toLowerCase().trim();
+
+    if (action === 'add') {
+      const { data, error } = await adminClient
+        .from('alpha_allowlist')
+        .upsert(
+          { email: normalizedEmail, notes: notes || null, invited_at: new Date().toISOString() },
+          { onConflict: 'email' }
+        )
+        .select()
+        .single();
+
+      if (error) {
+        return new Response(JSON.stringify({ error: 'Failed to add email', detail: error.message }), {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ success: true, action: 'added', email: normalizedEmail, record: data }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (action === 'remove') {
+      const { error } = await adminClient
+        .from('alpha_allowlist')
+        .delete()
+        .eq('email', normalizedEmail);
+
+      if (error) {
+        return new Response(JSON.stringify({ error: 'Failed to remove email', detail: error.message }), {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(JSON.stringify({ success: true, action: 'removed', email: normalizedEmail }), {
+        status: 200,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+  } catch (err) {
+    console.error('Edge function error:', err);
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260415200000_create_alpha_allowlist.sql
+++ b/supabase/migrations/20260415200000_create_alpha_allowlist.sql
@@ -1,0 +1,43 @@
+-- Alpha Allowlist: gates access during private alpha.
+-- Only emails present in this table can sign in via magic link.
+-- anon can SELECT (to check membership); only service_role can mutate.
+
+create table if not exists public.alpha_allowlist (
+  id uuid default gen_random_uuid() primary key,
+  email text not null unique,
+  invited_at timestamptz not null default now(),
+  accepted_at timestamptz,
+  notes text
+);
+
+-- Ensure emails are always stored lowercase
+create or replace function public.alpha_allowlist_lower_email()
+returns trigger as $$
+begin
+  new.email := lower(new.email);
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_alpha_allowlist_lower_email
+  before insert or update on public.alpha_allowlist
+  for each row execute function public.alpha_allowlist_lower_email();
+
+-- Index for fast email lookups
+create index idx_alpha_allowlist_email on public.alpha_allowlist (email);
+
+-- RLS
+alter table public.alpha_allowlist enable row level security;
+
+-- anon + authenticated can check if an email is on the list
+create policy "Anyone can check allowlist"
+  on public.alpha_allowlist for select
+  to anon, authenticated
+  using (true);
+
+-- No insert/update/delete for anon or authenticated — only service_role bypasses RLS
+
+-- Seed: first alpha user
+insert into public.alpha_allowlist (email, notes)
+values ('betsy.eble@gmail.com', 'Founder — first alpha user')
+on conflict (email) do nothing;

--- a/supabase/migrations/20260415200001_create_waitlist_requests.sql
+++ b/supabase/migrations/20260415200001_create_waitlist_requests.sql
@@ -1,0 +1,42 @@
+-- Waitlist Requests: captures emails from users who aren't on the alpha allowlist
+-- but want to be notified when access opens up.
+
+create table if not exists public.waitlist_requests (
+  id uuid default gen_random_uuid() primary key,
+  email text not null unique,
+  requested_at timestamptz not null default now(),
+  status text not null default 'pending',
+  notes text
+);
+
+-- Lowercase email trigger
+create or replace function public.waitlist_requests_lower_email()
+returns trigger as $$
+begin
+  new.email := lower(new.email);
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_waitlist_requests_lower_email
+  before insert or update on public.waitlist_requests
+  for each row execute function public.waitlist_requests_lower_email();
+
+-- Index
+create index idx_waitlist_requests_email on public.waitlist_requests (email);
+
+-- RLS
+alter table public.waitlist_requests enable row level security;
+
+-- anon can insert (submit a request) and select own row for duplicate checking
+create policy "Anyone can submit a waitlist request"
+  on public.waitlist_requests for insert
+  to anon, authenticated
+  with check (true);
+
+create policy "Anyone can check waitlist requests"
+  on public.waitlist_requests for select
+  to anon, authenticated
+  using (true);
+
+-- Only service_role can update/delete


### PR DESCRIPTION
## Summary
- **Alpha allowlist table** (`alpha_allowlist`): Only emails on this list can sign in via magic link. RLS allows anon SELECT for membership checks; only service_role can mutate. Seeded with `betsy.eble@gmail.com`.
- **Waitlist requests table** (`waitlist_requests`): Captures emails from non-invited users who want access. Anon can INSERT (submit request) and SELECT (duplicate check).
- **`manage-allowlist` edge function**: Admin POST endpoint (add/remove emails), protected by service_role key. Lets Betsy or automation manage the list without touching Supabase dashboard.
- **Auth flow gating**: `sendMagicLink()` now checks `alpha_allowlist` before calling `signInWithOtp`. Non-allowed emails see a branded "Private alpha" screen with a request-access form.
- **Session verification**: On app load, existing sessions are verified against the allowlist. If the email was removed, the user is signed out with a toast message.
- **Demo mode unchanged**: "Try the demo" button remains accessible to everyone on every screen state (form, gate, and sent).

## Test plan
- [ ] Enter an email NOT on the allowlist → should see "Private alpha" gate screen with request-access form
- [ ] Submit email on gate screen → should see "You're on the list" confirmation, email saved to `waitlist_requests`
- [ ] Click "Back to sign in" → returns to normal auth form
- [ ] Enter `betsy.eble@gmail.com` → magic link sent as normal
- [ ] "Try the demo" button works from all three auth states (form, gate, success)
- [ ] Remove an email from allowlist while user has active session → on next app load, user is signed out with toast
- [ ] Verify `manage-allowlist` edge function: POST with service_role key + `{action:"add", email:"..."}` adds entry
- [ ] Verify `manage-allowlist` edge function: POST with anon key returns 403
- [ ] Verify `getwellet.com` link appears on the gate success screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)