### PR TITLE
Feature: C-CDA XML parser — structured health record import Phase 2 (#27)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3263,6 +3263,9 @@ var currentPersonId = null; // selected person uuid
 var liveEvents = [];      // health_events fetched from DB
 var liveMeds = [];        // medications fetched from DB
 var liveDocs = [];        // documents fetched from DB
+var liveLabs = [];        // lab_results fetched from DB
+var liveVitals = [];      // vitals fetched from DB
+var liveAllergies = [];   // allergies fetched from DB
 var liveCareCircle = [];  // care_circle_members fetched from DB
 var summaryCache = {};    // { personId: summaryText } to avoid re-fetching
 var _cardToRemove = null;
@@ -3700,6 +3703,30 @@ async function loadPersonData(personId) {
     .order('uploaded_at', { ascending: false });
   liveDocs = docs || [];
 
+  // Load lab results
+  const { data: labs } = await db
+    .from('lab_results')
+    .select('*')
+    .eq('person_id', personId)
+    .order('effective_date', { ascending: false });
+  liveLabs = labs || [];
+
+  // Load vitals
+  const { data: vitals } = await db
+    .from('vitals')
+    .select('*')
+    .eq('person_id', personId)
+    .order('effective_date', { ascending: false });
+  liveVitals = vitals || [];
+
+  // Load allergies
+  const { data: allergies } = await db
+    .from('allergies')
+    .select('*')
+    .eq('person_id', personId)
+    .order('created_at', { ascending: false });
+  liveAllergies = allergies || [];
+
   // Load care circle members
   const { data: circle } = await db
     .from('care_circle_members')
@@ -4125,16 +4152,29 @@ function renderRecordsView() {
     html += '</div>';
   }
 
-  // EHR Allergies section
-  if (ehrAllergies.length > 0) {
+  // Allergies section (DB records + EHR cache)
+  var totalAllergies = liveAllergies.length + ehrAllergies.length;
+  if (totalAllergies > 0) {
     html += '<div class="record-group"><div class="record-group-header">'
-      + '<div class="record-group-title"><i data-lucide="alert-triangle" style="width:14px;height:14px;color:var(--red);"></i>Allergies ' + ehrBadgeHtml() + '</div>'
-      + '<span class="record-group-count">' + ehrAllergies.length + ' from EHR</span></div>';
+      + '<div class="record-group-title"><i data-lucide="alert-triangle" style="width:14px;height:14px;color:var(--red);"></i>Allergies</div>'
+      + '<span class="record-group-count">' + totalAllergies + ' tracked</span></div>';
+    liveAllergies.forEach(function(a) {
+      var srcBadge = a.source === 'ehr' ? ' ' + ehrBadgeHtml() : '';
+      html += '<div class="record-row">'
+        + '<div class="record-icon" style="background:#FEF0EE;color:var(--red);"><i data-lucide="alert-triangle" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(a.substance) + srcBadge + '</div>'
+        + '<div class="record-meta">' + (a.reaction ? escHtml(a.reaction) : '') + (a.severity ? ' \u00B7 ' + escHtml(a.severity) : '') + '</div></div>'
+        + (a.clinical_status === 'active' ? '<span class="record-badge amber">Active</span>' : '')
+        + '</div>';
+    });
     ehrAllergies.forEach(function(a) {
+      // Skip EHR cache entries that already exist in DB (by substance name)
+      var alreadyInDb = liveAllergies.some(function(dbA) { return dbA.substance && a.name && dbA.substance.toLowerCase() === a.name.toLowerCase(); });
+      if (alreadyInDb) return;
       var reactionStr = a.reactions && a.reactions.length > 0 ? a.reactions.join(', ') : '';
       html += '<div class="record-row">'
         + '<div class="record-icon" style="background:#FEF0EE;color:var(--red);"><i data-lucide="alert-triangle" style="width:15px;height:15px;"></i></div>'
-        + '<div style="flex:1;"><div class="record-label">' + escHtml(a.name) + '</div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(a.name) + ' ' + ehrBadgeHtml() + '</div>'
         + '<div class="record-meta">' + (reactionStr ? escHtml(reactionStr) : '') + (a.severity ? ' \u00B7 ' + escHtml(a.severity) : '') + '</div></div>'
         + ehrProviderBadgeHtml(ehrProvider)
         + '</div>';
@@ -4168,12 +4208,28 @@ function renderRecordsView() {
     html += '</div>';
   }
 
-  // Lab results (manual + EHR)
-  var totalLabs = labEvents.length + ehrObs.length;
+  // Lab results (DB records + manual events + EHR cache)
+  var totalLabs = liveLabs.length + labEvents.length + ehrObs.length;
   if (totalLabs > 0) {
     html += '<div class="record-group"><div class="record-group-header">'
       + '<div class="record-group-title"><i data-lucide="flask-conical" style="width:14px;height:14px;color:var(--blue);"></i>Lab results</div>'
-      + '<span class="record-group-count">' + totalLabs + ' logged</span></div>';
+      + '<span class="record-group-count">' + totalLabs + ' results</span></div>';
+    liveLabs.slice(0, 10).forEach(function(lab) {
+      var valStr = lab.value ? escHtml(lab.value) + (lab.unit ? ' ' + escHtml(lab.unit) : '') : '';
+      var statusBadge = '';
+      if (lab.status === 'abnormal') statusBadge = '<span class="record-badge amber">Abnormal</span>';
+      else if (lab.status === 'critical') statusBadge = '<span class="record-badge" style="background:#FEF0EE;color:var(--red);">Critical</span>';
+      else if (lab.status === 'normal') statusBadge = '<span class="record-badge moss">Normal</span>';
+      var srcBadge = lab.source === 'ehr' ? ' ' + ehrBadgeHtml() : '';
+      html += '<div class="record-row"><div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(lab.test_name) + srcBadge + '</div>'
+        + '<div class="record-meta">' + formatEventDate(lab.effective_date)
+        + (valStr ? ' \u00B7 ' + valStr : '')
+        + (lab.reference_range ? ' (ref: ' + escHtml(lab.reference_range) + ')' : '')
+        + '</div></div>'
+        + statusBadge
+        + '</div>';
+    });
     labEvents.slice(0,3).forEach(function(ev) {
       html += '<div class="record-row" onclick="openEditEvent(\'' + ev.id + '\')"><div class="record-icon blue"><i data-lucide="flask-conical" style="width:15px;height:15px;"></i></div>'
         + '<div style="flex:1;"><div class="record-label">' + escHtml(ev.title) + '</div>'
@@ -4186,6 +4242,41 @@ function renderRecordsView() {
         + '<div style="flex:1;"><div class="record-label">' + escHtml(obs.name) + ' ' + ehrBadgeHtml() + '</div>'
         + '<div class="record-meta">' + formatEventDate(obs.effective_date) + (valStr ? ' \u00B7 ' + escHtml(valStr) : '') + '</div></div>'
         + (obs.reference_range ? '<span class="record-badge moss" title="Ref: ' + escHtml(obs.reference_range) + '">Normal</span>' : ehrProviderBadgeHtml(ehrProvider))
+        + '</div>';
+    });
+    if (liveLabs.length > 10) {
+      html += '<div style="text-align:center;padding:8px;color:var(--text-secondary);font-size:12px;">'
+        + '+ ' + (liveLabs.length - 10) + ' more results</div>';
+    }
+    html += '</div>';
+  }
+
+  // Vitals section (DB records)
+  if (liveVitals.length > 0) {
+    // Show most recent reading for each vital type
+    var vitalsByType = {};
+    liveVitals.forEach(function(v) {
+      var vt = v.vital_type;
+      if (!vitalsByType[vt]) vitalsByType[vt] = [];
+      vitalsByType[vt].push(v);
+    });
+    var vitalTypes = Object.keys(vitalsByType);
+    html += '<div class="record-group"><div class="record-group-header">'
+      + '<div class="record-group-title"><i data-lucide="activity" style="width:14px;height:14px;color:var(--moss);"></i>Vitals</div>'
+      + '<span class="record-group-count">' + liveVitals.length + ' readings</span></div>';
+    vitalTypes.forEach(function(vt) {
+      var readings = vitalsByType[vt];
+      var latest = readings[0]; // Already sorted by effective_date desc
+      var valStr = escHtml(latest.value) + (latest.unit ? ' ' + escHtml(latest.unit) : '');
+      var trendHtml = '';
+      if (readings.length > 1) {
+        trendHtml = ' <span style="color:var(--text-muted);font-size:11px;">(' + readings.length + ' readings)</span>';
+      }
+      html += '<div class="record-row">'
+        + '<div class="record-icon moss"><i data-lucide="activity" style="width:15px;height:15px;"></i></div>'
+        + '<div style="flex:1;"><div class="record-label">' + escHtml(vt) + trendHtml + '</div>'
+        + '<div class="record-meta">' + escHtml(valStr) + ' \u00B7 ' + formatEventDate(latest.effective_date) + '</div></div>'
+        + (latest.source === 'ehr' ? ehrBadgeHtml() : '')
         + '</div>';
     });
     html += '</div>';
@@ -5146,27 +5237,62 @@ function showHealthImportSummary(summary) {
 
   document.getElementById('hi-summary-title').textContent = escHtml(name) + '\'s records are in Wellet';
 
-  var details = [];
+  var lines = [];
   if (summary) {
     if (summary.pdf_stored > 0) {
-      details.push('Found ' + summary.pdf_stored + ' PDF' + (summary.pdf_stored !== 1 ? 's' : ''));
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + escHtml(summary.pdf_stored + ' PDF' + (summary.pdf_stored !== 1 ? 's' : '') + ' stored') + '</span></div>');
     }
-    if (summary.xml_count > 0) {
-      details.push(summary.xml_count + ' structured data file' + (summary.xml_count !== 1 ? 's' : '') + ' (will be parsed in a future update)');
+    if (summary.medications_found > 0) {
+      var medDetail = escHtml(summary.medications_found + ' medication' + (summary.medications_found !== 1 ? 's' : '') + ' extracted');
+      if (summary.medications_new > 0 && summary.medications_new < summary.medications_found) {
+        medDetail += ' (' + escHtml(String(summary.medications_new)) + ' new, ' + escHtml(String(summary.medications_found - summary.medications_new)) + ' already in Wellet)';
+      }
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + medDetail + '</span></div>');
+    }
+    if (summary.allergies_found > 0) {
+      var allergyDetail = escHtml(summary.allergies_found + ' allerg' + (summary.allergies_found !== 1 ? 'ies' : 'y') + ' found');
+      if (summary.allergies_new > 0 && summary.allergies_new < summary.allergies_found) {
+        allergyDetail += ' (' + escHtml(String(summary.allergies_new)) + ' new)';
+      }
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + allergyDetail + '</span></div>');
+    }
+    if (summary.lab_results_found > 0) {
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + escHtml(String(summary.lab_results_found)) + ' lab result' + (summary.lab_results_found !== 1 ? 's' : '') + ' imported</span></div>');
+    }
+    if (summary.vitals_found > 0) {
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + escHtml(String(summary.vitals_found)) + ' vital sign reading' + (summary.vitals_found !== 1 ? 's' : '') + '</span></div>');
+    }
+    if (summary.conditions_found > 0) {
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="check-circle" style="width:16px;height:16px;color:var(--moss);flex-shrink:0;"></i>'
+        + '<span>' + escHtml(String(summary.conditions_found)) + ' condition' + (summary.conditions_found !== 1 ? 's' : '') + ' added to timeline</span></div>');
     }
     if (summary.source_system && summary.source_system !== 'unknown') {
       var sourceNames = { mychart: 'Epic MyChart', cerner: 'Cerner', generic: 'health record' };
-      details.push('Detected source: ' + (sourceNames[summary.source_system] || summary.source_system));
+      lines.push('<div style="display:flex;align-items:center;gap:8px;padding:4px 0;">'
+        + '<i data-lucide="hospital" style="width:16px;height:16px;color:var(--text-muted);flex-shrink:0;"></i>'
+        + '<span>Source: ' + escHtml(sourceNames[summary.source_system] || summary.source_system) + '</span></div>');
     }
   }
 
-  if (details.length === 0) {
-    details.push('Your file has been stored securely.');
+  if (lines.length === 0) {
+    lines.push('<div style="padding:4px 0;">' + escHtml('Your file has been stored securely.') + '</div>');
   }
 
-  details.push('Your documents are saved and Ask Wellet can answer questions about them.');
+  lines.push('<div style="padding:6px 0 0;color:var(--text-secondary);font-size:13px;">'
+    + escHtml('Your documents are saved and Ask Wellet can answer questions about them.') + '</div>');
 
-  document.getElementById('hi-summary-detail').innerHTML = details.map(function(d){ return escHtml(d); }).join('<br>');
+  document.getElementById('hi-summary-detail').innerHTML = lines.join('');
 
   var doneBtn = document.getElementById('hi-done-btn');
   doneBtn.onclick = function() {

--- a/supabase/functions/process-health-export/ccda-parser.ts
+++ b/supabase/functions/process-health-export/ccda-parser.ts
@@ -1,0 +1,605 @@
+/**
+ * C-CDA XML Parser — extracts structured clinical data from CDA documents.
+ *
+ * Parses these C-CDA sections by LOINC code:
+ *   - Medications   (10160-0)
+ *   - Allergies      (48765-2)
+ *   - Lab Results    (30954-2)
+ *   - Vitals         (8716-3)
+ *   - Conditions     (11450-4)
+ *
+ * Uses Deno's built-in DOMParser — no external CDA libraries.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ParsedMedication {
+  name: string;
+  dose: string | null;
+  frequency: string | null;
+  active: boolean;
+  source: "ehr";
+  ehr_system: string;
+}
+
+export interface ParsedAllergy {
+  substance: string;
+  reaction: string | null;
+  severity: string | null;
+  clinical_status: string;
+  source: "ehr";
+  source_system: string;
+}
+
+export interface ParsedLabResult {
+  test_name: string;
+  value: string | null;
+  unit: string | null;
+  reference_range: string | null;
+  status: "normal" | "abnormal" | "critical" | "unknown";
+  effective_date: string | null;
+  loinc_code: string | null;
+  category: "laboratory";
+  source: "ehr";
+}
+
+export interface ParsedVital {
+  vital_type: string;
+  value: string;
+  unit: string | null;
+  effective_date: string | null;
+  loinc_code: string | null;
+  source: "ehr";
+}
+
+export interface ParsedCondition {
+  event_type: "condition";
+  title: string;
+  event_date: string | null;
+  source: "ehr";
+  ehr_system: string;
+}
+
+export interface CcdaParseResult {
+  medications: ParsedMedication[];
+  allergies: ParsedAllergy[];
+  lab_results: ParsedLabResult[];
+  vitals: ParsedVital[];
+  conditions: ParsedCondition[];
+  errors: { section: string; error: string }[];
+}
+
+// ── Section LOINC Codes ──────────────────────────────────────────────────────
+
+const SECTION_CODES = {
+  medications: "10160-0",
+  allergies: "48765-2",
+  labs: "30954-2",
+  vitals: "8716-3",
+  conditions: "11450-4",
+} as const;
+
+// ── Vital type mapping by LOINC ──────────────────────────────────────────────
+
+const VITAL_LOINC_MAP: Record<string, string> = {
+  "8480-6": "Systolic BP",
+  "8462-4": "Diastolic BP",
+  "8867-4": "Heart Rate",
+  "8310-5": "Temperature",
+  "29463-7": "Weight",
+  "8302-2": "Height",
+  "39156-5": "BMI",
+  "2708-6": "SpO2",
+  "59408-5": "SpO2",
+  "9279-1": "Respiratory Rate",
+};
+
+// ── Date Parsing ─────────────────────────────────────────────────────────────
+
+/** Parse CDA date formats: yyyyMMddHHmmss, yyyyMMdd, or ISO */
+function parseCdaDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (s.length === 0) return null;
+
+  // yyyyMMddHHmmss or yyyyMMdd
+  const m = s.match(/^(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?/);
+  if (m) {
+    const iso = `${m[1]}-${m[2]}-${m[3]}T${m[4] || "00"}:${m[5] || "00"}:${m[6] || "00"}Z`;
+    const d = new Date(iso);
+    if (!isNaN(d.getTime())) return d.toISOString();
+  }
+
+  // Already ISO or parseable
+  const d = new Date(s);
+  if (!isNaN(d.getTime())) return d.toISOString();
+
+  return null;
+}
+
+// ── Helper: get text content from element ────────────────────────────────────
+
+function getText(el: Element | null): string {
+  if (!el) return "";
+  return (el.textContent || "").trim();
+}
+
+function getAttr(el: Element | null, attr: string): string {
+  if (!el) return "";
+  return (el.getAttribute(attr) || "").trim();
+}
+
+/** Check if element has nullFlavor — means "no information" */
+function hasNullFlavor(el: Element | null): boolean {
+  if (!el) return true;
+  return !!el.getAttribute("nullFlavor");
+}
+
+/** Check negationInd — "patient does NOT have this" */
+function isNegated(el: Element): boolean {
+  return el.getAttribute("negationInd") === "true";
+}
+
+/**
+ * Get display name from a CDA element — handles Epic's originalText/reference
+ * pattern and falls back to displayName attribute.
+ */
+function getDisplayName(el: Element, doc: Document): string {
+  // Try displayName attribute first (most common)
+  const displayName = el.getAttribute("displayName");
+  if (displayName && displayName.trim()) return displayName.trim();
+
+  // Try originalText child — Epic uses this with reference pointers
+  const origText = el.querySelector("originalText");
+  if (origText) {
+    const ref = origText.querySelector("reference");
+    if (ref) {
+      const refValue = ref.getAttribute("value");
+      if (refValue && refValue.startsWith("#")) {
+        // Resolve the reference in the document
+        const target = doc.getElementById(refValue.substring(1));
+        if (target) {
+          const text = getText(target);
+          if (text) return text;
+        }
+      }
+    }
+    const text = getText(origText);
+    if (text) return text;
+  }
+
+  // Try text child
+  const textChild = el.querySelector("text");
+  if (textChild) {
+    const text = getText(textChild);
+    if (text) return text;
+  }
+
+  return "";
+}
+
+/** Find a section by its LOINC code */
+function findSection(doc: Document, loincCode: string): Element | null {
+  const sections = doc.querySelectorAll("section");
+  for (const section of sections) {
+    const code = section.querySelector(":scope > code");
+    if (code && getAttr(code, "code") === loincCode) {
+      return section;
+    }
+  }
+  return null;
+}
+
+// ── Section Parsers ──────────────────────────────────────────────────────────
+
+function parseMedications(doc: Document, sourceSystem: string): ParsedMedication[] {
+  const section = findSection(doc, SECTION_CODES.medications);
+  if (!section) return [];
+
+  const results: ParsedMedication[] = [];
+  const entries = section.querySelectorAll(":scope > entry");
+
+  for (const entry of entries) {
+    const substAdmin = entry.querySelector("substanceAdministration");
+    if (!substAdmin) continue;
+    if (isNegated(substAdmin)) continue;
+    if (hasNullFlavor(substAdmin)) continue;
+
+    // Status
+    const statusCode = substAdmin.querySelector("statusCode");
+    const statusVal = getAttr(statusCode, "code") || "active";
+
+    // Medication name — in manufacturedProduct/manufacturedMaterial/code
+    const matCode = substAdmin.querySelector(
+      "consumable manufacturedProduct manufacturedMaterial code"
+    );
+    let name = "";
+    if (matCode) {
+      name = getDisplayName(matCode, doc);
+      if (!name) name = getAttr(matCode, "displayName");
+    }
+
+    // Fallback: try the text content of manufacturedMaterial
+    if (!name) {
+      const matName = substAdmin.querySelector(
+        "consumable manufacturedProduct manufacturedMaterial name"
+      );
+      if (matName) name = getText(matName);
+    }
+
+    if (!name) continue; // Can't record without a name
+
+    // Dose
+    const doseEl = substAdmin.querySelector("doseQuantity");
+    let dose: string | null = null;
+    if (doseEl && !hasNullFlavor(doseEl)) {
+      const val = getAttr(doseEl, "value");
+      const unit = getAttr(doseEl, "unit");
+      if (val) dose = val + (unit ? " " + unit : "");
+    }
+
+    // Frequency — from effectiveTime with operator="A" (periodic)
+    let frequency: string | null = null;
+    const effTimes = substAdmin.querySelectorAll("effectiveTime");
+    for (const et of effTimes) {
+      if (getAttr(et, "operator") === "A" || et.querySelector("period")) {
+        const period = et.querySelector("period");
+        if (period) {
+          const pVal = getAttr(period, "value");
+          const pUnit = getAttr(period, "unit");
+          if (pVal && pUnit) {
+            frequency = "Every " + pVal + " " + pUnit;
+          }
+        }
+      }
+    }
+
+    results.push({
+      name,
+      dose,
+      frequency,
+      active: statusVal === "active" || statusVal === "completed",
+      source: "ehr",
+      ehr_system: sourceSystem,
+    });
+  }
+
+  return results;
+}
+
+function parseAllergies(doc: Document, sourceSystem: string): ParsedAllergy[] {
+  const section = findSection(doc, SECTION_CODES.allergies);
+  if (!section) return [];
+
+  const results: ParsedAllergy[] = [];
+  const entries = section.querySelectorAll(":scope > entry");
+
+  for (const entry of entries) {
+    const act = entry.querySelector("act");
+    if (!act) continue;
+    if (isNegated(act)) continue;
+
+    const obs = act.querySelector("entryRelationship observation");
+    if (!obs) continue;
+    if (isNegated(obs)) continue;
+    if (hasNullFlavor(obs)) continue;
+
+    // Substance — from participant/participantRole/playingEntity/code
+    // or from observation/value
+    let substance = "";
+    const participant = obs.querySelector(
+      "participant participantRole playingEntity code"
+    );
+    if (participant) {
+      substance = getDisplayName(participant, doc);
+    }
+    if (!substance) {
+      const obsValue = obs.querySelector("value");
+      if (obsValue) {
+        substance = getDisplayName(obsValue, doc);
+      }
+    }
+    if (!substance) continue;
+
+    // Reaction
+    let reaction: string | null = null;
+    const reactionObs = obs.querySelector(
+      "entryRelationship observation value"
+    );
+    if (reactionObs) {
+      reaction = getDisplayName(reactionObs, doc) || null;
+    }
+
+    // Severity
+    let severity: string | null = null;
+    const severityObs = obs.querySelectorAll("entryRelationship observation");
+    for (const so of severityObs) {
+      const soCode = so.querySelector("code");
+      if (soCode && getAttr(soCode, "code") === "SEV") {
+        const sevVal = so.querySelector("value");
+        if (sevVal) {
+          const sevDisplay = getAttr(sevVal, "displayName")?.toLowerCase();
+          if (sevDisplay && ["mild", "moderate", "severe"].includes(sevDisplay)) {
+            severity = sevDisplay;
+          }
+        }
+      }
+    }
+
+    // Clinical status
+    const statusCode = act.querySelector("statusCode");
+    const clinicalStatus = getAttr(statusCode, "code") || "active";
+
+    results.push({
+      substance,
+      reaction,
+      severity,
+      clinical_status: clinicalStatus,
+      source: "ehr",
+      source_system: sourceSystem,
+    });
+  }
+
+  return results;
+}
+
+function parseLabResults(doc: Document): ParsedLabResult[] {
+  const section = findSection(doc, SECTION_CODES.labs);
+  if (!section) return [];
+
+  const results: ParsedLabResult[] = [];
+  const entries = section.querySelectorAll(":scope > entry");
+
+  for (const entry of entries) {
+    // Lab panels are organizers containing component observations
+    const organizer = entry.querySelector("organizer");
+    const observations = organizer
+      ? organizer.querySelectorAll("component observation")
+      : entry.querySelectorAll("observation");
+
+    for (const obs of observations) {
+      if (isNegated(obs)) continue;
+      if (hasNullFlavor(obs)) continue;
+
+      const code = obs.querySelector(":scope > code");
+      if (!code) continue;
+
+      const testName = getDisplayName(code, doc) || getAttr(code, "displayName");
+      if (!testName) continue;
+
+      const loincCode = getAttr(code, "code") || null;
+
+      // Value
+      const valueEl = obs.querySelector(":scope > value");
+      let value: string | null = null;
+      let unit: string | null = null;
+      if (valueEl && !hasNullFlavor(valueEl)) {
+        value = getAttr(valueEl, "value") || getText(valueEl) || null;
+        unit = getAttr(valueEl, "unit") || null;
+      }
+
+      // Reference range
+      let referenceRange: string | null = null;
+      const refRange = obs.querySelector("referenceRange observationRange");
+      if (refRange) {
+        const low = refRange.querySelector("low");
+        const high = refRange.querySelector("high");
+        const lowVal = low ? getAttr(low, "value") : "";
+        const highVal = high ? getAttr(high, "value") : "";
+        const rangeUnit = low ? getAttr(low, "unit") : high ? getAttr(high, "unit") : "";
+        if (lowVal || highVal) {
+          referenceRange = (lowVal || "?") + " - " + (highVal || "?");
+          if (rangeUnit) referenceRange += " " + rangeUnit;
+        }
+        // Text-based reference range
+        if (!referenceRange) {
+          const rangeText = refRange.querySelector("text, value");
+          if (rangeText) referenceRange = getText(rangeText) || null;
+        }
+      }
+
+      // Status — interpretationCode
+      let status: ParsedLabResult["status"] = "unknown";
+      const interp = obs.querySelector("interpretationCode");
+      if (interp) {
+        const interpCode = getAttr(interp, "code")?.toUpperCase();
+        if (interpCode === "N" || interpCode === "NRM") status = "normal";
+        else if (interpCode === "A" || interpCode === "H" || interpCode === "L" || interpCode === "AB") status = "abnormal";
+        else if (interpCode === "HH" || interpCode === "LL" || interpCode === "AA") status = "critical";
+      }
+
+      // Effective date
+      const effTime = obs.querySelector(":scope > effectiveTime");
+      const effectiveDate = parseCdaDate(getAttr(effTime, "value"));
+
+      results.push({
+        test_name: testName,
+        value,
+        unit,
+        reference_range: referenceRange,
+        status,
+        effective_date: effectiveDate,
+        loinc_code: loincCode,
+        category: "laboratory",
+        source: "ehr",
+      });
+    }
+  }
+
+  return results;
+}
+
+function parseVitals(doc: Document): ParsedVital[] {
+  const section = findSection(doc, SECTION_CODES.vitals);
+  if (!section) return [];
+
+  const results: ParsedVital[] = [];
+  const entries = section.querySelectorAll(":scope > entry");
+
+  for (const entry of entries) {
+    const organizer = entry.querySelector("organizer");
+    const observations = organizer
+      ? organizer.querySelectorAll("component observation")
+      : entry.querySelectorAll("observation");
+
+    // Date from the organizer's effectiveTime
+    const orgEffTime = organizer
+      ? organizer.querySelector(":scope > effectiveTime")
+      : null;
+    const orgDate = parseCdaDate(getAttr(orgEffTime, "value"));
+
+    for (const obs of observations) {
+      if (isNegated(obs)) continue;
+      if (hasNullFlavor(obs)) continue;
+
+      const code = obs.querySelector(":scope > code");
+      if (!code) continue;
+
+      const loincCode = getAttr(code, "code") || null;
+      let vitalType = VITAL_LOINC_MAP[loincCode || ""] ||
+        getDisplayName(code, doc) ||
+        getAttr(code, "displayName") ||
+        "";
+      if (!vitalType) continue;
+
+      const valueEl = obs.querySelector(":scope > value");
+      if (!valueEl || hasNullFlavor(valueEl)) continue;
+
+      const value = getAttr(valueEl, "value");
+      if (!value) continue;
+
+      const unit = getAttr(valueEl, "unit") || null;
+
+      // Per-observation date or fall back to organizer date
+      const obsEffTime = obs.querySelector(":scope > effectiveTime");
+      const effectiveDate = parseCdaDate(getAttr(obsEffTime, "value")) || orgDate;
+
+      results.push({
+        vital_type: vitalType,
+        value,
+        unit,
+        effective_date: effectiveDate,
+        loinc_code: loincCode,
+        source: "ehr",
+      });
+    }
+  }
+
+  return results;
+}
+
+function parseConditions(doc: Document, sourceSystem: string): ParsedCondition[] {
+  const section = findSection(doc, SECTION_CODES.conditions);
+  if (!section) return [];
+
+  const results: ParsedCondition[] = [];
+  const entries = section.querySelectorAll(":scope > entry");
+
+  for (const entry of entries) {
+    const act = entry.querySelector("act");
+    const obs = act
+      ? act.querySelector("entryRelationship observation")
+      : entry.querySelector("observation");
+    if (!obs) continue;
+    if (isNegated(obs)) continue;
+    if (hasNullFlavor(obs)) continue;
+
+    // Condition name from value element
+    const valueEl = obs.querySelector(":scope > value");
+    let title = "";
+    if (valueEl) {
+      title = getDisplayName(valueEl, doc);
+    }
+    if (!title) {
+      const codeEl = obs.querySelector(":scope > code");
+      if (codeEl) title = getDisplayName(codeEl, doc);
+    }
+    if (!title) continue;
+
+    // Onset date from effectiveTime/low
+    const effTime = obs.querySelector("effectiveTime");
+    let eventDate: string | null = null;
+    if (effTime) {
+      const low = effTime.querySelector("low");
+      eventDate = parseCdaDate(getAttr(low, "value")) || parseCdaDate(getAttr(effTime, "value"));
+    }
+
+    // Skip resolved/inactive conditions where status is "completed" and there's an end date
+    // but still include them — caregivers should see full history
+
+    results.push({
+      event_type: "condition",
+      title,
+      event_date: eventDate,
+      source: "ehr",
+      ehr_system: sourceSystem,
+    });
+  }
+
+  return results;
+}
+
+// ── Main Parser ──────────────────────────────────────────────────────────────
+
+export function parseCcdaXml(xmlString: string, sourceFile: string): CcdaParseResult {
+  const result: CcdaParseResult = {
+    medications: [],
+    allergies: [],
+    lab_results: [],
+    vitals: [],
+    conditions: [],
+    errors: [],
+  };
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlString, "text/xml");
+
+  if (!doc || !doc.documentElement) {
+    result.errors.push({ section: "document", error: "Failed to parse XML" });
+    return result;
+  }
+
+  // Check for parser errors
+  const parseError = doc.querySelector("parsererror");
+  if (parseError) {
+    result.errors.push({ section: "document", error: "XML parse error: " + getText(parseError) });
+    return result;
+  }
+
+  // Detect source system from the document
+  let sourceSystem = "unknown";
+  const custodian = doc.querySelector("custodian assignedCustodian representedCustodianOrganization name");
+  if (custodian) {
+    const custName = getText(custodian).toLowerCase();
+    if (custName.includes("epic") || custName.includes("mychart")) {
+      sourceSystem = "mychart";
+    } else if (custName.includes("cerner")) {
+      sourceSystem = "cerner";
+    } else {
+      sourceSystem = getText(custodian) || "unknown";
+    }
+  }
+
+  // Parse each section — partial failures must not block others
+  const sections: [string, () => void][] = [
+    ["medications", () => { result.medications = parseMedications(doc, sourceSystem); }],
+    ["allergies", () => { result.allergies = parseAllergies(doc, sourceSystem); }],
+    ["lab_results", () => { result.lab_results = parseLabResults(doc); }],
+    ["vitals", () => { result.vitals = parseVitals(doc); }],
+    ["conditions", () => { result.conditions = parseConditions(doc, sourceSystem); }],
+  ];
+
+  for (const [sectionName, parseFn] of sections) {
+    try {
+      parseFn();
+    } catch (e) {
+      result.errors.push({
+        section: sectionName,
+        error: (e as Error).message,
+      });
+      console.error(`[ccda-parser] Error parsing ${sectionName} from ${sourceFile}:`, e);
+    }
+  }
+
+  return result;
+}

--- a/supabase/functions/process-health-export/deduplicator.ts
+++ b/supabase/functions/process-health-export/deduplicator.ts
@@ -1,0 +1,107 @@
+/**
+ * Deduplication logic for C-CDA parsed records.
+ *
+ * Queries existing records ONCE per table, then filters in-memory.
+ * Rules:
+ *   - Allergies: match by substance (case-insensitive) per person
+ *   - Labs: match by test_name + effective_date (same day) per person
+ *   - Medications: match by name (case-insensitive) per person — manual entries always win
+ *   - Vitals: insert ALL (multiple readings per day is normal)
+ *   - Conditions/health_events: match by title (case-insensitive) + event_type per person
+ */
+
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import type {
+  ParsedMedication,
+  ParsedAllergy,
+  ParsedLabResult,
+  ParsedVital,
+  ParsedCondition,
+} from "./ccda-parser.ts";
+
+export interface DeduplicatedRecords {
+  medications: ParsedMedication[];
+  allergies: ParsedAllergy[];
+  lab_results: ParsedLabResult[];
+  vitals: ParsedVital[];
+  conditions: ParsedCondition[];
+}
+
+/** Normalize string for comparison */
+function norm(s: string | null | undefined): string {
+  return (s || "").trim().toLowerCase();
+}
+
+/** Get date-only string (YYYY-MM-DD) from ISO timestamp */
+function dateOnly(isoStr: string | null | undefined): string {
+  if (!isoStr) return "";
+  return isoStr.substring(0, 10);
+}
+
+export async function deduplicateRecords(
+  db: SupabaseClient,
+  personId: string,
+  parsed: {
+    medications: ParsedMedication[];
+    allergies: ParsedAllergy[];
+    lab_results: ParsedLabResult[];
+    vitals: ParsedVital[];
+    conditions: ParsedCondition[];
+  },
+): Promise<DeduplicatedRecords> {
+  // Query all existing records for this person in parallel
+  const [allergyRes, labRes, medRes, conditionRes] = await Promise.all([
+    db.from("allergies").select("substance").eq("person_id", personId),
+    db.from("lab_results").select("test_name, effective_date").eq("person_id", personId),
+    db.from("medications").select("name, source").eq("person_id", personId),
+    db.from("health_events").select("title, event_type").eq("person_id", personId).eq("event_type", "condition"),
+  ]);
+
+  // ── Allergies: dedupe by substance (case-insensitive) ──
+  const existingSubstances = new Set(
+    (allergyRes.data || []).map((a: { substance: string }) => norm(a.substance)),
+  );
+  const newAllergies = parsed.allergies.filter(
+    (a) => !existingSubstances.has(norm(a.substance)),
+  );
+
+  // ── Labs: dedupe by test_name + effective_date (same day) ──
+  const existingLabKeys = new Set(
+    (labRes.data || []).map(
+      (l: { test_name: string; effective_date: string }) =>
+        norm(l.test_name) + "|" + dateOnly(l.effective_date),
+    ),
+  );
+  const newLabs = parsed.lab_results.filter(
+    (l) => !existingLabKeys.has(norm(l.test_name) + "|" + dateOnly(l.effective_date)),
+  );
+
+  // ── Medications: dedupe by name — manual entries always win ──
+  const existingMeds = (medRes.data || []) as { name: string; source: string }[];
+  const existingMedNames = new Set(existingMeds.map((m) => norm(m.name)));
+  // Only add EHR meds that aren't already tracked (manual or EHR)
+  const newMeds = parsed.medications.filter(
+    (m) => !existingMedNames.has(norm(m.name)),
+  );
+
+  // ── Vitals: insert ALL — multiple readings per day is normal ──
+  const newVitals = parsed.vitals;
+
+  // ── Conditions: dedupe by title + event_type ──
+  const existingCondKeys = new Set(
+    (conditionRes.data || []).map(
+      (c: { title: string; event_type: string }) => norm(c.title) + "|" + norm(c.event_type),
+    ),
+  );
+  const newConditions = parsed.conditions.filter(
+    (c) => !existingCondKeys.has(norm(c.title) + "|" + norm(c.event_type)),
+  );
+
+  return {
+    medications: newMeds,
+    allergies: newAllergies,
+    lab_results: newLabs,
+    vitals: newVitals,
+    conditions: newConditions,
+  };
+}

--- a/supabase/functions/process-health-export/index.ts
+++ b/supabase/functions/process-health-export/index.ts
@@ -1,6 +1,8 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
 import JSZip from "https://esm.sh/jszip@3.10.1";
+import { parseCcdaXml } from "./ccda-parser.ts";
+import { deduplicateRecords } from "./deduplicator.ts";
 
 Deno.serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
@@ -173,16 +175,154 @@ Deno.serve(async (req) => {
       }
     }
 
+    // ── Phase 2: Parse C-CDA XML files ─────────────────────────────────────
+    const parsedData = {
+      medications: [] as ReturnType<typeof parseCcdaXml>["medications"],
+      allergies: [] as ReturnType<typeof parseCcdaXml>["allergies"],
+      lab_results: [] as ReturnType<typeof parseCcdaXml>["lab_results"],
+      vitals: [] as ReturnType<typeof parseCcdaXml>["vitals"],
+      conditions: [] as ReturnType<typeof parseCcdaXml>["conditions"],
+    };
+    const xmlParseErrors: { file: string; error: string }[] = [];
+    let xmlParsed = 0;
+
+    for (const xmlPath of xmlFiles) {
+      try {
+        const xmlContent = await zip.file(xmlPath)!.async("text");
+        // Skip non-CDA XMLs (manifest files, metadata, etc.)
+        if (!xmlContent.includes("ClinicalDocument")) continue;
+
+        const extracted = parseCcdaXml(xmlContent, xmlPath);
+        parsedData.medications.push(...extracted.medications);
+        parsedData.allergies.push(...extracted.allergies);
+        parsedData.lab_results.push(...extracted.lab_results);
+        parsedData.vitals.push(...extracted.vitals);
+        parsedData.conditions.push(...extracted.conditions);
+
+        // Collect section-level parse errors but don't fail the job
+        for (const err of extracted.errors) {
+          xmlParseErrors.push({ file: xmlPath + " [" + err.section + "]", error: err.error });
+        }
+        xmlParsed++;
+      } catch (e) {
+        xmlParseErrors.push({ file: xmlPath, error: (e as Error).message });
+      }
+    }
+
+    // Deduplicate against existing records
+    const deduped = await deduplicateRecords(db, personId, parsedData);
+
+    // Batch insert — each table independently, partial failures logged
+    const insertErrors: { table: string; error: string }[] = [];
+
+    if (deduped.allergies.length > 0) {
+      const rows = deduped.allergies.map((a) => ({
+        person_id: personId,
+        substance: a.substance,
+        reaction: a.reaction,
+        severity: a.severity,
+        clinical_status: a.clinical_status,
+        source: a.source,
+        source_system: a.source_system,
+        export_job_id: job_id,
+      }));
+      const { error: err } = await db.from("allergies").insert(rows);
+      if (err) insertErrors.push({ table: "allergies", error: err.message });
+    }
+
+    if (deduped.lab_results.length > 0) {
+      const rows = deduped.lab_results.map((l) => ({
+        person_id: personId,
+        test_name: l.test_name,
+        value: l.value,
+        unit: l.unit,
+        reference_range: l.reference_range,
+        status: l.status,
+        effective_date: l.effective_date,
+        loinc_code: l.loinc_code,
+        category: l.category,
+        source: l.source,
+        export_job_id: job_id,
+      }));
+      const { error: err } = await db.from("lab_results").insert(rows);
+      if (err) insertErrors.push({ table: "lab_results", error: err.message });
+    }
+
+    if (deduped.vitals.length > 0) {
+      const rows = deduped.vitals.map((v) => ({
+        person_id: personId,
+        vital_type: v.vital_type,
+        value: v.value,
+        unit: v.unit,
+        effective_date: v.effective_date,
+        loinc_code: v.loinc_code,
+        source: v.source,
+        export_job_id: job_id,
+      }));
+      const { error: err } = await db.from("vitals").insert(rows);
+      if (err) insertErrors.push({ table: "vitals", error: err.message });
+    }
+
+    if (deduped.medications.length > 0) {
+      const rows = deduped.medications.map((m) => ({
+        person_id: personId,
+        name: m.name,
+        dose: m.dose,
+        frequency: m.frequency,
+        active: m.active,
+        source: m.source,
+        ehr_system: m.ehr_system,
+        export_job_id: job_id,
+      }));
+      const { error: err } = await db.from("medications").insert(rows);
+      if (err) insertErrors.push({ table: "medications", error: err.message });
+    }
+
+    if (deduped.conditions.length > 0) {
+      const rows = deduped.conditions.map((c) => ({
+        person_id: personId,
+        event_type: c.event_type,
+        title: c.title,
+        event_date: c.event_date || new Date().toISOString(),
+        source: c.source,
+        ehr_system: c.ehr_system,
+        export_job_id: job_id,
+      }));
+      const { error: err } = await db.from("health_events").insert(rows);
+      if (err) insertErrors.push({ table: "health_events", error: err.message });
+    }
+
     // Build summary
-    const summary = {
+    const summary: Record<string, unknown> = {
       pdf_count: pdfFiles.length,
       pdf_stored: uploadedDocs,
       xml_count: xmlFiles.length,
-      has_structured_data: hasIheXdm || xmlFiles.length > 0,
+      xml_parsed: xmlParsed,
+      has_structured_data: xmlParsed > 0,
       source_system: sourceSystem,
+      medications_found: parsedData.medications.length,
+      medications_new: deduped.medications.length,
+      allergies_found: parsedData.allergies.length,
+      allergies_new: deduped.allergies.length,
+      lab_results_found: parsedData.lab_results.length,
+      lab_results_new: deduped.lab_results.length,
+      vitals_found: parsedData.vitals.length,
+      vitals_new: deduped.vitals.length,
+      conditions_found: parsedData.conditions.length,
+      conditions_new: deduped.conditions.length,
     };
 
-    const finalStatus = uploadErrors.length > 0 && uploadedDocs === 0 ? "failed" : "completed";
+    const allErrors = [
+      ...uploadErrors.map((e) => ({ ...e, phase: "pdf" })),
+      ...xmlParseErrors.map((e) => ({ ...e, phase: "xml_parse" })),
+      ...insertErrors.map((e) => ({ ...e, phase: "xml_insert" })),
+    ];
+    const finalStatus =
+      allErrors.length > 0 && uploadedDocs === 0 && xmlParsed === 0
+        ? "failed"
+        : allErrors.length > 0
+          ? "completed"
+          : "completed";
 
     // Update job with summary
     await db
@@ -191,7 +331,7 @@ Deno.serve(async (req) => {
         status: finalStatus,
         source_system: sourceSystem,
         summary: summary,
-        errors: uploadErrors.length > 0 ? uploadErrors : [],
+        errors: allErrors.length > 0 ? allErrors : [],
         completed_at: new Date().toISOString(),
       })
       .eq("id", job_id);
@@ -199,7 +339,7 @@ Deno.serve(async (req) => {
     return json({
       success: true,
       summary: summary,
-      errors: uploadErrors,
+      errors: allErrors,
     });
   } catch (e) {
     console.error("process-health-export error:", e);

--- a/supabase/migrations/20260416000003_ccda_parser_phase2.sql
+++ b/supabase/migrations/20260416000003_ccda_parser_phase2.sql
@@ -1,0 +1,19 @@
+-- Phase 2: C-CDA XML parser support
+-- Add export_job_id to medications if missing (other tables already have it)
+ALTER TABLE public.medications ADD COLUMN IF NOT EXISTS export_job_id uuid;
+
+-- Add indexes for deduplication queries (fast lookups by person + key fields)
+CREATE INDEX IF NOT EXISTS idx_allergies_person_substance
+  ON public.allergies (person_id, lower(substance));
+
+CREATE INDEX IF NOT EXISTS idx_lab_results_person_test_date
+  ON public.lab_results (person_id, lower(test_name), effective_date);
+
+CREATE INDEX IF NOT EXISTS idx_medications_person_name
+  ON public.medications (person_id, lower(name));
+
+CREATE INDEX IF NOT EXISTS idx_vitals_person_type
+  ON public.vitals (person_id, vital_type);
+
+CREATE INDEX IF NOT EXISTS idx_health_events_person_title_type
+  ON public.health_events (person_id, lower(title), event_type);


### PR DESCRIPTION
## Summary

Closes #27

Adds Phase 2 of the health export pipeline: C-CDA XML parsing from MyChart/EHR export ZIPs with structured clinical data insertion into Supabase tables.

### What's new

- **`ccda-parser.ts`** — DOM-based C-CDA XML parser using Deno's built-in DOMParser (no heavy dependencies). Parses 5 section types by LOINC code:
  - Medications (10160-0)
  - Allergies (48765-2)
  - Lab Results (30954-2)
  - Vitals (8716-3)
  - Problems/Conditions (11450-4)
  - Handles Epic quirks: `originalText/reference` pointers, `nullFlavor` entries, `negationInd`, CDA date formats

- **`deduplicator.ts`** — Pre-insert deduplication against existing records:
  - Allergies: by substance (case-insensitive)
  - Labs: by test_name + effective_date (same day)
  - Medications: by name (manual entries always win)
  - Vitals: insert all (multiple readings/day is normal)
  - Conditions: by title + event_type

- **Edge function (`index.ts`)** — XML parsing runs after existing PDF extraction (PDF handling unchanged). Each table insert is independent — partial failures in one section don't block others. Summary now includes extraction counts.

- **Client UI (`index.html`)**:
  - Summary screen shows actual extraction counts with check icons instead of "will be parsed in a future update"
  - Records view now loads and displays Labs, Vitals, and Allergies from DB tables
  - Lab results show test name, value, unit, reference range, and status badges (Normal/Abnormal/Critical)
  - Vitals grouped by type with most recent reading and trend count
  - Allergies combined from DB records + EHR cache with source badges

- **Migration** — Adds `export_job_id` column to medications table, plus deduplication indexes on allergies, lab_results, medications, vitals, and health_events

### Safety constraints
- NO dosing error detection — we help coordinate care, not find medical errors
- All inserts include `person_id` and `export_job_id` for traceability
- `escHtml()` used for all user-generated content
- `var` declarations used throughout index.html
- `initIcons()` called after dynamic HTML insertion

## Test plan

- [ ] Upload a MyChart ZIP export containing C-CDA XML files — verify medications, allergies, labs, vitals, and conditions are extracted and shown in Records
- [ ] Upload a ZIP with only PDFs — verify existing PDF-only flow still works unchanged
- [ ] Upload same ZIP twice — verify deduplication prevents duplicate records
- [ ] Upload a ZIP with malformed XML — verify partial failure handling (good sections still import)
- [ ] Verify summary screen shows extraction counts with check icons
- [ ] Verify Records view displays Labs section with status badges, Vitals section with readings, and Allergies section with source indicators
- [ ] Run migration and verify indexes are created and `export_job_id` column exists on medications

🤖 Generated with [Claude Code](https://claude.com/claude-code)