### PR TITLE
Security Phase 2: CORS, headers, console cleanup, redirect fix

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,7 @@
+/*
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://nrpdhxygzyfmyljzfexv.supabase.co wss://nrpdhxygzyfmyljzfexv.supabase.co https://api.openai.com; frame-ancestors 'none';

--- a/index.html
+++ b/index.html
@@ -5418,7 +5418,7 @@ function fetchEhrData(personId) {
     return res.json();
   }).then(function(data) {
     if (!data || data.error) {
-      console.log('EHR fetch:', data ? data.error : 'no response');
+      // PHI log removed
       return;
     }
     saveEhrCache(personId, data);
@@ -6529,7 +6529,7 @@ async function confirmUpload() {
       
       if (fnResponse.ok) {
         var fnResult = await fnResponse.json();
-        console.log('AI extraction result:', fnResult);
+        // PHI log removed
       } else {
         console.warn('Edge function returned:', fnResponse.status);
       }
@@ -7436,7 +7436,7 @@ async function obHandleFiles(input, type) {
       _obExtractedData = extractedData;
     }
   } catch(e) {
-    console.log('Extraction not available yet, skipping:', e.message);
+    // PHI log removed
   }
 
   // Short delay for the user to see upload completion, then proceed to name screen
@@ -7515,7 +7515,7 @@ async function obFinishWithNames() {
             extraction_status: 'pending'
           });
         } catch(e) {
-          console.log('Doc record insert skipped:', e.message);
+          // PHI log removed
         }
       }
     }
@@ -7532,7 +7532,7 @@ async function obFinishWithNames() {
               title: _obExtractedData.conditions[c],
               source: 'Onboarding upload'
             });
-          } catch(e) { console.log('Condition insert skipped:', e.message); }
+          } catch(e) { /* PHI log removed */ }
         }
       }
       if (_obExtractedData.medications) {
@@ -7545,7 +7545,7 @@ async function obFinishWithNames() {
               status: 'active',
               source: 'Onboarding upload'
             });
-          } catch(e) { console.log('Med insert skipped:', e.message); }
+          } catch(e) { /* PHI log removed */ }
         }
       }
     }

--- a/index.html
+++ b/index.html
@@ -2855,6 +2855,8 @@ async function checkInviteOnLoad() {
   var params = new URLSearchParams(window.location.search);
   var token = params.get('invite');
   if (!token) return false;
+  // Validate invite token format (UUID) to prevent injection
+  if (!/^[a-f0-9\-]{36}$/.test(token)) return false;
   _pendingInviteToken = token;
 
   try {
@@ -5325,8 +5327,17 @@ function startEhrConnect() {
       return;
     }
     if (data.authorize_url) {
-      // Redirect to 1upHealth system picker
-      window.location.href = data.authorize_url;
+      // Validate redirect URL to prevent open redirect
+      try {
+        var authUrl = new URL(data.authorize_url);
+        if (authUrl.hostname.endsWith('1up.health')) {
+          window.location.href = data.authorize_url;
+        } else {
+          showToast('Invalid authorize URL');
+        }
+      } catch(e) {
+        showToast('Invalid authorize URL');
+      }
     }
   }).catch(function(err) {
     _ehrConnecting = false;
@@ -5340,6 +5351,8 @@ function handleEhrCallback() {
   var params = new URLSearchParams(window.location.search);
   var code = params.get('code');
   if (!code) return;
+  // Validate OAuth code format (alphanumeric, hyphens, underscores)
+  if (!/^[a-zA-Z0-9\-_]{1,256}$/.test(code)) return;
 
   // Get the pending person_id
   var personId;
@@ -6138,7 +6151,22 @@ async function createShareLink(action) {
       throw new Error(result.error || 'Failed to create share');
     }
 
-    _lastShareUrl = result.share_url;
+    // Validate share URL is relative or same-origin before using
+    var shareUrl = result.share_url || '';
+    if (shareUrl.startsWith('/') && !shareUrl.startsWith('//')) {
+      _lastShareUrl = shareUrl;
+    } else {
+      try {
+        var parsedShare = new URL(shareUrl, window.location.origin);
+        if (parsedShare.origin === window.location.origin) {
+          _lastShareUrl = shareUrl;
+        } else {
+          throw new Error('External share URL rejected');
+        }
+      } catch(e) {
+        throw new Error('Invalid share URL returned');
+      }
+    }
 
     // Also store in shares table directly as fallback
     // (edge function handles this, but track locally)

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,15 @@
+const ALLOWED_ORIGINS = [
+  "https://mywellet.com",
+  "https://www.mywellet.com",
+  "https://getwellet.com",
+  "https://www.getwellet.com",
+];
+
+export function getCorsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("Origin") || "";
+  return {
+    "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : "",
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+  };
+}

--- a/supabase/functions/care-circle-invite/index.ts
+++ b/supabase/functions/care-circle-invite/index.ts
@@ -3,12 +3,13 @@
 // Deployed with verify_jwt=false (lookup needs to work without auth)
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { corsHeaders } from '../_shared/cors.ts'
+import { getCorsHeaders } from '../_shared/cors.ts'
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL')!
 const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
 
 Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req)
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }

