### PR TITLE
Fix: Audio upload stall — add CSP storage domain + upload timeout

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,4 +4,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://nrpdhxygzyfmyljzfexv.supabase.co wss://nrpdhxygzyfmyljzfexv.supabase.co https://api.openai.com; frame-ancestors 'none';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://nrpdhxygzyfmyljzfexv.supabase.co https://nrpdhxygzyfmyljzfexv.storage.supabase.co wss://nrpdhxygzyfmyljzfexv.supabase.co https://api.openai.com; frame-ancestors 'none';

--- a/index.html
+++ b/index.html
@@ -6667,16 +6667,61 @@ async function confirmUpload() {
     var safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
     var storagePath = userId + '/' + timestamp + '_' + safeName;
 
-    document.getElementById('upload-progress-bar').style.width = '25%';
+    document.getElementById('upload-progress-bar').style.width = '15%';
 
-    var uploadResult = await db.storage.from('documents').upload(storagePath, file, {
-      cacheControl: '3600',
-      upsert: false
+    // Upload via XMLHttpRequest for real progress + timeout (fixes silent hang with SDK)
+    var session = await db.auth.getSession();
+    var uploadToken = session.data.session.access_token;
+    var uploadUrl = SUPABASE_URL + '/storage/v1/object/documents/' + storagePath;
+
+    await new Promise(function(resolve, reject) {
+      var xhr = new XMLHttpRequest();
+      var uploadTimedOut = false;
+      var uploadTimeout = setTimeout(function() {
+        uploadTimedOut = true;
+        xhr.abort();
+        reject(new Error('Upload timed out after 60 seconds. Please check your connection and try again.'));
+      }, 60000);
+
+      xhr.upload.onprogress = function(e) {
+        if (e.lengthComputable) {
+          var pct = Math.round(15 + (e.loaded / e.total) * 35);
+          document.getElementById('upload-progress-bar').style.width = pct + '%';
+        }
+      };
+
+      xhr.onload = function() {
+        clearTimeout(uploadTimeout);
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          var errMsg = 'Storage upload failed (HTTP ' + xhr.status + ')';
+          try { errMsg = JSON.parse(xhr.responseText).message || errMsg; } catch(_e) {}
+          reject(new Error(errMsg));
+        }
+      };
+
+      xhr.onerror = function() {
+        clearTimeout(uploadTimeout);
+        if (!uploadTimedOut) {
+          reject(new Error('Upload failed — network error. Please check your connection.'));
+        }
+      };
+
+      xhr.onabort = function() {
+        clearTimeout(uploadTimeout);
+        if (!uploadTimedOut) {
+          reject(new Error('Upload was cancelled.'));
+        }
+      };
+
+      xhr.open('POST', uploadUrl, true);
+      xhr.setRequestHeader('Authorization', 'Bearer ' + uploadToken);
+      xhr.setRequestHeader('apikey', SUPABASE_ANON_KEY);
+      xhr.setRequestHeader('x-upsert', 'false');
+      xhr.setRequestHeader('cache-control', '3600');
+      xhr.send(file);
     });
-
-    if (uploadResult.error) {
-      throw new Error('Storage upload failed: ' + uploadResult.error.message);
-    }
 
     document.getElementById('upload-progress-bar').style.width = '50%';
     document.getElementById('upload-progress-title').textContent = 'Saving record...';


### PR DESCRIPTION
## Summary
- **CSP fix**: Added `https://nrpdhxygzyfmyljzfexv.storage.supabase.co` to the `connect-src` directive in `_headers`. The Supabase JS v2 client may route storage uploads through this subdomain, and without it the browser silently blocks the request — the SDK's Promise never resolves or rejects, leaving the UI stuck at "Uploading recording..." forever.
- **Upload rewrite**: Replaced `db.storage.from('documents').upload()` with a direct `XMLHttpRequest` to the Supabase storage REST API. This gives us:
  - **Real upload progress** — the progress bar reflects actual bytes uploaded (15%–50% range during file transfer) instead of fake incremental steps
  - **60-second timeout** — if the upload hangs, the user sees a clear error message instead of waiting forever
  - **Proper error handling** — network errors, HTTP errors, and aborts all surface user-friendly messages and fall into the existing catch block that shows the error UI

## Testing
- [ ] Upload a PDF or image document — should work exactly as before
- [ ] Upload an audio file (.m4a, .mp3, .wav) — should now complete with real progress
- [ ] Disconnect network mid-upload — should show "network error" message within seconds
- [ ] Verify CSP header includes `storage.supabase.co` via browser DevTools (Network → Response Headers)
- [ ] Verify no console.log of PHI/user data

🤖 Generated with [Claude Code](https://claude.com/claude-code)