### PR TITLE
Fix: Client-side ZIP extraction to bypass 50MB upload limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="/lucide.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.2/jspdf.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 <style>
   :root {
     --moss: #608F7C;
@@ -5144,6 +5145,24 @@ function cancelHealthImport() {
   showToast('Import cancelled');
 }
 
+async function uploadBlobToStorage(blob, storagePath, token, contentType) {
+  var response = await fetch(SUPABASE_URL + '/storage/v1/object/documents/' + storagePath, {
+    method: 'POST',
+    headers: {
+      'Authorization': 'Bearer ' + token,
+      'apikey': SUPABASE_ANON_KEY,
+      'x-upsert': 'true',
+      'Content-Type': contentType || 'application/octet-stream'
+    },
+    body: blob
+  });
+  if (!response.ok) {
+    var errMsg = 'Upload failed (HTTP ' + response.status + ')';
+    try { errMsg = (await response.json()).message || errMsg; } catch(_e) {}
+    throw new Error(errMsg);
+  }
+}
+
 async function startHealthImport() {
   if (!currentUser || !_hiFile) return;
   var file = _hiFile;
@@ -5153,98 +5172,52 @@ async function startHealthImport() {
   // Switch to processing step
   document.getElementById('hi-step-confirm').style.display = 'none';
   document.getElementById('hi-step-processing').style.display = 'block';
-  document.getElementById('hi-progress-bar').style.width = '5%';
-  document.getElementById('hi-progress-title').textContent = 'Uploading health records...';
-  document.getElementById('hi-progress-sub').textContent = 'Storing ' + escHtml(file.name);
+  document.getElementById('hi-progress-bar').style.width = '2%';
+  document.getElementById('hi-progress-title').textContent = 'Unpacking health records...';
+  document.getElementById('hi-progress-sub').textContent = 'Reading ' + escHtml(file.name);
 
   try {
-    // 1. Upload ZIP to Supabase Storage
-    var timestamp = Date.now();
-    var safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
-    var storagePath = userId + '/' + timestamp + '_' + safeName;
-
     var session = await db.auth.getSession();
     var uploadToken = session.data.session.access_token;
-    var uploadUrl = SUPABASE_URL + '/storage/v1/object/documents/' + storagePath;
+    var timestamp = Date.now();
 
-    await new Promise(function(resolve, reject) {
-      var xhr = new XMLHttpRequest();
-      _hiXhr = xhr;
-      var uploadTimedOut = false;
-      var lastProgressTime = Date.now();
+    // ── Phase 1 (0-20%): Unzip client-side ──────────────────────────────
+    var arrayBuffer = await file.arrayBuffer();
+    document.getElementById('hi-progress-bar').style.width = '8%';
 
-      // Stall detection: abort if no progress for 30 seconds
-      var stallCheck = setInterval(function() {
-        if (Date.now() - lastProgressTime > 30000) {
-          clearInterval(stallCheck);
-          uploadTimedOut = true;
-          xhr.abort();
-          reject(new Error('Upload stalled — no progress for 30 seconds.'));
-        }
-      }, 5000);
+    var zip;
+    try {
+      zip = await JSZip.loadAsync(arrayBuffer);
+    } catch (zipErr) {
+      throw new Error('Could not open ZIP file. Please make sure this is the export file from your health portal.');
+    }
 
-      // Hard timeout: 180 seconds for large ZIP files
-      var uploadTimeout = setTimeout(function() {
-        clearInterval(stallCheck);
-        uploadTimedOut = true;
-        xhr.abort();
-        reject(new Error('Upload timed out. Please check your connection and try again.'));
-      }, 180000);
-
-      xhr.upload.onprogress = function(e) {
-        lastProgressTime = Date.now();
-        if (e.lengthComputable) {
-          var pct = Math.round(5 + (e.loaded / e.total) * 40);
-          document.getElementById('hi-progress-bar').style.width = pct + '%';
-          var uploadedMB = (e.loaded / (1024 * 1024)).toFixed(1);
-          var totalMB = (e.total / (1024 * 1024)).toFixed(1);
-          document.getElementById('hi-progress-sub').textContent = 'Uploading ' + uploadedMB + ' / ' + totalMB + ' MB';
-        }
-      };
-
-      xhr.onload = function() {
-        clearTimeout(uploadTimeout);
-        clearInterval(stallCheck);
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve();
-        } else {
-          var errMsg = 'Storage upload failed (HTTP ' + xhr.status + ')';
-          try { errMsg = JSON.parse(xhr.responseText).message || errMsg; } catch(_e) {}
-          reject(new Error(errMsg));
-        }
-      };
-
-      xhr.onerror = function() {
-        clearTimeout(uploadTimeout);
-        clearInterval(stallCheck);
-        if (!uploadTimedOut) reject(new Error('Upload failed — network error.'));
-      };
-
-      xhr.onabort = function() {
-        clearTimeout(uploadTimeout);
-        clearInterval(stallCheck);
-        if (!uploadTimedOut) reject(new Error('Upload was cancelled.'));
-      };
-
-      xhr.open('POST', uploadUrl, true);
-      xhr.setRequestHeader('Authorization', 'Bearer ' + uploadToken);
-      xhr.setRequestHeader('apikey', SUPABASE_ANON_KEY);
-      xhr.setRequestHeader('x-upsert', 'true');
-      xhr.setRequestHeader('cache-control', '3600');
-      xhr.send(file);
+    var xmlFiles = [];
+    var pdfFiles = [];
+    zip.forEach(function(relativePath, zipEntry) {
+      if (zipEntry.dir) return;
+      var lower = relativePath.toLowerCase();
+      if (lower.endsWith('.xml')) xmlFiles.push({ path: relativePath, entry: zipEntry });
+      if (lower.endsWith('.pdf')) pdfFiles.push({ path: relativePath, entry: zipEntry });
     });
-    _hiXhr = null;
 
-    document.getElementById('hi-progress-bar').style.width = '50%';
-    document.getElementById('hi-progress-title').textContent = 'Processing health records...';
-    document.getElementById('hi-progress-sub').textContent = 'Unpacking and organizing documents';
+    var totalFiles = xmlFiles.length + pdfFiles.length;
+    if (totalFiles === 0) {
+      throw new Error('No health record files found in this ZIP. Expected XML or PDF files from a health portal export.');
+    }
+
+    document.getElementById('hi-progress-bar').style.width = '20%';
+    var compressedMB = (file.size / (1024 * 1024)).toFixed(1);
+    document.getElementById('hi-progress-title').textContent = 'Found ' + totalFiles + ' document' + (totalFiles !== 1 ? 's' : '');
+    document.getElementById('hi-progress-sub').textContent = compressedMB + ' MB compressed — uploading files individually';
+
+    // ── Phase 2 (20-70%): Upload files individually ─────────────────────
     document.getElementById('hi-cancel-btn').style.display = 'none';
 
-    // 2. Create health_export_jobs row
+    // Create the health_export_jobs row first
     var jobInsert = await db.from('health_export_jobs').insert({
       user_id: userId,
       person_id: personId,
-      file_path: storagePath,
       file_name: file.name,
       file_size_bytes: file.size,
       status: 'uploading'
@@ -5253,11 +5226,57 @@ async function startHealthImport() {
     if (jobInsert.error) {
       throw new Error('Failed to create import job: ' + jobInsert.error.message);
     }
-
     _hiJobId = jobInsert.data.id;
-    document.getElementById('hi-progress-bar').style.width = '55%';
 
-    // 3. Call Edge Function
+    var filesUploaded = 0;
+    var xmlStoragePaths = [];
+    var pdfCount = 0;
+
+    // Upload PDFs + create documents rows (no edge function needed)
+    for (var pi = 0; pi < pdfFiles.length; pi++) {
+      var pdf = pdfFiles[pi];
+      var pdfBlob = await pdf.entry.async('blob');
+      var pdfSafeName = pdf.path.split('/').pop().replace(/[^a-zA-Z0-9._-]/g, '_');
+      var pdfPath = userId + '/' + timestamp + '_' + pdfSafeName;
+
+      await uploadBlobToStorage(pdfBlob, pdfPath, uploadToken, 'application/pdf');
+
+      await db.from('documents').insert({
+        person_id: personId,
+        file_name: pdfSafeName,
+        storage_path: pdfPath,
+        document_type: 'Health record PDF',
+        extraction_status: 'stored'
+      });
+
+      pdfCount++;
+      filesUploaded++;
+      var uploadPct = Math.round(20 + (filesUploaded / totalFiles) * 50);
+      document.getElementById('hi-progress-bar').style.width = uploadPct + '%';
+      document.getElementById('hi-progress-sub').textContent = 'Uploaded ' + filesUploaded + ' of ' + totalFiles + ' files';
+    }
+
+    // Upload XMLs to storage
+    for (var xi = 0; xi < xmlFiles.length; xi++) {
+      var xml = xmlFiles[xi];
+      var xmlBlob = await xml.entry.async('blob');
+      var xmlSafeName = xml.path.split('/').pop().replace(/[^a-zA-Z0-9._-]/g, '_');
+      var xmlPath = userId + '/' + timestamp + '_' + xmlSafeName;
+
+      await uploadBlobToStorage(xmlBlob, xmlPath, uploadToken, 'text/xml');
+      xmlStoragePaths.push(xmlPath);
+
+      filesUploaded++;
+      var xmlUploadPct = Math.round(20 + (filesUploaded / totalFiles) * 50);
+      document.getElementById('hi-progress-bar').style.width = xmlUploadPct + '%';
+      document.getElementById('hi-progress-sub').textContent = 'Uploaded ' + filesUploaded + ' of ' + totalFiles + ' files';
+    }
+
+    // ── Phase 3 (70-100%): Call edge function for XML analysis ──────────
+    document.getElementById('hi-progress-bar').style.width = '70%';
+    document.getElementById('hi-progress-title').textContent = 'Analyzing health records...';
+    document.getElementById('hi-progress-sub').textContent = 'Extracting medications, allergies, and lab results';
+
     var token = (await db.auth.getSession()).data.session.access_token;
     var fnResponse = await fetch(SUPABASE_URL + '/functions/v1/process-health-export', {
       method: 'POST',
@@ -5268,12 +5287,17 @@ async function startHealthImport() {
       },
       body: JSON.stringify({
         job_id: _hiJobId,
-        storage_path: storagePath
+        xml_paths: xmlStoragePaths
       })
     });
 
     if (fnResponse.ok) {
       var result = await fnResponse.json();
+      // Merge client-side PDF count into the summary
+      if (result.summary) {
+        result.summary.pdf_stored = (result.summary.pdf_stored || 0) + pdfCount;
+        result.summary.pdf_count = (result.summary.pdf_count || 0) + pdfCount;
+      }
       document.getElementById('hi-progress-bar').style.width = '100%';
       showHealthImportSummary(result.summary);
     } else {

--- a/supabase/functions/process-health-export/index.ts
+++ b/supabase/functions/process-health-export/index.ts
@@ -42,9 +42,10 @@ Deno.serve(async (req) => {
 
     const db = createClient(supabaseUrl, supabaseServiceKey);
 
-    const { job_id, storage_path } = await req.json();
-    if (!job_id || !storage_path) {
-      return json({ error: "job_id and storage_path required" }, 400);
+    const body = await req.json();
+    const { job_id, storage_path, xml_paths } = body;
+    if (!job_id || (!storage_path && !xml_paths)) {
+      return json({ error: "job_id and either storage_path or xml_paths required" }, 400);
     }
 
     // Verify the job belongs to this user
@@ -67,140 +68,12 @@ Deno.serve(async (req) => {
       .update({ status: "processing" })
       .eq("id", job_id);
 
-    // Download the ZIP from Supabase Storage
-    const { data: fileData, error: dlError } = await db.storage
-      .from("documents")
-      .download(storage_path);
-
-    if (dlError || !fileData) {
-      await db
-        .from("health_export_jobs")
-        .update({
-          status: "failed",
-          errors: [{ message: "Failed to download file: " + (dlError?.message || "unknown") }],
-        })
-        .eq("id", job_id);
-      return json({ error: "Failed to download file" }, 500);
-    }
-
-    // Unzip and inventory contents
-    const arrayBuffer = await fileData.arrayBuffer();
-    let zip: JSZip;
-    try {
-      zip = await JSZip.loadAsync(arrayBuffer);
-    } catch (e) {
-      await db
-        .from("health_export_jobs")
-        .update({
-          status: "failed",
-          errors: [{ message: "Invalid ZIP file: " + (e as Error).message }],
-        })
-        .eq("id", job_id);
-      return json({ error: "Invalid ZIP file" }, 400);
-    }
-
-    // Inventory: count PDFs, XMLs, detect IHE_XDM and Apple Health
-    const pdfFiles: { name: string; relativePath: string }[] = [];
-    const xmlFiles: string[] = [];
-    let hasIheXdm = false;
-    let hasCcdaFolder = false;
-    let appleHealthXmlPath: string | null = null;
-
-    zip.forEach((relativePath, zipEntry) => {
-      if (zipEntry.dir) {
-        if (relativePath.toUpperCase().includes("IHE_XDM")) hasIheXdm = true;
-        if (relativePath.toUpperCase().includes("CCDA")) hasCcdaFolder = true;
-        return;
-      }
-      const lower = relativePath.toLowerCase();
-      if (lower.endsWith(".pdf")) {
-        const fileName = relativePath.split("/").pop() || relativePath;
-        pdfFiles.push({ name: fileName, relativePath });
-      }
-      if (lower.endsWith(".xml")) {
-        xmlFiles.push(relativePath);
-      }
-      // Check file paths for IHE_XDM too
-      if (lower.includes("ihe_xdm")) hasIheXdm = true;
-      // Detect Apple Health export.xml in root or apple_health_export/ folder
-      if (lower === "export.xml" || lower === "apple_health_export/export.xml") {
-        appleHealthXmlPath = relativePath;
-      }
-    });
-
-    // Detect source system
-    let sourceSystem = "unknown";
-    if (hasIheXdm) {
-      sourceSystem = "mychart";
-    } else if (hasCcdaFolder) {
-      sourceSystem = "cerner";
-    } else if (xmlFiles.length > 0) {
-      sourceSystem = "generic";
-    }
-
-    // Check if the detected XML is actually Apple Health
-    if (appleHealthXmlPath) {
-      try {
-        const ahPreview = await zip.file(appleHealthXmlPath)!.async("text");
-        const previewSlice = ahPreview.substring(0, 500);
-        if (
-          previewSlice.includes("<!DOCTYPE HealthData") ||
-          previewSlice.includes("<HealthData locale=") ||
-          previewSlice.includes("<HealthData")
-        ) {
-          sourceSystem = "apple_health";
-        } else {
-          appleHealthXmlPath = null; // Not actually Apple Health
-        }
-      } catch {
-        appleHealthXmlPath = null;
-      }
-    }
-
-    // For each PDF found: upload individually to documents bucket, create documents row
     const personId = job.person_id;
     const userId = job.user_id;
     let uploadedDocs = 0;
     const uploadErrors: { file: string; error: string }[] = [];
 
-    for (const pdf of pdfFiles) {
-      try {
-        const pdfData = await zip.file(pdf.relativePath)!.async("arraybuffer");
-        const pdfBlob = new Blob([pdfData], { type: "application/pdf" });
-
-        // Upload to storage
-        const safeName = pdf.name.replace(/[^a-zA-Z0-9._-]/g, "_");
-        const pdfStoragePath = userId + "/" + Date.now() + "_" + safeName;
-
-        const { error: uploadErr } = await db.storage
-          .from("documents")
-          .upload(pdfStoragePath, pdfBlob, { upsert: true, contentType: "application/pdf" });
-
-        if (uploadErr) {
-          uploadErrors.push({ file: pdf.name, error: uploadErr.message });
-          continue;
-        }
-
-        // Create document record
-        const { error: insertErr } = await db.from("documents").insert({
-          person_id: personId,
-          file_name: pdf.name,
-          storage_path: pdfStoragePath,
-          document_type: "Health record PDF",
-          extraction_status: "stored",
-        });
-
-        if (insertErr) {
-          uploadErrors.push({ file: pdf.name, error: insertErr.message });
-        } else {
-          uploadedDocs++;
-        }
-      } catch (e) {
-        uploadErrors.push({ file: pdf.name, error: (e as Error).message });
-      }
-    }
-
-    // ── Phase 2: Parse C-CDA XML files ─────────────────────────────────────
+    // ── Shared data structures for XML parsing ─────────────────────────────
     const parsedData = {
       medications: [] as ReturnType<typeof parseCcdaXml>["medications"],
       allergies: [] as ReturnType<typeof parseCcdaXml>["allergies"],
@@ -211,58 +84,266 @@ Deno.serve(async (req) => {
     const xmlParseErrors: { file: string; error: string }[] = [];
     let xmlParsed = 0;
 
-    // ── Apple Health XML parsing ───────────────────────────────────────────
+    // Track inventory for summary
+    let pdfFileCount = 0;
+    let xmlFileCount = 0;
+    let sourceSystem = "unknown";
     let appleHealthStats = { vitals: 0, activities: 0, sleep: 0, workouts: 0 };
-    if (sourceSystem === "apple_health" && appleHealthXmlPath) {
-      try {
-        const ahContent = await zip.file(appleHealthXmlPath)!.async("text");
-        const ahResult = parseAppleHealthXml(ahContent);
 
-        parsedData.vitals.push(...ahResult.vitals);
-        parsedData.conditions.push(...ahResult.conditions);
+    if (xml_paths && Array.isArray(xml_paths)) {
+      // ── New flow: individual XML files already uploaded by client ───────
+      // PDFs were handled client-side, so we only process XMLs here
+      xmlFileCount = xml_paths.length;
 
-        for (const err of ahResult.errors) {
-          xmlParseErrors.push({ file: appleHealthXmlPath + " [" + err.section + "]", error: err.error });
+      for (const xmlStoragePath of xml_paths) {
+        try {
+          const { data: xmlData, error: xmlDlErr } = await db.storage
+            .from("documents")
+            .download(xmlStoragePath);
+
+          if (xmlDlErr || !xmlData) {
+            xmlParseErrors.push({ file: xmlStoragePath, error: "Download failed: " + (xmlDlErr?.message || "unknown") });
+            continue;
+          }
+
+          const xmlContent = await xmlData.text();
+
+          // Detect Apple Health XML
+          const previewSlice = xmlContent.substring(0, 500);
+          if (
+            previewSlice.includes("<!DOCTYPE HealthData") ||
+            previewSlice.includes("<HealthData locale=") ||
+            previewSlice.includes("<HealthData")
+          ) {
+            sourceSystem = "apple_health";
+            const ahResult = parseAppleHealthXml(xmlContent);
+
+            parsedData.vitals.push(...ahResult.vitals);
+            parsedData.conditions.push(...ahResult.conditions);
+
+            for (const err of ahResult.errors) {
+              xmlParseErrors.push({ file: xmlStoragePath + " [" + err.section + "]", error: err.error });
+            }
+
+            appleHealthStats.vitals = ahResult.vitals.length;
+            appleHealthStats.activities = ahResult.conditions.filter(
+              (c) => (c as { event_type: string }).event_type === "activity" || (c as { event_type: string }).event_type === "activity_summary",
+            ).length;
+            appleHealthStats.sleep = ahResult.conditions.filter(
+              (c) => (c as { event_type: string }).event_type === "sleep",
+            ).length;
+            appleHealthStats.workouts = ahResult.conditions.filter(
+              (c) => (c as { event_type: string }).event_type === "workout",
+            ).length;
+            xmlParsed++;
+            continue;
+          }
+
+          // Skip non-CDA XMLs (manifest files, metadata, etc.)
+          if (!xmlContent.includes("ClinicalDocument")) continue;
+
+          // Detect source system from XML content
+          if (sourceSystem === "unknown") {
+            if (xmlContent.includes("Epic") || xmlContent.includes("MyChart")) {
+              sourceSystem = "mychart";
+            } else if (xmlContent.includes("Cerner")) {
+              sourceSystem = "cerner";
+            } else {
+              sourceSystem = "generic";
+            }
+          }
+
+          const extracted = parseCcdaXml(xmlContent, xmlStoragePath);
+          parsedData.medications.push(...extracted.medications);
+          parsedData.allergies.push(...extracted.allergies);
+          parsedData.lab_results.push(...extracted.lab_results);
+          parsedData.vitals.push(...extracted.vitals);
+          parsedData.conditions.push(...extracted.conditions);
+
+          for (const err of extracted.errors) {
+            xmlParseErrors.push({ file: xmlStoragePath + " [" + err.section + "]", error: err.error });
+          }
+          xmlParsed++;
+        } catch (e) {
+          xmlParseErrors.push({ file: xmlStoragePath, error: (e as Error).message });
         }
-
-        // Tally Apple Health stats
-        appleHealthStats.vitals = ahResult.vitals.length;
-        appleHealthStats.activities = ahResult.conditions.filter(
-          (c) => (c as { event_type: string }).event_type === "activity" || (c as { event_type: string }).event_type === "activity_summary",
-        ).length;
-        appleHealthStats.sleep = ahResult.conditions.filter(
-          (c) => (c as { event_type: string }).event_type === "sleep",
-        ).length;
-        appleHealthStats.workouts = ahResult.conditions.filter(
-          (c) => (c as { event_type: string }).event_type === "workout",
-        ).length;
-        xmlParsed++;
-      } catch (e) {
-        xmlParseErrors.push({ file: appleHealthXmlPath, error: (e as Error).message });
       }
-    }
+    } else {
+      // ── Legacy flow: download ZIP and process server-side ───────────────
+      const { data: fileData, error: dlError } = await db.storage
+        .from("documents")
+        .download(storage_path);
 
-    // ── C-CDA XML parsing ─────────────────────────────────────────────────
-    for (const xmlPath of xmlFiles) {
+      if (dlError || !fileData) {
+        await db
+          .from("health_export_jobs")
+          .update({
+            status: "failed",
+            errors: [{ message: "Failed to download file: " + (dlError?.message || "unknown") }],
+          })
+          .eq("id", job_id);
+        return json({ error: "Failed to download file" }, 500);
+      }
+
+      const arrayBuffer = await fileData.arrayBuffer();
+      let zip: JSZip;
       try {
-        const xmlContent = await zip.file(xmlPath)!.async("text");
-        // Skip non-CDA XMLs (manifest files, metadata, Apple Health export.xml)
-        if (!xmlContent.includes("ClinicalDocument")) continue;
-
-        const extracted = parseCcdaXml(xmlContent, xmlPath);
-        parsedData.medications.push(...extracted.medications);
-        parsedData.allergies.push(...extracted.allergies);
-        parsedData.lab_results.push(...extracted.lab_results);
-        parsedData.vitals.push(...extracted.vitals);
-        parsedData.conditions.push(...extracted.conditions);
-
-        // Collect section-level parse errors but don't fail the job
-        for (const err of extracted.errors) {
-          xmlParseErrors.push({ file: xmlPath + " [" + err.section + "]", error: err.error });
-        }
-        xmlParsed++;
+        zip = await JSZip.loadAsync(arrayBuffer);
       } catch (e) {
-        xmlParseErrors.push({ file: xmlPath, error: (e as Error).message });
+        await db
+          .from("health_export_jobs")
+          .update({
+            status: "failed",
+            errors: [{ message: "Invalid ZIP file: " + (e as Error).message }],
+          })
+          .eq("id", job_id);
+        return json({ error: "Invalid ZIP file" }, 400);
+      }
+
+      // Inventory: count PDFs, XMLs, detect IHE_XDM and Apple Health
+      const pdfFiles: { name: string; relativePath: string }[] = [];
+      const xmlFiles: string[] = [];
+      let hasIheXdm = false;
+      let hasCcdaFolder = false;
+      let appleHealthXmlPath: string | null = null;
+
+      zip.forEach((relativePath, zipEntry) => {
+        if (zipEntry.dir) {
+          if (relativePath.toUpperCase().includes("IHE_XDM")) hasIheXdm = true;
+          if (relativePath.toUpperCase().includes("CCDA")) hasCcdaFolder = true;
+          return;
+        }
+        const lower = relativePath.toLowerCase();
+        if (lower.endsWith(".pdf")) {
+          const fileName = relativePath.split("/").pop() || relativePath;
+          pdfFiles.push({ name: fileName, relativePath });
+        }
+        if (lower.endsWith(".xml")) {
+          xmlFiles.push(relativePath);
+        }
+        if (lower.includes("ihe_xdm")) hasIheXdm = true;
+        // Detect Apple Health export.xml in root or apple_health_export/ folder
+        if (lower === "export.xml" || lower === "apple_health_export/export.xml") {
+          appleHealthXmlPath = relativePath;
+        }
+      });
+
+      if (hasIheXdm) {
+        sourceSystem = "mychart";
+      } else if (hasCcdaFolder) {
+        sourceSystem = "cerner";
+      } else if (xmlFiles.length > 0) {
+        sourceSystem = "generic";
+      }
+
+      // Check if the detected XML is actually Apple Health
+      if (appleHealthXmlPath) {
+        try {
+          const ahPreview = await zip.file(appleHealthXmlPath)!.async("text");
+          const previewSlice = ahPreview.substring(0, 500);
+          if (
+            previewSlice.includes("<!DOCTYPE HealthData") ||
+            previewSlice.includes("<HealthData locale=") ||
+            previewSlice.includes("<HealthData")
+          ) {
+            sourceSystem = "apple_health";
+          } else {
+            appleHealthXmlPath = null; // Not actually Apple Health
+          }
+        } catch {
+          appleHealthXmlPath = null;
+        }
+      }
+
+      pdfFileCount = pdfFiles.length;
+      xmlFileCount = xmlFiles.length;
+
+      // For each PDF found: upload individually to documents bucket, create documents row
+      for (const pdf of pdfFiles) {
+        try {
+          const pdfData = await zip.file(pdf.relativePath)!.async("arraybuffer");
+          const pdfBlob = new Blob([pdfData], { type: "application/pdf" });
+
+          const safeName = pdf.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+          const pdfStoragePath = userId + "/" + Date.now() + "_" + safeName;
+
+          const { error: uploadErr } = await db.storage
+            .from("documents")
+            .upload(pdfStoragePath, pdfBlob, { upsert: true, contentType: "application/pdf" });
+
+          if (uploadErr) {
+            uploadErrors.push({ file: pdf.name, error: uploadErr.message });
+            continue;
+          }
+
+          const { error: insertErr } = await db.from("documents").insert({
+            person_id: personId,
+            file_name: pdf.name,
+            storage_path: pdfStoragePath,
+            document_type: "Health record PDF",
+            extraction_status: "stored",
+          });
+
+          if (insertErr) {
+            uploadErrors.push({ file: pdf.name, error: insertErr.message });
+          } else {
+            uploadedDocs++;
+          }
+        } catch (e) {
+          uploadErrors.push({ file: pdf.name, error: (e as Error).message });
+        }
+      }
+
+      // ── Apple Health XML parsing ───────────────────────────────────────
+      if (sourceSystem === "apple_health" && appleHealthXmlPath) {
+        try {
+          const ahContent = await zip.file(appleHealthXmlPath)!.async("text");
+          const ahResult = parseAppleHealthXml(ahContent);
+
+          parsedData.vitals.push(...ahResult.vitals);
+          parsedData.conditions.push(...ahResult.conditions);
+
+          for (const err of ahResult.errors) {
+            xmlParseErrors.push({ file: appleHealthXmlPath + " [" + err.section + "]", error: err.error });
+          }
+
+          appleHealthStats.vitals = ahResult.vitals.length;
+          appleHealthStats.activities = ahResult.conditions.filter(
+            (c) => (c as { event_type: string }).event_type === "activity" || (c as { event_type: string }).event_type === "activity_summary",
+          ).length;
+          appleHealthStats.sleep = ahResult.conditions.filter(
+            (c) => (c as { event_type: string }).event_type === "sleep",
+          ).length;
+          appleHealthStats.workouts = ahResult.conditions.filter(
+            (c) => (c as { event_type: string }).event_type === "workout",
+          ).length;
+          xmlParsed++;
+        } catch (e) {
+          xmlParseErrors.push({ file: appleHealthXmlPath, error: (e as Error).message });
+        }
+      }
+
+      // ── C-CDA XML parsing ─────────────────────────────────────────────
+      for (const xmlPath of xmlFiles) {
+        try {
+          const xmlContent = await zip.file(xmlPath)!.async("text");
+          // Skip non-CDA XMLs (manifest files, metadata, Apple Health export.xml)
+          if (!xmlContent.includes("ClinicalDocument")) continue;
+
+          const extracted = parseCcdaXml(xmlContent, xmlPath);
+          parsedData.medications.push(...extracted.medications);
+          parsedData.allergies.push(...extracted.allergies);
+          parsedData.lab_results.push(...extracted.lab_results);
+          parsedData.vitals.push(...extracted.vitals);
+          parsedData.conditions.push(...extracted.conditions);
+
+          for (const err of extracted.errors) {
+            xmlParseErrors.push({ file: xmlPath + " [" + err.section + "]", error: err.error });
+          }
+          xmlParsed++;
+        } catch (e) {
+          xmlParseErrors.push({ file: xmlPath, error: (e as Error).message });
+        }
       }
     }
 
@@ -351,9 +432,9 @@ Deno.serve(async (req) => {
 
     // Build summary
     const summary: Record<string, unknown> = {
-      pdf_count: pdfFiles.length,
+      pdf_count: pdfFileCount,
       pdf_stored: uploadedDocs,
-      xml_count: xmlFiles.length,
+      xml_count: xmlFileCount,
       xml_parsed: xmlParsed,
       has_structured_data: xmlParsed > 0,
       source_system: sourceSystem,
@@ -383,9 +464,7 @@ Deno.serve(async (req) => {
     const finalStatus =
       allErrors.length > 0 && uploadedDocs === 0 && xmlParsed === 0
         ? "failed"
-        : allErrors.length > 0
-          ? "completed"
-          : "completed";
+        : "completed";
 
     // Update job with summary
     await db


### PR DESCRIPTION
## Summary

- **Problem**: Supabase free plan has a 50MB file upload limit, but real MyChart exports can be 118MB+ as ZIPs. The XML/PDF files inside compress extremely well and are each well under 50MB individually.
- **Solution**: Unzip in the browser using JSZip, then upload each XML/PDF file individually to Supabase Storage. PDFs are stored client-side with `documents` rows created directly. Only XML paths are sent to the edge function for C-CDA parsing.
- **Backward compatibility**: The edge function still accepts `{ job_id, storage_path }` for the legacy ZIP flow. The new flow sends `{ job_id, xml_paths: [...] }` instead.

### Changes

**`index.html`**
- Added JSZip CDN (`jszip@3.10.1`)
- Rewrote `startHealthImport()` with three-phase progress:
  - Phase 1 (0–20%): Client-side ZIP extraction with file inventory
  - Phase 2 (20–70%): Individual file uploads with per-file progress
  - Phase 3 (70–100%): Edge function XML analysis
- Added `uploadBlobToStorage()` helper for individual file uploads
- PDFs uploaded + `documents` rows created client-side (no edge function needed)
- XMLs uploaded individually, paths collected and sent to edge function

**`supabase/functions/process-health-export/index.ts`**
- Accepts `xml_paths` array as alternative to `storage_path`
- When `xml_paths` provided: downloads each XML from storage individually, parses with `parseCcdaXml`, skips ZIP handling entirely
- When `storage_path` provided: existing ZIP flow unchanged (backward compatibility)
- Source system detection from XML content in the new flow (since ZIP folder structure isn't available)

## Test plan

- [ ] Upload a small ZIP (<50MB) — should unzip client-side and show three-phase progress
- [ ] Upload a large ZIP (>50MB) — should succeed where it previously failed with storage limit error
- [ ] Verify PDF documents appear in Records after import
- [ ] Verify XML health data (medications, allergies, labs) is extracted correctly
- [ ] Verify progress UI shows file count after unzip phase
- [ ] Test with non-ZIP file — should show friendly error message
- [ ] Test with ZIP containing no XML/PDF — should show "no health record files" error
- [ ] Verify backward compatibility: edge function still works if called with `storage_path` directly

---
🤖 *Generated by Computer*