--- a/supabase/functions/create-share/index.ts
+++ b/supabase/functions/create-share/index.ts
@@ -4,12 +4,7 @@
 // Returns: { token, share_url, expires_at }
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 function generateToken(): string {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -23,6 +18,7 @@ function generateToken(): string {
 }
 
 Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/extract-onboarding/index.ts
+++ b/supabase/functions/extract-onboarding/index.ts
@@ -5,21 +5,19 @@
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { unzipSync } from 'https://esm.sh/fflate@0.8.2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-user-token',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
-
-function jsonResponse(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
-}
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 Deno.serve(async (req) => {
+  const corsHeaders = {
+    ...getCorsHeaders(req),
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-user-token',
+  };
+  function jsonResponse(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/fetch-ehr-data/index.ts
+++ b/supabase/functions/fetch-ehr-data/index.ts
@@ -4,25 +4,13 @@
 // and returns the data to the frontend (NOT stored in Supabase).
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 const ONEUP_CLIENT_ID = Deno.env.get('ONEUP_CLIENT_ID') ?? '';
 const ONEUP_CLIENT_SECRET = Deno.env.get('ONEUP_CLIENT_SECRET') ?? '';
 const ONEUP_API_BASE = 'https://api.1up.health';
 const ONEUP_AUTH_BASE = 'https://auth.1up.health';
 const FHIR_BASE = `${ONEUP_API_BASE}/fhir/r4`;
-
-function jsonResponse(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
-}
 
 function getAdminClient() {
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
@@ -233,6 +221,13 @@ function mapProcedures(resources: unknown[]) {
 }
 
 Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+  function jsonResponse(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/generate-emergency-summary/index.ts
+++ b/supabase/functions/generate-emergency-summary/index.ts
@@ -1,13 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
-};
+import { getCorsHeaders } from "../_shared/cors.ts";
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }

--- a/supabase/functions/generate-visit-questions/index.ts
+++ b/supabase/functions/generate-visit-questions/index.ts
@@ -1,13 +1,9 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
-};
+import { getCorsHeaders } from "../_shared/cors.ts";
 
 serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }

--- a/supabase/functions/manage-allowlist/index.ts
+++ b/supabase/functions/manage-allowlist/index.ts
@@ -4,14 +4,10 @@
 // POST body: { action: "add" | "remove", email: string, notes?: string }
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/oneup-auth/index.ts
+++ b/supabase/functions/oneup-auth/index.ts
@@ -5,24 +5,12 @@
 //   POST /callback — Exchanges auth code for tokens, stores in ehr_connections
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-};
+import { getCorsHeaders } from '../_shared/cors.ts';
 
 const ONEUP_CLIENT_ID = Deno.env.get('ONEUP_CLIENT_ID') ?? '';
 const ONEUP_CLIENT_SECRET = Deno.env.get('ONEUP_CLIENT_SECRET') ?? '';
 const ONEUP_API_BASE = 'https://api.1up.health';
 const ONEUP_AUTH_BASE = 'https://auth.1up.health';
-
-function jsonResponse(data: unknown, status = 200) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
-}
 
 async function getAuthenticatedUser(req: Request) {
   const authHeader = req.headers.get('Authorization');
@@ -121,6 +109,13 @@ async function refreshAccessToken(refreshToken: string): Promise<{
 }
 
 Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+  function jsonResponse(data: unknown, status = 200) {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }


### PR DESCRIPTION
## Summary

Closes #34
Closes #35

Security hardening across four areas:

- **Console.log PHI cleanup**: Removed 6 `console.log` statements in `index.html` that could leak PHI (EHR fetch errors, AI extraction results, medication/condition/doc insert details) to browser devtools. Non-PHI logs (errors, auth state) are preserved.

- **Netlify `_headers`**: Added security headers for the Netlify-hosted site — HSTS (2-year max-age + preload), X-Frame-Options DENY, X-Content-Type-Options nosniff, strict Referrer-Policy, Permissions-Policy denying camera/mic/geo, and a Content-Security-Policy restricting script/style/connect sources with frame-ancestors none.

- **Share URL open redirect prevention**: Validated invite token format (UUID regex) before API calls, validated EHR authorize_url against known `1up.health` domain before redirect, validated share URLs from the edge function are same-origin before use, and validated OAuth callback code format. Prevents open redirects via user-controlled URL parameters.

- **CORS restriction on edge functions**: Created `supabase/functions/_shared/cors.ts` with an origin allowlist (mywellet.com, getwellet.com + www variants). Updated all 8 edge functions to use dynamic `getCorsHeaders(req)` instead of `Access-Control-Allow-Origin: *`. Functions updated: care-circle-invite, create-share, extract-onboarding, fetch-ehr-data, generate-emergency-summary, generate-visit-questions, manage-allowlist, oneup-auth.

## Test plan

- [ ] Verify app loads correctly with new CSP headers on Netlify deploy preview
- [ ] Test share link creation (copy + email) works end-to-end
- [ ] Test care circle invite flow (create, lookup, accept)
- [ ] Test EHR connection OAuth flow redirects to 1up.health correctly
- [ ] Verify edge functions respond with correct CORS headers from allowed origins
- [ ] Verify edge functions reject requests from non-allowed origins
- [ ] Confirm no console.log PHI leaks remain in browser devtools during normal usage
- [ ] Test with malformed invite tokens (non-UUID) are rejected gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)