### PR TITLE
Security: Phase 1 quick fixes — escHtml, localStorage PHI, share token, shares RLS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3195,6 +3195,7 @@ async function initApp() {
         return;
       }
       currentUser = session.user;
+      resetInactivityTimer();
       await loadUserData();
       // Auto-accept invite if pending
       if (_pendingInviteToken && _inviteData) {
@@ -3202,6 +3203,7 @@ async function initApp() {
       }
     } else if (event === 'SIGNED_OUT') {
       currentUser = null;
+      if (_inactivityTimer) clearTimeout(_inactivityTimer);
       showAuthScreen();
     }
   });
@@ -3347,6 +3349,7 @@ async function submitWaitlistRequest() {
 }
 
 async function handleLogout() {
+  clearPhiFromStorage();
   await db.auth.signOut();
   isDemoMode = false;
   currentUser = null;
@@ -3358,10 +3361,44 @@ async function handleLogout() {
   liveCareCircle = [];
   summaryCache = {};
   if (_audioPlayer) { _audioPlayer.pause(); _audioPlayer = null; }
+  ehrCache = {};
+  _emergencyBriefCache = {};
   closeSettings();
   showAuthScreen();
   showToast('Signed out');
 }
+
+// ── PHI STORAGE CLEANUP ───────────────────────────────────────────────────────
+function clearPhiFromStorage() {
+  try {
+    var keysToRemove = [];
+    for (var i = 0; i < localStorage.length; i++) {
+      var k = localStorage.key(i);
+      if (k && (k.indexOf('wellet_ehr_') === 0 || k.indexOf('wellet_er_brief_') === 0)) {
+        keysToRemove.push(k);
+      }
+    }
+    keysToRemove.forEach(function(k) { localStorage.removeItem(k); });
+  } catch(e) { /* localStorage unavailable */ }
+}
+
+// ── INACTIVITY TIMEOUT (15 minutes) ──────────────────────────────────────────
+var _inactivityTimer = null;
+var INACTIVITY_LIMIT_MS = 15 * 60 * 1000;
+
+function resetInactivityTimer() {
+  if (_inactivityTimer) clearTimeout(_inactivityTimer);
+  _inactivityTimer = setTimeout(function() {
+    if (currentUser && !isDemoMode) {
+      handleLogout();
+      showToast('Signed out due to inactivity');
+    }
+  }, INACTIVITY_LIMIT_MS);
+}
+
+['mousedown','keydown','touchstart','scroll'].forEach(function(evt) {
+  document.addEventListener(evt, resetInactivityTimer, { passive: true });
+});
 
 // ── LOAD USER DATA ────────────────────────────────────────────────────────────
 async function loadUserData() {
@@ -5576,7 +5613,7 @@ function formatEventDate(dateStr) {
 
 function escHtml(t) {
   if (!t) return '';
-  return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  return String(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
 // ── EHR INTEGRATION (1upHealth FHIR) ────────────────────────────────────────
@@ -6994,9 +7031,11 @@ async function createShareLink(action) {
 
 function generateShareToken() {
   var chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  var arr = new Uint32Array(24);
+  crypto.getRandomValues(arr);
   var token = '';
   for (var i = 0; i < 24; i++) {
-    token += chars.charAt(Math.floor(Math.random() * chars.length));
+    token += chars.charAt(arr[i] % chars.length);
   }
   return token;
 }

--- a/share.html
+++ b/share.html
@@ -229,9 +229,7 @@ async function loadShare() {
     var client = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
     var { data, error } = await client
-      .from('shares')
-      .select('*')
-      .eq('token', token)
+      .rpc('get_share_by_token', { share_token: token })
       .single();
 
     if (error || !data) {

--- a/supabase/migrations/20260416000001_fix_shares_rls_token_filter.sql
+++ b/supabase/migrations/20260416000001_fix_shares_rls_token_filter.sql
@@ -1,0 +1,38 @@
+-- SECURITY FIX: Shares table RLS — restrict anon SELECT to token-filtered lookups
+--
+-- BEFORE: Any anonymous caller could read ALL non-expired shares (person names,
+-- medications, appointments) without providing a token.
+--
+-- AFTER: Anonymous callers can only read a share row if they filter by a specific
+-- token value in the query. The share.html page already does .eq('token', token),
+-- so this is a no-op for legitimate use but blocks enumeration.
+
+-- Drop the overly permissive policy
+drop policy if exists "Public can read shares by token" on public.shares;
+
+-- Recreate with proper token filter using RLS + security definer function
+-- Since RLS can't inspect query params directly, we use a server-side function
+-- that takes a token and returns the share if valid and non-expired.
+
+-- Step 1: Create a secure lookup function (runs as service role, bypasses RLS)
+create or replace function public.get_share_by_token(share_token text)
+returns setof public.shares
+language sql
+security definer
+set search_path = public
+as $$
+  select * from public.shares
+  where token = share_token
+    and expires_at > now()
+  limit 1;
+$$;
+
+-- Step 2: Grant execute to anon role
+grant execute on function public.get_share_by_token(text) to anon;
+
+-- Step 3: Revoke direct anon SELECT on shares table entirely
+-- (authenticated users still have their own SELECT policy)
+revoke select on public.shares from anon;
+
+-- Note: share.html must be updated to call this function via .rpc() instead
+-- of querying the table directly. See the corresponding share.html change.

--- a/supabase/migrations/20260416000001_fix_shares_rls_token_filter.sql
+++ b/supabase/migrations/20260416000001_fix_shares_rls_token_filter.sql
@@ -1,25 +1,31 @@
--- SECURITY FIX: Shares table RLS — restrict anon SELECT to token-filtered lookups
+-- ============================================================================
+-- SECURITY FIX: Shares table RLS — restrict anon SELECT to token-gated RPC
+-- Run this BEFORE merging PR #29 to main (share.html calls this function)
+-- ============================================================================
 --
--- BEFORE: Any anonymous caller could read ALL non-expired shares (person names,
--- medications, appointments) without providing a token.
+-- PROBLEM: The anon SELECT policy "Public can read shares by token" allows any
+-- unauthenticated caller to read ALL non-expired share rows — patient names,
+-- medications, appointments — without providing a token value.
 --
--- AFTER: Anonymous callers can only read a share row if they filter by a specific
--- token value in the query. The share.html page already does .eq('token', token),
--- so this is a no-op for legitimate use but blocks enumeration.
+-- FIX: Replace direct table access with a security-definer RPC function that
+-- requires the caller to supply the exact token. Revoke direct anon SELECT.
+-- ============================================================================
 
--- Drop the overly permissive policy
+begin;
+
+-- 1. Drop the overly permissive anon SELECT policy
 drop policy if exists "Public can read shares by token" on public.shares;
 
--- Recreate with proper token filter using RLS + security definer function
--- Since RLS can't inspect query params directly, we use a server-side function
--- that takes a token and returns the share if valid and non-expired.
-
--- Step 1: Create a secure lookup function (runs as service role, bypasses RLS)
+-- 2. Create a secure lookup function
+--    - security definer: runs as the function owner (postgres), bypasses RLS
+--    - set search_path: prevents search_path injection
+--    - returns at most 1 row matching the exact token and checks expiration
 create or replace function public.get_share_by_token(share_token text)
 returns setof public.shares
 language sql
 security definer
 set search_path = public
+stable  -- result depends only on DB state, safe to cache within a transaction
 as $$
   select * from public.shares
   where token = share_token
@@ -27,12 +33,27 @@ as $$
   limit 1;
 $$;
 
--- Step 2: Grant execute to anon role
+-- 3. Grant execute to both anon and authenticated roles
 grant execute on function public.get_share_by_token(text) to anon;
+grant execute on function public.get_share_by_token(text) to authenticated;
 
--- Step 3: Revoke direct anon SELECT on shares table entirely
--- (authenticated users still have their own SELECT policy)
+-- 4. Revoke direct anon SELECT on the shares table
+--    Authenticated users keep their "Users can view own shares" policy.
+--    The security-definer function bypasses RLS entirely, so anon callers
+--    can still read shares — but ONLY through the RPC with a valid token.
 revoke select on public.shares from anon;
 
--- Note: share.html must be updated to call this function via .rpc() instead
--- of querying the table directly. See the corresponding share.html change.
+commit;
+
+-- ============================================================================
+-- ROLLBACK (if needed):
+--
+--   begin;
+--   drop function if exists public.get_share_by_token(text);
+--   grant select on public.shares to anon;
+--   create policy "Public can read shares by token"
+--     on public.shares for select
+--     to anon
+--     using (expires_at > now());
+--   commit;
+-- ============================================================================


### PR DESCRIPTION
## What this PR fixes

Four critical/high-severity findings from the HIPAA security audit, all low-effort and safe to merge.

### 1. `escHtml()` now escapes quotes (XSS fix)
**Before:** `escHtml()` only escaped `& < >` — user-generated content injected into HTML attributes (like `title=""` or `data-*=""`) could break out and execute arbitrary scripts.

**After:** Also escapes `"` → `&quot;` and `'` → `&#39;`. All 106+ call sites are covered.

### 2. PHI cleared from localStorage on logout + 15-min inactivity timeout
**Before:** EHR cache (`wellet_ehr_*`) and emergency briefs (`wellet_er_brief_*`) persisted in the browser after logout. Anyone opening the same browser could read patient data. No auto-logoff existed.

**After:**
- `handleLogout()` calls `clearPhiFromStorage()` which iterates localStorage and removes all `wellet_ehr_*` and `wellet_er_brief_*` keys
- In-memory caches (`ehrCache`, `_emergencyBriefCache`) are also wiped
- 15-minute inactivity timeout triggers automatic logout (HIPAA §164.312(a)(2)(iii))
- Timer resets on mousedown, keydown, touchstart, scroll
- Timer starts on SIGNED_IN, clears on SIGNED_OUT

### 3. `Math.random()` → `crypto.getRandomValues()` for share tokens
**Before:** Share tokens used `Math.random()` which is predictable and could theoretically allow token guessing.

**After:** Uses `crypto.getRandomValues()` for cryptographically secure 24-character tokens. The `crypto` API is available in all modern browsers and has been since 2013.

### 4. Shares table RLS — token-gated access via RPC
**Before:** The anon SELECT policy on `shares` allowed any unauthenticated caller to read ALL non-expired shares — patient names, medications, appointments — without providing a token.

**After:**
- Drops the permissive anon SELECT policy
- Creates a `get_share_by_token(share_token text)` security-definer function that returns at most 1 row matching the exact token and checks expiration
- Revokes direct anon SELECT on the shares table
- `share.html` updated to use `.rpc('get_share_by_token')` instead of `.from('shares').eq('token')`

### Deployment notes
- **index.html + share.html**: Auto-deploy via Netlify on merge to main
- **SQL migration**: Must be run against Supabase manually or via `supabase db push`. **Run the migration BEFORE merging to main** — otherwise share.html will call the RPC function before it exists.

### Testing
- [ ] Verify share links still work after migration (`/share.html?token=...`)
- [ ] Verify logout clears localStorage (DevTools → Application → Local Storage)
- [ ] Verify inactivity timeout fires after 15 min idle
- [ ] Verify `escHtml()` handles quotes in person names, event descriptions