### PR TITLE
feat: 1upHealth EHR integration — FHIR data proof of concept

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,6 +754,30 @@
   #explainer-stage { width:100%; max-width:720px; aspect-ratio:16/9; position:relative; border-radius:12px; overflow:hidden; box-shadow:0 8px 40px rgba(0,0,0,0.4); }
   #explainer-stage video { width:100%; height:100%; object-fit:cover; display:block; }
   @media (max-width:768px) { #explainer-stage { max-width:95vw; } }
+
+  /* ── EHR INTEGRATION ── */
+  .ehr-badge { display:inline-flex; align-items:center; gap:3px; font-size:10px; font-weight:600; letter-spacing:0.04em; color:white; background:#2d6a4f; border-radius:6px; padding:2px 7px; line-height:1.4; vertical-align:middle; white-space:nowrap; }
+  .ehr-badge i { width:10px; height:10px; }
+  .ehr-provider-badge { display:inline-flex; align-items:center; gap:3px; font-size:10px; font-weight:500; color:var(--moss-dark); background:var(--mint); border-radius:6px; padding:2px 7px; line-height:1.4; white-space:nowrap; }
+  .ehr-connect-card { background:white; border:1.5px dashed var(--moss); border-radius:14px; padding:16px; text-align:center; cursor:pointer; transition:background 0.15s, border-color 0.15s; }
+  .ehr-connect-card:hover { background:var(--mint); border-color:var(--moss-dark); }
+  .ehr-connect-icon { width:44px; height:44px; border-radius:50%; background:var(--mint); display:flex; align-items:center; justify-content:center; margin:0 auto 10px; color:var(--moss); }
+  .ehr-connect-title { font-size:14px; font-weight:500; color:var(--text-primary); margin-bottom:4px; }
+  .ehr-connect-desc { font-size:12px; color:var(--text-muted); line-height:1.5; }
+  .ehr-status-bar { display:flex; align-items:center; justify-content:space-between; padding:10px 16px; background:var(--mint); border-radius:10px; margin-bottom:12px; }
+  .ehr-status-left { display:flex; align-items:center; gap:8px; font-size:12px; color:var(--moss-dark); }
+  .ehr-status-dot { width:7px; height:7px; border-radius:50%; background:#47B08A; flex-shrink:0; }
+  .ehr-status-right { display:flex; align-items:center; gap:8px; }
+  .ehr-refresh-btn { background:none; border:none; color:var(--moss); cursor:pointer; padding:4px; border-radius:6px; display:flex; align-items:center; justify-content:center; transition:background 0.15s; }
+  .ehr-refresh-btn:hover { background:rgba(45,106,79,0.1); }
+  .ehr-privacy-notice { background:var(--cream); border-radius:10px; padding:12px 14px; margin:12px 0; font-size:12px; color:var(--text-secondary); line-height:1.6; display:flex; gap:8px; align-items:flex-start; }
+  .ehr-privacy-notice i { flex-shrink:0; color:var(--moss); margin-top:1px; }
+  .ehr-section-prompt { text-align:center; padding:16px; color:var(--text-muted); font-size:12px; line-height:1.5; font-style:italic; }
+  .ehr-section-prompt a { color:var(--moss); text-decoration:none; font-style:normal; font-weight:500; cursor:pointer; }
+  .ehr-section-prompt a:hover { text-decoration:underline; }
+  .ehr-demo-tooltip { position:relative; }
+  .ehr-demo-tooltip:hover::after { content:attr(data-tooltip); position:absolute; bottom:calc(100% + 6px); left:50%; transform:translateX(-50%); background:var(--text-primary); color:white; font-size:11px; padding:6px 10px; border-radius:8px; white-space:nowrap; z-index:10; pointer-events:none; }
+  .ehr-demo-tooltip:hover::before { content:''; position:absolute; bottom:calc(100% + 2px); left:50%; transform:translateX(-50%); border:4px solid transparent; border-top-color:var(--text-primary); z-index:10; }
 </style>
 </head>
 <body>
@@ -1051,6 +1075,30 @@
             <div class="tl-card-date">March 16 @ 9:00 AM</div>
           </div>
         </div>
+        <div class="tl-item">
+          <div class="tl-line-col"><div class="tl-dot appt"></div><div class="tl-connector"></div></div>
+          <div class="tl-card moss-border">
+            <div class="tl-card-type-row"><i data-lucide="calendar-check" style="width:11px;height:11px;color:var(--moss);"></i><span class="tl-card-type appt">Appointment</span> <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div>
+            <div class="tl-card-title">Office visit — Neurology</div>
+            <div class="tl-card-date">March 28 · <span style="color:var(--moss);font-weight:500;">From Duke Health (Epic)</span></div>
+          </div>
+        </div>
+        <div class="tl-item">
+          <div class="tl-line-col"><div class="tl-dot lab"></div><div class="tl-connector"></div></div>
+          <div class="tl-card blue-border">
+            <div class="tl-card-type-row"><i data-lucide="flask-conical" style="width:11px;height:11px;color:var(--blue);"></i><span class="tl-card-type lab">Lab result</span> <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div>
+            <div class="tl-card-title">CBC — WBC 6.8, Hemoglobin 14.2</div>
+            <div class="tl-card-date">March 28 · <span style="color:var(--moss);font-weight:500;">From Duke Health (Epic)</span></div>
+          </div>
+        </div>
+        <div class="tl-item">
+          <div class="tl-line-col"><div class="tl-dot lab"></div><div class="tl-connector"></div></div>
+          <div class="tl-card blue-border">
+            <div class="tl-card-type-row"><i data-lucide="flask-conical" style="width:11px;height:11px;color:var(--blue);"></i><span class="tl-card-type lab">Lab result</span> <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div>
+            <div class="tl-card-title">Metabolic panel — Glucose 98, Creatinine 1.0</div>
+            <div class="tl-card-date">March 15 · <span style="color:var(--moss);font-weight:500;">From Duke Health (Epic)</span></div>
+          </div>
+        </div>
         <div class="tl-month">February 2026</div>
         <div class="tl-item">
           <div class="tl-line-col"><div class="tl-dot med"></div><div class="tl-connector"></div></div>
@@ -1218,11 +1266,18 @@
         </div>
       </div>
       <div id="records-dad" class="records-section">
+        <div class="ehr-status-bar">
+          <div class="ehr-status-left"><div class="ehr-status-dot"></div><strong>EHR Connected</strong> · Duke Health (Epic)</div>
+          <div class="ehr-status-right">
+            <span style="font-size:11px;color:var(--text-muted);">Demo data</span>
+            <button class="ehr-demo-tooltip ehr-refresh-btn" data-tooltip="In the real app, this connects to your provider's records" onclick="showToast('In the real app, this refreshes data from your provider')"><i data-lucide="refresh-cw" style="width:14px;height:14px;"></i></button>
+          </div>
+        </div>
         <div class="record-group">
           <div class="record-group-header">
             <div class="record-group-title"><i data-lucide="pill" style="width:14px;height:14px;color:var(--amber);"></i>Medications</div>
             <div style="display:flex;align-items:center;gap:8px;">
-              <span class="record-group-count" id="dad-med-count">6 active</span>
+              <span class="record-group-count" id="dad-med-count">8 active</span>
               <button onclick="openAddMed()" style="background:var(--mint);border:none;border-radius:8px;padding:4px 10px;font-size:11px;font-weight:500;color:var(--moss-dark);cursor:pointer;font-family:'DM Sans',sans-serif;">+ Add</button>
             </div>
           </div>
@@ -1242,13 +1297,23 @@
               <div style="flex:1;"><div class="record-label">Gleevec (Imatinib) 400mg</div><div class="record-meta">Once daily · CML</div></div>
               <i data-lucide="chevron-right" style="width:16px;height:16px;color:var(--text-muted);"></i>
             </div>
+            <div class="record-row">
+              <div class="record-icon amber"><i data-lucide="pill" style="width:15px;height:15px;"></i></div>
+              <div style="flex:1;"><div class="record-label">Levodopa/Carbidopa 25-100mg <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">3x daily · Parkinson's</div></div>
+              <span class="ehr-provider-badge">From Duke Health</span>
+            </div>
+            <div class="record-row">
+              <div class="record-icon amber"><i data-lucide="pill" style="width:15px;height:15px;"></i></div>
+              <div style="flex:1;"><div class="record-label">Lisinopril 20mg <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">Once daily · Hypertension</div></div>
+              <span class="ehr-provider-badge">From Duke Health</span>
+            </div>
           </div>
         </div>
 
         <div class="record-group">
           <div class="record-group-header">
             <div class="record-group-title"><i data-lucide="stethoscope" style="width:14px;height:14px;color:var(--moss);"></i>Diagnoses</div>
-            <span class="record-group-count">4 active</span>
+            <span class="record-group-count">6 active</span>
           </div>
           <div class="record-row">
             <div class="record-icon moss"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>
@@ -1265,12 +1330,34 @@
             <div style="flex:1;"><div class="record-label">Glaucoma</div><div class="record-meta">Stable · Dr. Patel</div></div>
             <span class="record-badge moss">Stable</span>
           </div>
+          <div class="record-row">
+            <div class="record-icon moss"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Parkinson's disease <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">Since Jun 2023</div></div>
+            <span class="record-badge amber">Active</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon moss"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Essential hypertension <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">Since Mar 2020</div></div>
+            <span class="record-badge amber">Active</span>
+          </div>
+        </div>
+
+        <div class="record-group">
+          <div class="record-group-header">
+            <div class="record-group-title"><i data-lucide="alert-triangle" style="width:14px;height:14px;color:var(--red);"></i>Allergies <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div>
+            <span class="record-group-count">1 from EHR</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon" style="background:#FEF0EE;color:var(--red);"><i data-lucide="alert-triangle" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Sulfonamide</div><div class="record-meta">Skin rash, Hives · moderate</div></div>
+            <span class="ehr-provider-badge">From Duke Health</span>
+          </div>
         </div>
 
         <div class="record-group">
           <div class="record-group-header">
             <div class="record-group-title"><i data-lucide="flask-conical" style="width:14px;height:14px;color:var(--blue);"></i>Recent labs</div>
-            <span class="record-group-count">3 this month</span>
+            <span class="record-group-count">7 this month</span>
           </div>
           <div class="record-row">
             <div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>
@@ -1281,6 +1368,33 @@
             <div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>
             <div style="flex:1;"><div class="record-label">Basic metabolic panel</div><div class="record-meta">January 12 · All normal</div></div>
             <span class="record-badge moss">Normal</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Complete blood count (CBC) <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">Mar 28 · WBC 6.8, Hgb 14.2</div></div>
+            <span class="record-badge moss">Normal</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Comprehensive metabolic panel <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div><div class="record-meta">Mar 15 · Glucose 98, Creatinine 1.0</div></div>
+            <span class="record-badge moss">Normal</span>
+          </div>
+        </div>
+
+        <div class="record-group">
+          <div class="record-group-header">
+            <div class="record-group-title"><i data-lucide="calendar-check" style="width:14px;height:14px;color:var(--moss);"></i>Recent visits <span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span></div>
+            <span class="record-group-count">2 from EHR</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon moss"><i data-lucide="calendar-check" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Office visit — Neurology</div><div class="record-meta">Mar 28</div></div>
+            <span class="ehr-provider-badge">From Duke Health</span>
+          </div>
+          <div class="record-row">
+            <div class="record-icon moss"><i data-lucide="calendar-check" style="width:15px;height:15px;"></i></div>
+            <div style="flex:1;"><div class="record-label">Annual physical exam</div><div class="record-meta">Feb 15</div></div>
+            <span class="ehr-provider-badge">From Duke Health</span>
           </div>
         </div>
 
@@ -1299,6 +1413,10 @@
             <div style="flex:1;"><div class="record-label">Ask Dr. E about ferritin levels</div><div class="record-meta">Feb 22 · you</div></div>
             <i data-lucide="chevron-right" style="width:16px;height:16px;color:var(--text-muted);"></i>
           </div>
+        </div>
+        <div class="ehr-privacy-notice">
+          <i data-lucide="shield-check" style="width:16px;height:16px;"></i>
+          <span>Your health records stay on this device. Wellet never stores raw medical data on our servers.</span>
         </div>
       </div>
 
@@ -1856,7 +1974,18 @@
     </div>
 
     <div class="settings-section" style="margin-top:12px;">
-      <div class="settings-section-label">Connected services</div>
+      <div class="settings-section-label">Health Records</div>
+      <div style="padding:0 0 4px;">
+        <div style="font-size:12px;color:var(--text-secondary);line-height:1.5;margin-bottom:10px;">Connect your EHR to import medical data — medications, conditions, lab results, and more.</div>
+        <div id="settings-ehr-status"></div>
+        <div class="settings-row" style="cursor:pointer;" onclick="startEhrConnect()">
+          <div class="settings-row-left">
+            <div class="settings-row-icon" style="background:var(--mint);color:var(--moss);"><i data-lucide="hospital" style="width:15px;height:15px;"></i></div>
+            <div><div class="settings-row-label" id="settings-ehr-label">Connect Health Records</div><div class="settings-row-meta" id="settings-ehr-meta">Import data from your provider (Epic, Cerner, etc.)</div></div>
+          </div>
+          <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
+        </div>
+      </div>
       <div class="settings-row">
         <div class="settings-row-left">
           <div class="settings-row-icon"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>
@@ -2085,6 +2214,15 @@
     <div class="profile-form-row">
       <label class="profile-form-label">Insurance info</label>
       <input class="input-field" id="profile-insurance-input" style="margin-top:0;" type="text" placeholder="e.g. Blue Cross PPO #123456">
+    </div>
+
+    <div class="profile-section-label">Health Records (EHR)</div>
+    <div id="profile-ehr-section" style="padding:0 20px;">
+      <div class="ehr-connect-card" onclick="startEhrConnect()" id="profile-ehr-connect-card">
+        <div class="ehr-connect-icon"><i data-lucide="hospital" style="width:22px;height:22px;"></i></div>
+        <div class="ehr-connect-title">Connect Health Records</div>
+        <div class="ehr-connect-desc">Import medications, conditions, and lab results from your provider</div>
+      </div>
     </div>
 
     <div style="padding:8px 20px 0;display:flex;flex-direction:column;gap:8px;">
@@ -2388,6 +2526,8 @@ async function initApp() {
       showAuthScreen();
     }
   });
+  // Check for EHR OAuth callback code in URL
+  checkEhrCallbackOnLoad();
 }
 
 function togglePrivacyDetail() {
@@ -2529,6 +2669,10 @@ async function loadPersonData(personId) {
     .eq('person_id', personId)
     .order('created_at', { ascending: true });
   liveCareCircle = circle || [];
+
+  // Load cached EHR data and auto-refresh if stale
+  loadEhrCache(personId);
+  autoRefreshEhrIfNeeded(personId);
 }
 
 // ── SHOW AUTHENTICATED APP ────────────────────────────────────────────────────
@@ -2668,11 +2812,34 @@ function renderTimeline() {
     + '<button class="btn-primary" style="width:auto;padding:10px 16px;font-size:13px;gap:6px;" onclick="openAddEvent()">'
     + '<i data-lucide="plus" style="width:14px;height:14px;"></i> Add event</button></div>';
 
-  if (liveEvents.length === 0) {
+  // Merge EHR events into timeline
+  var ehrData = getEhrData(currentPersonId);
+  var ehrTimelineItems = [];
+  if (ehrData) {
+    (ehrData.encounters || []).forEach(function(enc) {
+      ehrTimelineItems.push({ event_type:'appointment', title:enc.name, event_date:enc.start_date, notes:'', source:'ehr', _ehrProvider:ehrData.provider });
+    });
+    (ehrData.conditions || []).forEach(function(c) {
+      ehrTimelineItems.push({ event_type:'note', title:c.name + ' (diagnosed)', event_date:c.onset_date || c.recorded_date, notes:'', source:'ehr', _ehrProvider:ehrData.provider });
+    });
+    (ehrData.procedures || []).forEach(function(p) {
+      ehrTimelineItems.push({ event_type:'appointment', title:p.name, event_date:p.performed_date, notes:'', source:'ehr', _ehrProvider:ehrData.provider });
+    });
+    (ehrData.observations || []).forEach(function(obs) {
+      var valStr = obs.value ? ' \u2014 ' + obs.value + (obs.unit ? ' ' + obs.unit : '') : '';
+      ehrTimelineItems.push({ event_type:'lab_result', title:obs.name + valStr, event_date:obs.effective_date, notes:'', source:'ehr', _ehrProvider:ehrData.provider });
+    });
+  }
+
+  var allEvents = liveEvents.concat(ehrTimelineItems.filter(function(e){ return e.event_date; }));
+  allEvents.sort(function(a,b) { return new Date(b.event_date) - new Date(a.event_date); });
+
+  if (allEvents.length === 0) {
     pane.innerHTML = addBtn + '<div class="timeline-section">'
       + '<div style="text-align:center;padding:48px 24px;">'
       + '<div style="font-size:32px;margin-bottom:12px;opacity:0.3;"><i data-lucide="calendar" style="width:32px;height:32px;"></i></div>'
       + '<div style="font-size:14px;color:var(--text-muted);line-height:1.6;">Appointments, medications, lab results, and your own notes \u2014 they\u2019ll all show up here in order as you add them.</div>'
+      + (!ehrData && !isDemoMode ? buildEhrPrompt() : '')
       + '</div></div>';
     initIcons();
     return;
@@ -2680,29 +2847,38 @@ function renderTimeline() {
 
   // Group by month
   var months = {};
-  liveEvents.forEach(function(ev) {
+  allEvents.forEach(function(ev) {
     var d = new Date(ev.event_date);
+    if (isNaN(d.getTime())) return;
     var key = d.getFullYear() + '-' + String(d.getMonth()).padStart(2,'0');
     var label = d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
     if (!months[key]) months[key] = { label: label, events: [] };
     months[key].events.push(ev);
   });
 
-  var html = addBtn + '<div class="timeline-section">';
+  var html = addBtn;
+  if (ehrData) html += buildEhrStatusBar(ehrData);
+  html += '<div class="timeline-section">';
   Object.keys(months).sort().reverse().forEach(function(k) {
     html += '<div class="tl-month">' + months[k].label + '</div>';
     months[k].events.forEach(function(ev, i) {
       var isLast = i === months[k].events.length - 1;
       var typeInfo = getEventTypeInfo(ev.event_type);
       var dateStr = formatEventDate(ev.event_date);
+      var isEhr = ev.source === 'ehr';
+      var clickAttr = isEhr ? '' : ' onclick="openEditEvent(\'' + ev.id + '\')"';
       html += '<div class="tl-item">'
         + '<div class="tl-line-col"><div class="tl-dot ' + typeInfo.dot + '"></div>' + (isLast ? '' : '<div class="tl-connector"></div>') + '</div>'
-        + '<div class="tl-card ' + typeInfo.border + '" onclick="openEditEvent(\'' + ev.id + '\')">'
+        + '<div class="tl-card ' + typeInfo.border + '"' + clickAttr + '>'
         + '<div class="tl-card-type-row"><i data-lucide="' + typeInfo.icon + '" style="width:11px;height:11px;color:' + typeInfo.color + ';"></i>'
-        + '<span class="tl-card-type ' + typeInfo.dot + '">' + typeInfo.label + '</span></div>'
+        + '<span class="tl-card-type ' + typeInfo.dot + '">' + typeInfo.label + '</span>'
+        + (isEhr ? ' ' + ehrBadgeHtml() : '')
+        + '</div>'
         + '<div class="tl-card-title">' + escHtml(ev.title) + '</div>'
         + (ev.notes ? '<div class="tl-card-body">' + escHtml(ev.notes) + '</div>' : '')
-        + '<div class="tl-card-date">' + dateStr + '</div>'
+        + '<div class="tl-card-date">' + dateStr
+        + (isEhr ? ' \u00B7 <span style="color:var(--moss);font-weight:500;">From ' + escHtml(ev._ehrProvider || 'EHR') + '</span>' : '')
+        + '</div>'
         + '</div></div>';
     });
   });
@@ -2802,6 +2978,14 @@ function renderRecordsView() {
   var person = currentPeople.find(function(p){ return p.id === currentPersonId; });
   var name = person ? person.name.split(' ')[0] : 'Person';
   var activeMeds = liveMeds.filter(function(m){ return m.active; });
+  var ehrData = getEhrData(currentPersonId);
+  var ehrMeds = ehrData ? ehrData.medications || [] : [];
+  var ehrConditions = ehrData ? ehrData.conditions || [] : [];
+  var ehrAllergies = ehrData ? ehrData.allergies || [] : [];
+  var ehrObs = ehrData ? ehrData.observations || [] : [];
+  var ehrEncounters = ehrData ? ehrData.encounters || [] : [];
+  var ehrProcedures = ehrData ? ehrData.procedures || [] : [];
+  var ehrProvider = ehrData ? ehrData.provider || 'EHR' : '';
 
   var html = '<div class="view-header"><div class="view-title">Records</div>'
     + '<div style="display:flex;gap:8px;margin-top:10px;">';
@@ -2812,23 +2996,39 @@ function renderRecordsView() {
   });
   html += '</div></div>';
 
-  // Medications section
-  html += '<div class="records-section">'
-    + '<div class="record-group">'
+  // EHR status bar
+  if (ehrData) {
+    html += buildEhrStatusBar(ehrData);
+  }
+
+  html += '<div class="records-section">';
+
+  // Medications section (manual + EHR)
+  var totalMeds = activeMeds.length + ehrMeds.length;
+  html += '<div class="record-group">'
     + '<div class="record-group-header">'
     + '<div class="record-group-title"><i data-lucide="pill" style="width:14px;height:14px;color:var(--amber);"></i>Medications</div>'
-    + '<span class="record-group-count">' + activeMeds.length + ' active</span>'
+    + '<span class="record-group-count">' + totalMeds + ' active</span>'
     + '</div>';
 
-  if (activeMeds.length === 0) {
+  if (totalMeds === 0) {
     html += '<div style="text-align:center;padding:24px 16px;color:var(--text-muted);font-size:13px;font-style:italic;">No medications added yet.</div>';
+    if (!ehrData) html += buildEhrPrompt();
   } else {
     activeMeds.forEach(function(med) {
       html += '<div class="record-row" onclick="openEditMed(\'' + med.id + '\')">'
         + '<div class="record-icon amber"><i data-lucide="pill" style="width:15px;height:15px;"></i></div>'
         + '<div style="flex:1;"><div class="record-label">' + escHtml(med.name) + (med.dose ? ' ' + escHtml(med.dose) : '') + '</div>'
-        + '<div class="record-meta">' + (med.frequency ? escHtml(med.frequency) : '') + (med.prescriber ? ' · ' + escHtml(med.prescriber) : '') + '</div></div>'
+        + '<div class="record-meta">' + (med.frequency ? escHtml(med.frequency) : '') + (med.prescriber ? ' \u00B7 ' + escHtml(med.prescriber) : '') + '</div></div>'
         + '<i data-lucide="chevron-right" style="width:16px;height:16px;color:var(--text-muted);"></i>'
+        + '</div>';
+    });
+    ehrMeds.forEach(function(med) {
+      html += '<div class="record-row">'
+        + '<div class="record-icon amber"><i data-lucide="pill" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(med.name) + ' ' + ehrBadgeHtml() + '</div>'
+        + '<div class="record-meta">' + escHtml(med.dosage || med.frequency || '') + '</div></div>'
+        + ehrProviderBadgeHtml(ehrProvider)
         + '</div>';
     });
   }
@@ -2837,33 +3037,100 @@ function renderRecordsView() {
     + '<i data-lucide="plus" style="width:15px;height:15px;"></i> Add medication</button>'
     + '</div>';
 
-  // Events by type
+  // EHR Conditions section
+  if (ehrConditions.length > 0) {
+    html += '<div class="record-group"><div class="record-group-header">'
+      + '<div class="record-group-title"><i data-lucide="stethoscope" style="width:14px;height:14px;color:var(--moss);"></i>Conditions ' + ehrBadgeHtml() + '</div>'
+      + '<span class="record-group-count">' + ehrConditions.length + ' from EHR</span></div>';
+    ehrConditions.forEach(function(c) {
+      var statusBadge = c.status === 'active' ? '<span class="record-badge amber">Active</span>' : '<span class="record-badge moss">' + escHtml(c.status || 'Recorded') + '</span>';
+      html += '<div class="record-row">'
+        + '<div class="record-icon moss"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(c.name) + '</div>'
+        + '<div class="record-meta">' + (c.onset_date ? 'Since ' + formatEventDate(c.onset_date) : '') + '</div></div>'
+        + statusBadge
+        + '</div>';
+    });
+    html += '</div>';
+  }
+
+  // EHR Allergies section
+  if (ehrAllergies.length > 0) {
+    html += '<div class="record-group"><div class="record-group-header">'
+      + '<div class="record-group-title"><i data-lucide="alert-triangle" style="width:14px;height:14px;color:var(--red);"></i>Allergies ' + ehrBadgeHtml() + '</div>'
+      + '<span class="record-group-count">' + ehrAllergies.length + ' from EHR</span></div>';
+    ehrAllergies.forEach(function(a) {
+      var reactionStr = a.reactions && a.reactions.length > 0 ? a.reactions.join(', ') : '';
+      html += '<div class="record-row">'
+        + '<div class="record-icon" style="background:#FEF0EE;color:var(--red);"><i data-lucide="alert-triangle" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(a.name) + '</div>'
+        + '<div class="record-meta">' + (reactionStr ? escHtml(reactionStr) : '') + (a.severity ? ' \u00B7 ' + escHtml(a.severity) : '') + '</div></div>'
+        + ehrProviderBadgeHtml(ehrProvider)
+        + '</div>';
+    });
+    html += '</div>';
+  }
+
+  // Events by type (manual)
   var labEvents = liveEvents.filter(function(e){ return e.event_type === 'lab_result'; });
   var noteEvents = liveEvents.filter(function(e){ return e.event_type === 'note'; });
   var apptEvents = liveEvents.filter(function(e){ return e.event_type === 'appointment'; });
 
-  if (apptEvents.length > 0) {
+  if (apptEvents.length > 0 || ehrEncounters.length > 0) {
+    var totalAppts = apptEvents.length + ehrEncounters.length;
     html += '<div class="record-group"><div class="record-group-header">'
-      + '<div class="record-group-title"><i data-lucide="calendar-check" style="width:14px;height:14px;color:var(--moss);"></i>Appointments</div>'
-      + '<span class="record-group-count">' + apptEvents.length + ' logged</span></div>';
+      + '<div class="record-group-title"><i data-lucide="calendar-check" style="width:14px;height:14px;color:var(--moss);"></i>Appointments &amp; visits</div>'
+      + '<span class="record-group-count">' + totalAppts + ' logged</span></div>';
     apptEvents.slice(0,3).forEach(function(ev) {
       html += '<div class="record-row" onclick="openEditEvent(\'' + ev.id + '\')"><div class="record-icon moss"><i data-lucide="calendar-check" style="width:15px;height:15px;"></i></div>'
         + '<div style="flex:1;"><div class="record-label">' + escHtml(ev.title) + '</div>'
         + '<div class="record-meta">' + formatEventDate(ev.event_date) + '</div></div>'
         + '<i data-lucide="chevron-right" style="width:16px;height:16px;color:var(--text-muted);"></i></div>';
     });
+    ehrEncounters.forEach(function(enc) {
+      html += '<div class="record-row"><div class="record-icon moss"><i data-lucide="calendar-check" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(enc.name) + ' ' + ehrBadgeHtml() + '</div>'
+        + '<div class="record-meta">' + formatEventDate(enc.start_date) + '</div></div>'
+        + ehrProviderBadgeHtml(ehrProvider)
+        + '</div>';
+    });
     html += '</div>';
   }
 
-  if (labEvents.length > 0) {
+  // Lab results (manual + EHR)
+  var totalLabs = labEvents.length + ehrObs.length;
+  if (totalLabs > 0) {
     html += '<div class="record-group"><div class="record-group-header">'
       + '<div class="record-group-title"><i data-lucide="flask-conical" style="width:14px;height:14px;color:var(--blue);"></i>Lab results</div>'
-      + '<span class="record-group-count">' + labEvents.length + ' logged</span></div>';
+      + '<span class="record-group-count">' + totalLabs + ' logged</span></div>';
     labEvents.slice(0,3).forEach(function(ev) {
       html += '<div class="record-row" onclick="openEditEvent(\'' + ev.id + '\')"><div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>'
         + '<div style="flex:1;"><div class="record-label">' + escHtml(ev.title) + '</div>'
         + '<div class="record-meta">' + formatEventDate(ev.event_date) + '</div></div>'
         + '<span class="record-badge moss">Logged</span></div>';
+    });
+    ehrObs.forEach(function(obs) {
+      var valStr = obs.value ? obs.value + (obs.unit ? ' ' + obs.unit : '') : '';
+      html += '<div class="record-row"><div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(obs.name) + ' ' + ehrBadgeHtml() + '</div>'
+        + '<div class="record-meta">' + formatEventDate(obs.effective_date) + (valStr ? ' \u00B7 ' + escHtml(valStr) : '') + '</div></div>'
+        + (obs.reference_range ? '<span class="record-badge moss" title="Ref: ' + escHtml(obs.reference_range) + '">Normal</span>' : ehrProviderBadgeHtml(ehrProvider))
+        + '</div>';
+    });
+    html += '</div>';
+  }
+
+  // EHR Procedures section
+  if (ehrProcedures.length > 0) {
+    html += '<div class="record-group"><div class="record-group-header">'
+      + '<div class="record-group-title"><i data-lucide="scissors" style="width:14px;height:14px;color:var(--text-secondary);"></i>Procedures ' + ehrBadgeHtml() + '</div>'
+      + '<span class="record-group-count">' + ehrProcedures.length + ' from EHR</span></div>';
+    ehrProcedures.forEach(function(p) {
+      html += '<div class="record-row"><div class="record-icon" style="background:var(--cream);color:var(--text-secondary);"><i data-lucide="scissors" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(p.name) + '</div>'
+        + '<div class="record-meta">' + formatEventDate(p.performed_date) + '</div></div>'
+        + ehrProviderBadgeHtml(ehrProvider)
+        + '</div>';
     });
     html += '</div>';
   }
@@ -2875,7 +3142,7 @@ function renderRecordsView() {
     noteEvents.slice(0,3).forEach(function(ev) {
       html += '<div class="record-row" onclick="openEditEvent(\'' + ev.id + '\')"><div class="record-icon muted"><i data-lucide="pencil-line" style="width:15px;height:15px;"></i></div>'
         + '<div style="flex:1;"><div class="record-label">' + escHtml(ev.title) + '</div>'
-        + '<div class="record-meta">' + formatEventDate(ev.event_date) + ' · you</div></div>'
+        + '<div class="record-meta">' + formatEventDate(ev.event_date) + ' \u00B7 you</div></div>'
         + '<i data-lucide="chevron-right" style="width:16px;height:16px;color:var(--text-muted);"></i></div>';
     });
     html += '</div>';
@@ -2900,7 +3167,7 @@ function renderRecordsView() {
       html += '<div class="doc-row"' + clickable + '>'
         + '<div class="doc-icon"><i data-lucide="' + iconName + '" style="width:15px;height:15px;"></i></div>'
         + '<div class="doc-info"><div class="doc-name">' + escHtml(doc.file_name) + '</div>'
-        + '<div class="doc-meta">' + escHtml(doc.document_type || 'Document') + ' · ' + dateStr + '</div></div>'
+        + '<div class="doc-meta">' + escHtml(doc.document_type || 'Document') + ' \u00B7 ' + dateStr + '</div></div>'
         + '<span class="doc-status ' + statusClass + '">' + statusLabel + '</span>'
         + '<div class="doc-actions">'
         + '<button class="doc-action-btn" title="View" onclick="event.stopPropagation();viewDocument(\'' + doc.id + '\')"><i data-lucide="eye" style="width:14px;height:14px;"></i></button>'
@@ -2913,6 +3180,11 @@ function renderRecordsView() {
   html += '<button class="add-person-btn" style="border-style:dashed;margin:12px 0 4px;" onclick="openUploadById(\'' + currentPersonId + '\')">'
     + '<i data-lucide="upload-cloud" style="width:15px;height:15px;"></i> Upload document</button>'
     + '</div>';
+
+  // EHR prompt if no connection
+  if (!ehrData && !isDemoMode) {
+    html += buildEhrPrompt();
+  }
 
   html += '</div>';
   view.innerHTML = html;
@@ -3893,6 +4165,421 @@ function escHtml(t) {
   return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
 
+// ── EHR INTEGRATION (1upHealth FHIR) ────────────────────────────────────────
+var ehrCache = {}; // { personId: { data: {...}, synced_at: '...' } }
+var _ehrConnecting = false;
+var _ehrPendingPersonId = null;
+
+// Demo EHR data for Dad
+var DEMO_EHR_DATA = {
+  conditions: [
+    { type:'condition', source:'ehr', name:"Parkinson's disease", code:'49049000', status:'active', onset_date:'2023-06-15', recorded_date:'2023-06-15' },
+    { type:'condition', source:'ehr', name:'Essential hypertension', code:'59621000', status:'active', onset_date:'2020-03-10', recorded_date:'2020-03-10' }
+  ],
+  medications: [
+    { type:'medication', source:'ehr', name:'Levodopa/Carbidopa 25-100mg', code:'197741', status:'active', dosage:'1 tablet three times daily', frequency:'3x daily', date_asserted:'2023-07-01' },
+    { type:'medication', source:'ehr', name:'Lisinopril 20mg', code:'314077', status:'active', dosage:'1 tablet daily', frequency:'Once daily', date_asserted:'2020-04-01' }
+  ],
+  allergies: [
+    { type:'allergy', source:'ehr', name:'Sulfonamide', code:'387406002', severity:'moderate', reactions:['Skin rash','Hives'], status:'active', recorded_date:'2019-11-20' }
+  ],
+  observations: [
+    { type:'observation', source:'ehr', name:'Complete blood count (CBC)', code:'58410-2', value:'', unit:'', reference_range:'', status:'final', effective_date:'2026-03-28', category:'laboratory' },
+    { type:'observation', source:'ehr', name:'White blood cell count', code:'6690-2', value:'6.8', unit:'10*3/uL', reference_range:'4.5-11.0', status:'final', effective_date:'2026-03-28', category:'laboratory' },
+    { type:'observation', source:'ehr', name:'Hemoglobin', code:'718-7', value:'14.2', unit:'g/dL', reference_range:'13.5-17.5', status:'final', effective_date:'2026-03-28', category:'laboratory' },
+    { type:'observation', source:'ehr', name:'Comprehensive metabolic panel', code:'24323-8', value:'', unit:'', reference_range:'', status:'final', effective_date:'2026-03-15', category:'laboratory' },
+    { type:'observation', source:'ehr', name:'Glucose', code:'2345-7', value:'98', unit:'mg/dL', reference_range:'70-100', status:'final', effective_date:'2026-03-15', category:'laboratory' },
+    { type:'observation', source:'ehr', name:'Creatinine', code:'2160-0', value:'1.0', unit:'mg/dL', reference_range:'0.7-1.3', status:'final', effective_date:'2026-03-15', category:'laboratory' }
+  ],
+  encounters: [
+    { type:'encounter', source:'ehr', name:'Office visit — Neurology', status:'finished', start_date:'2026-03-28', end_date:'2026-03-28', class:'AMB' },
+    { type:'encounter', source:'ehr', name:'Annual physical exam', status:'finished', start_date:'2026-02-15', end_date:'2026-02-15', class:'AMB' }
+  ],
+  procedures: [
+    { type:'procedure', source:'ehr', name:'Electroencephalogram (EEG)', code:'54093003', status:'completed', performed_date:'2026-01-10' }
+  ],
+  provider: 'Duke Health (Epic)',
+  synced_at: new Date().toISOString()
+};
+
+// Load cached EHR data from localStorage
+function loadEhrCache(personId) {
+  if (!personId) return null;
+  try {
+    var key = 'wellet_ehr_' + personId;
+    var cached = localStorage.getItem(key);
+    if (cached) {
+      var parsed = JSON.parse(cached);
+      ehrCache[personId] = parsed;
+      return parsed;
+    }
+  } catch(e) { console.warn('EHR cache read error:', e); }
+  return null;
+}
+
+// Save EHR data to localStorage
+function saveEhrCache(personId, data) {
+  if (!personId || !data) return;
+  try {
+    var key = 'wellet_ehr_' + personId;
+    ehrCache[personId] = data;
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch(e) { console.warn('EHR cache write error:', e); }
+}
+
+// Clear EHR cache for a person
+function clearEhrCache(personId) {
+  if (!personId) return;
+  try {
+    delete ehrCache[personId];
+    localStorage.removeItem('wellet_ehr_' + personId);
+  } catch(e) {}
+}
+
+// Check if cached EHR data is stale (older than 24 hours)
+function isEhrCacheStale(personId) {
+  var cached = ehrCache[personId];
+  if (!cached || !cached.synced_at) return true;
+  var age = Date.now() - new Date(cached.synced_at).getTime();
+  return age > 24 * 60 * 60 * 1000;
+}
+
+// Get EHR data for current person (demo or real)
+function getEhrData(personId) {
+  if (isDemoMode) {
+    // In demo mode, only Dad has EHR data
+    var pills = document.querySelectorAll('#view-records .person-pill, .person-pill.active');
+    var isDad = !personId || personId === 'dad';
+    if (isDad) return DEMO_EHR_DATA;
+    return null;
+  }
+  return ehrCache[personId] || loadEhrCache(personId);
+}
+
+// Start the EHR connection OAuth flow
+function startEhrConnect() {
+  if (isDemoMode) {
+    showToast('In the real app, this connects to your provider\u2019s records');
+    return;
+  }
+  if (_ehrConnecting) return;
+  if (!currentUser) {
+    showToast('Please sign in first');
+    return;
+  }
+  var personId = currentPersonId;
+  if (!personId) {
+    showToast('Please select a person first');
+    return;
+  }
+
+  _ehrConnecting = true;
+  _ehrPendingPersonId = personId;
+
+  // Store the person_id so we can use it when the callback returns
+  try { localStorage.setItem('wellet_ehr_pending_person', personId); } catch(e) {}
+
+  // Show privacy notice
+  var confirmed = confirm(
+    'Connect Health Records\n\n'
+    + 'Your health records stay on this device. Wellet processes the data to show you what matters \u2014 it\u2019s never stored on our servers.\n\n'
+    + 'You\u2019ll be redirected to select your health provider and sign in.'
+  );
+  if (!confirmed) {
+    _ehrConnecting = false;
+    return;
+  }
+
+  showToast('Connecting to health records\u2026');
+
+  // Call the oneup-auth edge function to get the authorize URL
+  db.auth.getSession().then(function(sessionRes) {
+    var session = sessionRes.data.session;
+    if (!session) {
+      showToast('Session expired. Please sign in again.');
+      _ehrConnecting = false;
+      return;
+    }
+    return fetch(SUPABASE_URL + '/functions/v1/oneup-auth', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + session.access_token,
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_ANON_KEY
+      },
+      body: JSON.stringify({ action: 'start', person_id: personId })
+    });
+  }).then(function(res) {
+    if (!res) return;
+    return res.json();
+  }).then(function(data) {
+    _ehrConnecting = false;
+    if (!data) return;
+    if (data.error) {
+      showToast('Error: ' + data.error);
+      return;
+    }
+    if (data.authorize_url) {
+      // Redirect to 1upHealth system picker
+      window.location.href = data.authorize_url;
+    }
+  }).catch(function(err) {
+    _ehrConnecting = false;
+    console.error('EHR connect error:', err);
+    showToast('Failed to start EHR connection');
+  });
+}
+
+// Handle the OAuth callback (called on page load if code is present)
+function handleEhrCallback() {
+  var params = new URLSearchParams(window.location.search);
+  var code = params.get('code');
+  if (!code) return;
+
+  // Get the pending person_id
+  var personId;
+  try { personId = localStorage.getItem('wellet_ehr_pending_person'); } catch(e) {}
+  if (!personId) {
+    console.warn('EHR callback: no pending person_id');
+    return;
+  }
+
+  // Clean up URL
+  try {
+    var cleanUrl = window.location.origin + window.location.pathname;
+    window.history.replaceState({}, '', cleanUrl);
+  } catch(e) {}
+
+  // Wait for auth to be ready, then exchange the code
+  var checkAuth = setInterval(function() {
+    if (!currentUser) return;
+    clearInterval(checkAuth);
+
+    showToast('Completing EHR connection\u2026');
+
+    db.auth.getSession().then(function(sessionRes) {
+      var session = sessionRes.data.session;
+      if (!session) return;
+      return fetch(SUPABASE_URL + '/functions/v1/oneup-auth', {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer ' + session.access_token,
+          'Content-Type': 'application/json',
+          'apikey': SUPABASE_ANON_KEY
+        },
+        body: JSON.stringify({ action: 'callback', code: code, person_id: personId })
+      });
+    }).then(function(res) {
+      if (!res) return;
+      return res.json();
+    }).then(function(data) {
+      if (!data) return;
+      if (data.error) {
+        showToast('EHR connection failed: ' + data.error);
+        return;
+      }
+      try { localStorage.removeItem('wellet_ehr_pending_person'); } catch(e) {}
+      showToast('Health records connected! Fetching data\u2026');
+      // Fetch EHR data now
+      fetchEhrData(personId);
+    }).catch(function(err) {
+      console.error('EHR callback error:', err);
+      showToast('EHR connection failed');
+    });
+  }, 500);
+
+  // Timeout after 15 seconds
+  setTimeout(function() { clearInterval(checkAuth); }, 15000);
+}
+
+// Fetch EHR data from the edge function
+function fetchEhrData(personId) {
+  if (isDemoMode || !currentUser || !personId) return;
+
+  db.auth.getSession().then(function(sessionRes) {
+    var session = sessionRes.data.session;
+    if (!session) return;
+    return fetch(SUPABASE_URL + '/functions/v1/fetch-ehr-data', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + session.access_token,
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_ANON_KEY
+      },
+      body: JSON.stringify({ person_id: personId })
+    });
+  }).then(function(res) {
+    if (!res) return;
+    return res.json();
+  }).then(function(data) {
+    if (!data || data.error) {
+      console.log('EHR fetch:', data ? data.error : 'no response');
+      return;
+    }
+    saveEhrCache(personId, data);
+    showToast('Health records updated');
+    // Re-render views with EHR data
+    if (personId === currentPersonId) {
+      renderRecordsView();
+      renderTimeline();
+    }
+  }).catch(function(err) {
+    console.error('EHR fetch error:', err);
+  });
+}
+
+// Refresh EHR data (manual button click)
+function refreshEhrData() {
+  if (isDemoMode) {
+    showToast('Demo data refreshed');
+    return;
+  }
+  var personId = currentPersonId;
+  if (!personId) return;
+  showToast('Refreshing health records\u2026');
+  fetchEhrData(personId);
+}
+
+// Disconnect EHR
+function disconnectEhr() {
+  if (isDemoMode) return;
+  var personId = currentPersonId;
+  if (!personId) return;
+  if (!confirm('Disconnect health records? Cached data on this device will be removed.')) return;
+
+  clearEhrCache(personId);
+
+  db.auth.getSession().then(function(sessionRes) {
+    var session = sessionRes.data.session;
+    if (!session) return;
+    return fetch(SUPABASE_URL + '/functions/v1/oneup-auth', {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + session.access_token,
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_ANON_KEY
+      },
+      body: JSON.stringify({ action: 'disconnect', person_id: personId })
+    });
+  }).then(function() {
+    showToast('Health records disconnected');
+    renderRecordsView();
+    renderTimeline();
+    updateSettingsEhr();
+  }).catch(function(err) {
+    console.error('EHR disconnect error:', err);
+  });
+}
+
+// Update settings EHR status display
+function updateSettingsEhr() {
+  var statusEl = document.getElementById('settings-ehr-status');
+  var labelEl = document.getElementById('settings-ehr-label');
+  var metaEl = document.getElementById('settings-ehr-meta');
+  if (!statusEl) return;
+
+  var ehrData = getEhrData(currentPersonId);
+  if (isDemoMode && ehrData) {
+    statusEl.innerHTML = '<div class="ehr-status-bar">'
+      + '<div class="ehr-status-left"><div class="ehr-status-dot"></div>Connected to ' + escHtml(ehrData.provider) + '</div>'
+      + '<div class="ehr-status-right"><span style="font-size:11px;color:var(--text-muted);">Demo data</span></div>'
+      + '</div>';
+    if (labelEl) labelEl.textContent = 'Health Records Connected';
+    if (metaEl) metaEl.textContent = 'Demo mode \u2014 showing sample EHR data';
+  } else if (ehrData && ehrData.synced_at) {
+    var syncedStr = formatEventDate(ehrData.synced_at);
+    statusEl.innerHTML = '<div class="ehr-status-bar">'
+      + '<div class="ehr-status-left"><div class="ehr-status-dot"></div>Connected to ' + escHtml(ehrData.provider || 'EHR Provider') + '</div>'
+      + '<div class="ehr-status-right">'
+      + '<span style="font-size:11px;color:var(--text-muted);">Synced ' + syncedStr + '</span>'
+      + '<button class="ehr-refresh-btn" onclick="event.stopPropagation();refreshEhrData();" title="Refresh"><i data-lucide="refresh-cw" style="width:14px;height:14px;"></i></button>'
+      + '<button class="ehr-refresh-btn" onclick="event.stopPropagation();disconnectEhr();" title="Disconnect" style="color:var(--red);"><i data-lucide="unplug" style="width:14px;height:14px;"></i></button>'
+      + '</div></div>';
+    if (labelEl) labelEl.textContent = 'Manage Health Records';
+    if (metaEl) metaEl.textContent = 'Connected to ' + (ehrData.provider || 'EHR Provider');
+    initIcons();
+  } else {
+    statusEl.innerHTML = '';
+    if (labelEl) labelEl.textContent = 'Connect Health Records';
+    if (metaEl) metaEl.textContent = 'Import data from your provider (Epic, Cerner, etc.)';
+  }
+}
+
+// Update profile EHR section
+function updateProfileEhr(personId) {
+  var section = document.getElementById('profile-ehr-section');
+  if (!section) return;
+  var pid = personId || currentPersonId;
+  var ehrData = getEhrData(pid);
+
+  if (isDemoMode && ehrData) {
+    section.innerHTML = '<div class="ehr-status-bar">'
+      + '<div class="ehr-status-left"><div class="ehr-status-dot"></div>Connected to ' + escHtml(ehrData.provider) + '</div>'
+      + '<div class="ehr-status-right"><span style="font-size:11px;color:var(--text-muted);">Demo</span></div>'
+      + '</div>';
+  } else if (ehrData && ehrData.synced_at) {
+    section.innerHTML = '<div class="ehr-status-bar">'
+      + '<div class="ehr-status-left"><div class="ehr-status-dot"></div>Connected to ' + escHtml(ehrData.provider || 'EHR Provider') + '</div>'
+      + '<div class="ehr-status-right">'
+      + '<button class="ehr-refresh-btn" onclick="event.stopPropagation();refreshEhrData();" title="Refresh"><i data-lucide="refresh-cw" style="width:14px;height:14px;"></i></button>'
+      + '</div></div>';
+    initIcons();
+  } else {
+    section.innerHTML = '<div class="ehr-connect-card" onclick="startEhrConnect()">'
+      + '<div class="ehr-connect-icon"><i data-lucide="hospital" style="width:22px;height:22px;"></i></div>'
+      + '<div class="ehr-connect-title">Connect Health Records</div>'
+      + '<div class="ehr-connect-desc">Import medications, conditions, and lab results from your provider</div>'
+      + '</div>';
+    initIcons();
+  }
+}
+
+// Build EHR badge HTML
+function ehrBadgeHtml(provider) {
+  return '<span class="ehr-badge"><i data-lucide="hospital" style="width:10px;height:10px;"></i>EHR</span>';
+}
+
+function ehrProviderBadgeHtml(provider) {
+  return '<span class="ehr-provider-badge">From ' + escHtml(provider || 'EHR') + '</span>';
+}
+
+// Build EHR status bar for Records view
+function buildEhrStatusBar(ehrData) {
+  if (!ehrData || !ehrData.synced_at) return '';
+  var syncedStr = formatEventDate(ehrData.synced_at);
+  return '<div class="ehr-status-bar">'
+    + '<div class="ehr-status-left"><div class="ehr-status-dot"></div><strong>EHR Connected</strong> \u00B7 ' + escHtml(ehrData.provider || 'Provider') + '</div>'
+    + '<div class="ehr-status-right">'
+    + '<span style="font-size:11px;color:var(--text-muted);">Synced ' + syncedStr + '</span>'
+    + '<button class="ehr-refresh-btn" onclick="refreshEhrData()" title="Refresh data"><i data-lucide="refresh-cw" style="width:14px;height:14px;"></i></button>'
+    + '</div></div>';
+}
+
+// Build the "no EHR connected" prompt
+function buildEhrPrompt() {
+  return '<div class="ehr-section-prompt">'
+    + '<i data-lucide="hospital" style="width:14px;height:14px;display:inline-block;vertical-align:-2px;margin-right:3px;color:var(--moss);"></i>'
+    + '<a onclick="startEhrConnect()">Connect health records</a> to see medications, conditions, and lab results from your provider.'
+    + '</div>';
+}
+
+// Check for auth callback code on page load
+function checkEhrCallbackOnLoad() {
+  var params = new URLSearchParams(window.location.search);
+  if (params.get('code')) {
+    handleEhrCallback();
+  }
+}
+
+// Auto-refresh stale EHR data on person load
+function autoRefreshEhrIfNeeded(personId) {
+  if (isDemoMode || !currentUser || !personId) return;
+  var cached = loadEhrCache(personId);
+  if (cached && isEhrCacheStale(personId)) {
+    fetchEhrData(personId);
+  }
+}
+
 // ── EXISTING UI FUNCTIONS (preserved) ────────────────────────────────────────
 var _responses = {
   dad: {
@@ -4826,6 +5513,7 @@ function openProfileEdit(personId) {
   document.getElementById('profile-ec-phone-input').value = person.emergency_contact_phone || '';
   document.getElementById('profile-insurance-input').value = person.insurance_info || '';
 
+  updateProfileEhr(pid);
   document.getElementById('profile-overlay').classList.add('show');
   initIcons();
 }
@@ -5314,6 +6002,7 @@ async function removeContact() {
 
 function openSettings() {
   updateSettingsAccount();
+  updateSettingsEhr();
   if (!isDemoMode) { renderCareCircle(); }
   document.getElementById('settings-overlay').classList.add('show');
   initIcons();

--- a/supabase/functions/fetch-ehr-data/index.ts
+++ b/supabase/functions/fetch-ehr-data/index.ts
@@ -1,0 +1,323 @@
+// Supabase Edge Function: fetch-ehr-data
+// Fetches FHIR resources from 1upHealth for a connected person,
+// maps them to a simplified Wellet-friendly JSON structure,
+// and returns the data to the frontend (NOT stored in Supabase).
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const ONEUP_CLIENT_ID = Deno.env.get('ONEUP_CLIENT_ID') ?? '';
+const ONEUP_CLIENT_SECRET = Deno.env.get('ONEUP_CLIENT_SECRET') ?? '';
+const ONEUP_API_BASE = 'https://api.1up.health';
+const ONEUP_AUTH_BASE = 'https://auth.1up.health';
+const FHIR_BASE = `${ONEUP_API_BASE}/fhir/r4`;
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function getAdminClient() {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  return createClient(supabaseUrl, supabaseServiceKey);
+}
+
+async function getAuthenticatedUser(req: Request) {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) return null;
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const { data: { user }, error } = await userClient.auth.getUser();
+  if (error || !user) return null;
+  return user;
+}
+
+// Refresh expired tokens
+async function refreshTokens(refreshToken: string) {
+  const res = await fetch(`${ONEUP_AUTH_BASE}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: ONEUP_CLIENT_ID,
+      client_secret: ONEUP_CLIENT_SECRET,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+  if (!res.ok) throw new Error('Token refresh failed');
+  return await res.json();
+}
+
+// Fetch a FHIR resource type, handling pagination
+async function fetchFhirResource(resourceType: string, accessToken: string): Promise<unknown[]> {
+  const entries: unknown[] = [];
+  let url: string | null = `${FHIR_BASE}/${resourceType}?_count=50`;
+
+  while (url && entries.length < 200) {
+    const res = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      console.error(`FHIR fetch ${resourceType} failed: ${res.status}`);
+      break;
+    }
+
+    const bundle = await res.json();
+    if (bundle.entry) {
+      for (const e of bundle.entry) {
+        if (e.resource) entries.push(e.resource);
+      }
+    }
+
+    // Follow next page link
+    url = null;
+    if (bundle.link) {
+      const nextLink = bundle.link.find((l: { relation: string; url: string }) => l.relation === 'next');
+      if (nextLink) url = nextLink.url;
+    }
+  }
+
+  return entries;
+}
+
+// ── FHIR → Wellet Mappers ──
+
+function mapConditions(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const coding = (r.code as Record<string, unknown>)?.coding as Record<string, unknown>[] || [];
+    const firstCoding = coding[0] || {};
+    return {
+      type: 'condition',
+      source: 'ehr',
+      name: (r.code as Record<string, unknown>)?.text || firstCoding.display || 'Unknown condition',
+      code: firstCoding.code || '',
+      system: firstCoding.system || '',
+      status: (r.clinicalStatus as Record<string, unknown>)?.coding?.[0]?.code || r.clinicalStatus || '',
+      onset_date: r.onsetDateTime || (r.onsetPeriod as Record<string, unknown>)?.start || '',
+      recorded_date: r.recordedDate || '',
+    };
+  });
+}
+
+function mapMedications(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const medCode = (r.medicationCodeableConcept as Record<string, unknown>) || {};
+    const coding = (medCode.coding as Record<string, unknown>[]) || [];
+    const firstCoding = coding[0] || {};
+    const dosage = (r.dosage as Record<string, unknown>[]) || [];
+    const firstDosage = dosage[0] || {};
+    const timing = (firstDosage.timing as Record<string, unknown>) || {};
+    const repeat = (timing.repeat as Record<string, unknown>) || {};
+
+    return {
+      type: 'medication',
+      source: 'ehr',
+      name: medCode.text || firstCoding.display || 'Unknown medication',
+      code: firstCoding.code || '',
+      status: r.status || '',
+      dosage: (firstDosage.text as string) || '',
+      frequency: repeat.frequency ? `${repeat.frequency}x per ${repeat.period || ''} ${repeat.periodUnit || ''}`.trim() : '',
+      date_asserted: r.dateAsserted || r.authoredOn || '',
+    };
+  });
+}
+
+function mapAllergies(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const coding = (r.code as Record<string, unknown>)?.coding as Record<string, unknown>[] || [];
+    const firstCoding = coding[0] || {};
+    const reactions = (r.reaction as Record<string, unknown>[]) || [];
+    const manifestations = reactions.length > 0
+      ? ((reactions[0].manifestation as Record<string, unknown>[]) || []).map(
+          (m) => (m.coding as Record<string, unknown>[])?.[0]?.display || m.text || ''
+        ).filter(Boolean)
+      : [];
+
+    return {
+      type: 'allergy',
+      source: 'ehr',
+      name: (r.code as Record<string, unknown>)?.text || firstCoding.display || 'Unknown allergen',
+      code: firstCoding.code || '',
+      severity: reactions[0]?.severity || '',
+      reactions: manifestations,
+      status: (r.clinicalStatus as Record<string, unknown>)?.coding?.[0]?.code || '',
+      recorded_date: r.recordedDate || r.assertedDate || '',
+    };
+  });
+}
+
+function mapObservations(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const coding = (r.code as Record<string, unknown>)?.coding as Record<string, unknown>[] || [];
+    const firstCoding = coding[0] || {};
+    let value = '';
+    let unit = '';
+
+    if (r.valueQuantity) {
+      const vq = r.valueQuantity as Record<string, unknown>;
+      value = String(vq.value || '');
+      unit = (vq.unit as string) || '';
+    } else if (r.valueString) {
+      value = r.valueString as string;
+    } else if (r.valueCodeableConcept) {
+      const vcc = r.valueCodeableConcept as Record<string, unknown>;
+      value = (vcc.text as string) || ((vcc.coding as Record<string, unknown>[]))?.[0]?.display as string || '';
+    }
+
+    return {
+      type: 'observation',
+      source: 'ehr',
+      name: (r.code as Record<string, unknown>)?.text || firstCoding.display || 'Lab result',
+      code: firstCoding.code || '',
+      value: value,
+      unit: unit,
+      reference_range: (r.referenceRange as Record<string, unknown>[])?.length > 0
+        ? (r.referenceRange as Record<string, unknown>[])[0].text || ''
+        : '',
+      status: r.status || '',
+      effective_date: r.effectiveDateTime || (r.effectivePeriod as Record<string, unknown>)?.start || '',
+      category: ((r.category as Record<string, unknown>[]) || [])[0]?.coding?.[0]?.code || '',
+    };
+  });
+}
+
+function mapEncounters(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const typeCoding = ((r.type as Record<string, unknown>[]) || [])[0];
+    const coding = (typeCoding?.coding as Record<string, unknown>[]) || [];
+    const firstCoding = coding[0] || {};
+    const period = (r.period as Record<string, unknown>) || {};
+
+    return {
+      type: 'encounter',
+      source: 'ehr',
+      name: typeCoding?.text || firstCoding.display || (r.class as Record<string, unknown>)?.display || 'Visit',
+      status: r.status || '',
+      start_date: period.start || '',
+      end_date: period.end || '',
+      class: (r.class as Record<string, unknown>)?.code || '',
+    };
+  });
+}
+
+function mapProcedures(resources: unknown[]) {
+  return (resources as Record<string, unknown>[]).map((r) => {
+    const coding = (r.code as Record<string, unknown>)?.coding as Record<string, unknown>[] || [];
+    const firstCoding = coding[0] || {};
+
+    return {
+      type: 'procedure',
+      source: 'ehr',
+      name: (r.code as Record<string, unknown>)?.text || firstCoding.display || 'Procedure',
+      code: firstCoding.code || '',
+      status: r.status || '',
+      performed_date: r.performedDateTime || (r.performedPeriod as Record<string, unknown>)?.start || '',
+    };
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      return jsonResponse({ error: 'Unauthorized' }, 401);
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const { person_id } = body;
+    if (!person_id) {
+      return jsonResponse({ error: 'person_id is required' }, 400);
+    }
+
+    const admin = getAdminClient();
+
+    // Get stored connection
+    const { data: conn, error: connError } = await admin.from('ehr_connections')
+      .select('*')
+      .eq('person_id', person_id)
+      .eq('user_id', user.id)
+      .single();
+
+    if (connError || !conn || !conn.access_token) {
+      return jsonResponse({ error: 'No EHR connection found for this person' }, 404);
+    }
+
+    let accessToken = conn.access_token;
+
+    // Refresh token if expired
+    if (conn.token_expires_at && new Date(conn.token_expires_at) <= new Date()) {
+      if (!conn.refresh_token) {
+        return jsonResponse({ error: 'Token expired and no refresh token available' }, 401);
+      }
+
+      const refreshed = await refreshTokens(conn.refresh_token);
+      accessToken = refreshed.access_token;
+      const newExpiry = new Date(Date.now() + (refreshed.expires_in || 7200) * 1000).toISOString();
+
+      await admin.from('ehr_connections').update({
+        access_token: refreshed.access_token,
+        refresh_token: refreshed.refresh_token || conn.refresh_token,
+        token_expires_at: newExpiry,
+      }).eq('id', conn.id);
+    }
+
+    // Fetch all FHIR resource types in parallel
+    const [conditions, medications, allergies, observations, encounters, procedures] = await Promise.all([
+      fetchFhirResource('Condition', accessToken),
+      fetchFhirResource('MedicationStatement', accessToken).then(async (stmts) => {
+        // Also try MedicationRequest if MedicationStatement is empty
+        if (stmts.length === 0) {
+          return await fetchFhirResource('MedicationRequest', accessToken);
+        }
+        return stmts;
+      }),
+      fetchFhirResource('AllergyIntolerance', accessToken),
+      fetchFhirResource('Observation', accessToken),
+      fetchFhirResource('Encounter', accessToken),
+      fetchFhirResource('Procedure', accessToken),
+    ]);
+
+    // Map FHIR resources to Wellet-friendly format
+    const result = {
+      conditions: mapConditions(conditions),
+      medications: mapMedications(medications),
+      allergies: mapAllergies(allergies),
+      observations: mapObservations(observations),
+      encounters: mapEncounters(encounters),
+      procedures: mapProcedures(procedures),
+      provider: conn.connected_provider || 'EHR Provider',
+      synced_at: new Date().toISOString(),
+    };
+
+    // Update last_synced_at
+    await admin.from('ehr_connections').update({
+      last_synced_at: result.synced_at,
+    }).eq('id', conn.id);
+
+    return jsonResponse(result);
+
+  } catch (err) {
+    console.error('fetch-ehr-data error:', err);
+    return jsonResponse({ error: err.message || 'Internal server error' }, 500);
+  }
+});

--- a/supabase/functions/oneup-auth/index.ts
+++ b/supabase/functions/oneup-auth/index.ts
@@ -1,0 +1,284 @@
+// Supabase Edge Function: oneup-auth
+// Handles 1upHealth OAuth2 flow for EHR connections.
+// Routes:
+//   POST /start   — Creates a 1upHealth user, returns authorize URL
+//   POST /callback — Exchanges auth code for tokens, stores in ehr_connections
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const ONEUP_CLIENT_ID = Deno.env.get('ONEUP_CLIENT_ID') ?? '';
+const ONEUP_CLIENT_SECRET = Deno.env.get('ONEUP_CLIENT_SECRET') ?? '';
+const ONEUP_API_BASE = 'https://api.1up.health';
+const ONEUP_AUTH_BASE = 'https://auth.1up.health';
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+async function getAuthenticatedUser(req: Request) {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) return null;
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+  const { data: { user }, error } = await userClient.auth.getUser();
+  if (error || !user) return null;
+  return user;
+}
+
+function getAdminClient() {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  return createClient(supabaseUrl, supabaseServiceKey);
+}
+
+// Create a 1upHealth user via their API
+async function createOneUpUser(appUserId: string): Promise<{ oneup_user_id: string; code: string }> {
+  const res = await fetch(`${ONEUP_API_BASE}/user-management/v1/user`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      app_user_id: appUserId,
+      client_id: ONEUP_CLIENT_ID,
+      client_secret: ONEUP_CLIENT_SECRET,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`1upHealth user creation failed: ${res.status} ${text}`);
+  }
+
+  const data = await res.json();
+  return {
+    oneup_user_id: String(data.oneup_user_id || data.id || ''),
+    code: data.code || '',
+  };
+}
+
+// Exchange an auth code for access + refresh tokens
+async function exchangeCodeForTokens(code: string): Promise<{
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}> {
+  const res = await fetch(`${ONEUP_AUTH_BASE}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: ONEUP_CLIENT_ID,
+      client_secret: ONEUP_CLIENT_SECRET,
+      code: code,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Token exchange failed: ${res.status} ${text}`);
+  }
+
+  return await res.json();
+}
+
+// Refresh an expired access token
+async function refreshAccessToken(refreshToken: string): Promise<{
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}> {
+  const res = await fetch(`${ONEUP_AUTH_BASE}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: ONEUP_CLIENT_ID,
+      client_secret: ONEUP_CLIENT_SECRET,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Token refresh failed: ${res.status} ${text}`);
+  }
+
+  return await res.json();
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const user = await getAuthenticatedUser(req);
+    if (!user) {
+      return jsonResponse({ error: 'Unauthorized' }, 401);
+    }
+
+    const url = new URL(req.url);
+    const body = await req.json().catch(() => ({}));
+    const action = body.action || url.searchParams.get('action') || '';
+
+    // ── START: Create 1upHealth user and return authorize URL ──
+    if (action === 'start') {
+      const { person_id } = body;
+      if (!person_id) {
+        return jsonResponse({ error: 'person_id is required' }, 400);
+      }
+
+      const admin = getAdminClient();
+
+      // Check if there's already a connection for this person
+      const { data: existing } = await admin.from('ehr_connections')
+        .select('*')
+        .eq('person_id', person_id)
+        .eq('user_id', user.id)
+        .single();
+
+      let oneupUserId: string;
+      let authCode: string;
+
+      if (existing?.oneup_user_id) {
+        // Re-generate an auth code for the existing 1upHealth user
+        const codeRes = await fetch(`${ONEUP_API_BASE}/user-management/v1/user/auth-code`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            app_user_id: `${user.id}_${person_id}`,
+            client_id: ONEUP_CLIENT_ID,
+            client_secret: ONEUP_CLIENT_SECRET,
+          }),
+        });
+        if (!codeRes.ok) {
+          // Fallback: re-create user
+          const result = await createOneUpUser(`${user.id}_${person_id}`);
+          oneupUserId = existing.oneup_user_id;
+          authCode = result.code;
+        } else {
+          const codeData = await codeRes.json();
+          oneupUserId = existing.oneup_user_id;
+          authCode = codeData.code || '';
+        }
+      } else {
+        // Create a new 1upHealth user
+        const result = await createOneUpUser(`${user.id}_${person_id}`);
+        oneupUserId = result.oneup_user_id;
+        authCode = result.code;
+
+        // Store the connection record
+        await admin.from('ehr_connections').upsert({
+          user_id: user.id,
+          person_id: person_id,
+          oneup_user_id: oneupUserId,
+          connected_at: new Date().toISOString(),
+        }, { onConflict: 'person_id' });
+      }
+
+      // Build the authorize URL — this opens 1upHealth's health system picker
+      const authorizeUrl = `${ONEUP_API_BASE}/connect/system/clinical?client_id=${ONEUP_CLIENT_ID}&access_token=${authCode}`;
+
+      return jsonResponse({
+        authorize_url: authorizeUrl,
+        oneup_user_id: oneupUserId,
+      });
+    }
+
+    // ── CALLBACK: Exchange auth code for tokens ──
+    if (action === 'callback') {
+      const { code, person_id } = body;
+      if (!code || !person_id) {
+        return jsonResponse({ error: 'code and person_id are required' }, 400);
+      }
+
+      // Exchange the code for tokens
+      const tokens = await exchangeCodeForTokens(code);
+      const expiresAt = new Date(Date.now() + (tokens.expires_in || 7200) * 1000).toISOString();
+
+      const admin = getAdminClient();
+
+      // Update the connection with tokens
+      const { error: updateError } = await admin.from('ehr_connections')
+        .update({
+          access_token: tokens.access_token,
+          refresh_token: tokens.refresh_token,
+          token_expires_at: expiresAt,
+          connected_provider: 'EHR Provider',
+          connected_at: new Date().toISOString(),
+        })
+        .eq('person_id', person_id)
+        .eq('user_id', user.id);
+
+      if (updateError) {
+        console.error('Token store error:', updateError);
+        return jsonResponse({ error: 'Failed to store tokens' }, 500);
+      }
+
+      return jsonResponse({ success: true, expires_at: expiresAt });
+    }
+
+    // ── STATUS: Check connection status ──
+    if (action === 'status') {
+      const { person_id } = body;
+      if (!person_id) {
+        return jsonResponse({ error: 'person_id is required' }, 400);
+      }
+
+      const admin = getAdminClient();
+      const { data: conn } = await admin.from('ehr_connections')
+        .select('id, connected_provider, connected_at, last_synced_at, token_expires_at')
+        .eq('person_id', person_id)
+        .eq('user_id', user.id)
+        .single();
+
+      if (!conn || !conn.connected_at) {
+        return jsonResponse({ connected: false });
+      }
+
+      return jsonResponse({
+        connected: true,
+        provider: conn.connected_provider,
+        connected_at: conn.connected_at,
+        last_synced_at: conn.last_synced_at,
+        token_valid: conn.token_expires_at ? new Date(conn.token_expires_at) > new Date() : false,
+      });
+    }
+
+    // ── DISCONNECT: Remove EHR connection ──
+    if (action === 'disconnect') {
+      const { person_id } = body;
+      if (!person_id) {
+        return jsonResponse({ error: 'person_id is required' }, 400);
+      }
+
+      const admin = getAdminClient();
+      await admin.from('ehr_connections')
+        .delete()
+        .eq('person_id', person_id)
+        .eq('user_id', user.id);
+
+      return jsonResponse({ success: true });
+    }
+
+    return jsonResponse({ error: 'Unknown action. Use: start, callback, status, disconnect' }, 400);
+
+  } catch (err) {
+    console.error('oneup-auth error:', err);
+    return jsonResponse({ error: err.message || 'Internal server error' }, 500);
+  }
+});

--- a/supabase/migrations/20260415200000_create_ehr_connections.sql
+++ b/supabase/migrations/20260415200000_create_ehr_connections.sql
@@ -1,0 +1,45 @@
+-- EHR Connections: stores 1upHealth OAuth connection metadata per person.
+-- Tokens are stored here (encrypted at rest by Supabase); raw FHIR data is NOT stored.
+
+create table if not exists public.ehr_connections (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  person_id uuid not null references public.people(id) on delete cascade,
+  oneup_user_id text,
+  access_token text,
+  refresh_token text,
+  token_expires_at timestamptz,
+  connected_provider text,
+  connected_at timestamptz default now(),
+  last_synced_at timestamptz,
+  created_at timestamptz default now()
+);
+
+-- One EHR connection per person
+create unique index idx_ehr_connections_person on public.ehr_connections (person_id);
+
+-- Fast lookup by user
+create index idx_ehr_connections_user on public.ehr_connections (user_id);
+
+-- RLS: users can only access their own connections
+alter table public.ehr_connections enable row level security;
+
+create policy "Users can view own EHR connections"
+  on public.ehr_connections for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own EHR connections"
+  on public.ehr_connections for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own EHR connections"
+  on public.ehr_connections for update
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can delete own EHR connections"
+  on public.ehr_connections for delete
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

Implements GitHub issue #15: Connect to 1upHealth's FHIR API to pull real EHR data and display it alongside manually-entered data — the core differentiator for Wellet.

### Backend (Supabase)

- **Migration** (`20260415200000_create_ehr_connections.sql`): Creates `ehr_connections` table storing OAuth tokens and connection metadata per person with full RLS policies
- **Edge function `oneup-auth`**: Handles the full 1upHealth OAuth2 flow:
  - `start` — Creates a 1upHealth user via their User Management API, returns the authorize URL for the health system picker
  - `callback` — Exchanges the auth code for access + refresh tokens, stores in `ehr_connections`
  - `status` — Checks connection status and token validity
  - `disconnect` — Removes the EHR connection
  - Handles token refresh for expired tokens and auth-code regeneration for existing users
- **Edge function `fetch-ehr-data`**: Fetches FHIR R4 resources and maps to Wellet-friendly JSON:
  - Resources: Condition, MedicationStatement/MedicationRequest, AllergyIntolerance, Observation, Encounter, Procedure
  - Handles FHIR Bundle pagination (up to 200 entries per resource)
  - Automatic token refresh if expired
  - Returns simplified, mapped data (NOT stored in Supabase — privacy by design)

### Frontend (index.html)

- **Settings**: New "Health Records" section with connect button, status bar (provider name, sync date), refresh and disconnect controls
- **Profile**: EHR connect card in person profile overlay, shows connected status when active
- **Records view**: EHR data displayed alongside manual data with green `EHR` pill badges:
  - Medications tab shows both manual and EHR meds
  - New Conditions section from EHR with active/resolved status
  - Allergies section from EHR with severity and reaction details
  - Lab results merged (manual + EHR observations with values and units)
  - Encounters shown as appointments/visits
  - Procedures section from EHR
  - Each EHR item shows "From [Provider Name]" attribution badge
- **Timeline**: EHR encounters, conditions, procedures, and labs merged into chronological timeline with EHR badges and provider attribution
- **Local caching**: FHIR data cached in `localStorage` keyed by `person_id`, auto-refreshes after 24 hours, manual refresh button
- **OAuth callback**: Handles `?code=` parameter on page load for the 1upHealth redirect flow

### Privacy

- Raw FHIR JSON stored ONLY on-device (localStorage), never in Supabase
- Confirm dialog with privacy notice before initiating connection
- Privacy notice in Records view: "Your health records stay on this device"
- 1upHealth credentials stored only in edge function environment variables

### Demo Mode

- Dad shows sample EHR data from "Duke Health (Epic)":
  - Conditions: Parkinson's disease, essential hypertension
  - Medications: Levodopa/Carbidopa 25-100mg, Lisinopril 20mg
  - Allergies: Sulfonamide (skin rash, hives)
  - Labs: CBC (WBC 6.8, Hgb 14.2), Comprehensive metabolic panel (Glucose 98, Creatinine 1.0)
  - Encounters: Neurology office visit, annual physical
  - Procedures: EEG
- EHR status bar with "Demo data" label
- Connect button shows informational tooltip in demo mode

### Environment Variables Required

```
ONEUP_CLIENT_ID=bc30693687c13d2a756c29de3cf00788
ONEUP_CLIENT_SECRET=043c03002638fff3968bc4edac2e26f7
```

## Test plan

- [ ] Verify demo mode shows EHR badges on Dad's records (medications, conditions, labs, visits)
- [ ] Verify EHR status bar appears at top of Dad's Records view in demo mode
- [ ] Verify EHR items appear in demo Timeline with badges and provider attribution
- [ ] Verify "Connect Health Records" button in Settings shows demo tooltip
- [ ] Verify "Connect Health Records" card appears in profile edit overlay
- [ ] Verify Mom's records do NOT show EHR data (only Dad has demo EHR data)
- [ ] Verify allergies section with EHR badge appears in Dad's records
- [ ] Verify privacy notice appears at bottom of Dad's records
- [ ] Verify no client secrets are exposed in frontend code (only in edge functions)
- [ ] Verify Supabase migration has proper RLS policies
- [ ] Verify edge functions handle CORS, authentication, and error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)