### PR TITLE
Copy: mywellet landing page hero + voice violations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1483,7 +1483,7 @@
   <div class="auth-headline">
     <h1>Stop wondering<br>if Mom is okay.<br><em>Wellet remembers,<br>so you don't have to.</em></h1>
   </div>
-  <p class="auth-description">An AI care companion that tracks your loved one's medications, appointments, and health patterns — and tells you what's changing before it becomes a crisis.</p>
+  <p class="auth-description">An AI care companion that reads your loved one's records, notices patterns, and tells you what's changing before it becomes a crisis.</p>
   <div class="auth-signals">
     <div class="auth-signal-card">
       <div class="auth-signal-label"><span class="auth-signal-dot auth-signal-dot--green"></span> TODAY</div>
@@ -1592,7 +1592,8 @@
       <path fill="white" d="M104.11,168.14c-1.13,1.44-2.57,2.56-4.32,3.37-1.75.8-3.61,1.21-5.58,1.21s-3.92-.49-5.65-1.48c-1.73-.98-3.1-2.32-4.1-4.01-1.01-1.69-1.51-3.55-1.51-5.56s.5-3.87,1.51-5.56c1.01-1.69,2.38-3.03,4.1-4.01,1.73-.98,3.61-1.48,5.65-1.48,1.92,0,3.62.28,5.09.83,1.48.55,2.62,1.31,3.42,2.29.8.97,1.21,2.06,1.21,3.26,0,2.62-1.68,4.46-5.04,5.54-1.49.46-3.06.68-4.72.68-1.08,0-2.24-.11-3.49-.32.02,1.13.35,2.16.99,3.1.64.94,1.46,1.67,2.47,2.21,1.01.54,2.05.81,3.13.81.96,0,1.94-.2,2.93-.61s1.82-.98,2.47-1.73l1.44,1.48ZM92.5,155.59c-.8,1.26-1.34,2.86-1.6,4.81.84.17,1.64.25,2.41.25,1.61,0,2.87-.34,3.78-1.01s1.51-1.5,1.8-2.48c.09-.29.14-.59.14-.9,0-.86-.32-1.56-.95-2.09-.64-.53-1.36-.76-2.18-.68-1.46.14-2.6.85-3.4,2.11Z"/>
       <path fill="white" d="M139.93,141.71c.46.5.76,1.14.86,1.81.17,1.09-.14,2.07-.91,2.95s-1.69,1.36-2.84,1.51c-.83.11-1.71.14-2.64.09-1.17-.04-2.31,0-3.43.15-1.24.16-2.36.49-3.36,1-1,.5-1.5.85-2.29,1.37-1.25.83-.64.51-2.68,1.64-1.7.75-1.02.47-2.27.96-2.92,1.15-5.84,1.04-6.2,1.21v12.12c0,.86.13,1.51.38,1.93s.58.63.99.63c.26,0,.55-.09.86-.27.31-.18.6-.43.86-.74l1.44,1.48c-.98,1.1-1.96,1.87-2.92,2.3-.96.43-2.08.65-3.35.65-1.58,0-2.89-.4-3.92-1.21-1.03-.8-1.55-1.95-1.55-3.44v-13c-.74-.07-1.58-.24-2.52-.5v-1.8c.53.12.97.18,1.33.18.96,0,1.82-.27,2.59-.81.77-.54,1.42-1.18,1.96-1.91.54-.73,1.15-1.66,1.82-2.79.48-.89.88-1.52,1.19-1.91h.83v6.8c3.33.07,5-.58,7.3-1.62,1.91-1.06,2.49-1.68,3.33-2.56.36-.38.58-.67,1.77-1.97.66-.72,2.14-1.98,2.76-2.44,1.43-1.1,2.12-1.49,3.27-2.09,1.14-.61,2.11-.76,3.26-.88,2.04-.21,3.13.16,4.06,1.16Z"/>
     </svg>
-    <h1>What does care look like <em>when you stop holding it all in your head?</em></h1>
+    <h1>The Notes app. The group text. The 11pm pharmacy call. <em>You're already a caregiver.</em></h1>
+    <p class="hero-subtitle" style="font-size:15px;line-height:1.6;opacity:0.85;font-weight:300;margin-top:10px;">You've been holding all of it. Wellet reads the records, notices the patterns, and remembers what you can't. So you can stop being the memory.</p>
   </div>
 
   <div class="demo-preview">
@@ -11820,7 +11821,7 @@ function obInit() {
   obChat.phase = 'welcome';
   obSaveChatState();
   setTimeout(function() {
-    obTypeThen('Hi \u2014 I\u2019m Wellet. I help you keep track of your loved one\u2019s health so you can stop being the memory. Who are you here for?', obShowSituationChips, 900);
+    obTypeThen('Hi \u2014 I\u2019m Wellet. I help you stay on top of your loved one\u2019s health so you can stop being the memory. Who are you here for?', obShowSituationChips, 900);
   }, 400);
 }
 


### PR DESCRIPTION
## Changes

### Hero section (landing page before signup)
- **Headline:** Replaced "What does care look like when you stop holding it all in your head?" → "The Notes app. The group text. The 11pm pharmacy call. You're already a caregiver." (matches getwellet.com)
- **Subheadline added:** "You've been holding all of it. Wellet reads the records, notices the patterns, and remembers what you can't. So you can stop being the memory."

### Voice violations fixed
- **Auth screen description** (line 1486): "tracks your loved one's medications, appointments, and health patterns" → "reads your loved one's records, notices patterns"
- **Onboarding chat greeting** (line 11824): "keep track of your loved one's health" → "stay on top of your loved one's health"

### Voice guide reference
Forbidden terms: `track`, `tracks`, `tracking`, `monitor`, `keep tabs on`
Preferred alternatives: `notices`, `watches for`, `follows`, `reads`, `stays on top of`

> Note: These changes are already on main (commit d409561). This PR exists as a record of the voice/headline updates.