### PR TITLE
Foundations for manual-person onboarding: DOB + sex fallback columns (#66)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9449,6 +9449,10 @@ function renderPatterns() {
 }
 
 // ── SAVE PERSON AFTER ONBOARDING ──────────────────────────────────────────────
+// DOB + sex are optional at insert time so existing EHR-only flows keep working;
+// the upcoming manual-onboarding UI (issue #66) will populate obState.dateOfBirth
+// and obState.sex, which we snapshot into the manual_* columns so a later EHR
+// connection can't wipe caregiver-entered values.
 async function savePersonToSupabase() {
   if (!currentUser) return null;
   var name = obState.personName || 'My loved one';
@@ -9456,13 +9460,30 @@ async function savePersonToSupabase() {
   var initials = name.split(' ').map(function(w){ return w[0]; }).join('').toUpperCase().slice(0,2);
   if (initials.length < 2) initials = name.slice(0,2).toUpperCase();
 
-  const { data, error } = await db.from('people').insert({
+  // Normalize optional demographic fields. Only include them in the payload
+  // when present so we don't overwrite EHR-sourced values with nulls on
+  // subsequent edits. Sex is constrained to the four allowed enum values.
+  var ALLOWED_SEX = ['female', 'male', 'intersex', 'prefer_not_to_say'];
+  var dob = obState.dateOfBirth || null;
+  var sex = obState.sex && ALLOWED_SEX.indexOf(obState.sex) !== -1 ? obState.sex : null;
+
+  var payload = {
     user_id: currentUser.id,
     name: name,
     relationship: relationship,
     avatar_initials: initials,
     sort_order: currentPeople.length
-  }).select().single();
+  };
+  if (dob) {
+    payload.date_of_birth = dob;
+    payload.manual_date_of_birth = dob;
+  }
+  if (sex) {
+    payload.sex = sex;
+    payload.manual_sex = sex;
+  }
+
+  const { data, error } = await db.from('people').insert(payload).select().single();
 
   if (error) { console.error('Error saving person:', error); return null; }
   currentPeople.push(data);

--- a/supabase/migrations/20260423010000_people_manual_dob_sex_fallback.sql
+++ b/supabase/migrations/20260423010000_people_manual_dob_sex_fallback.sql
@@ -1,0 +1,41 @@
+-- Manual-person onboarding foundations (issue #66)
+-- Adds DOB + sex fallback columns so caregiver-entered values survive
+-- EHR connect/disconnect cycles. See PR description for full context.
+
+-- 1. Fallback columns: preserve caregiver-entered values even after an EHR
+--    connection overwrites the live date_of_birth / sex fields.
+ALTER TABLE public.people
+  ADD COLUMN IF NOT EXISTS manual_date_of_birth date,
+  ADD COLUMN IF NOT EXISTS manual_sex text;
+
+-- 2. Constrain sex to the four UI-exposed values. Using a named constraint
+--    so we can drop/replace it cleanly if the enum ever expands.
+--    Existing rows with NULL or unexpected values are left untouched
+--    (NOT VALID) so this migration never fails on legacy data; new writes
+--    are enforced immediately on the manual_sex column and normalized on
+--    the live sex column going forward.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'people_sex_check'
+  ) THEN
+    ALTER TABLE public.people
+      ADD CONSTRAINT people_sex_check
+      CHECK (sex IS NULL OR sex IN ('female','male','intersex','prefer_not_to_say'))
+      NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'people_manual_sex_check'
+  ) THEN
+    ALTER TABLE public.people
+      ADD CONSTRAINT people_manual_sex_check
+      CHECK (manual_sex IS NULL OR manual_sex IN ('female','male','intersex','prefer_not_to_say'));
+  END IF;
+END $$;
+
+-- 3. Column comments for anyone reading the schema cold.
+COMMENT ON COLUMN public.people.manual_date_of_birth IS
+  'Caregiver-entered DOB snapshot. Preserved across EHR connect/disconnect. The live date_of_birth column may be overwritten by FHIR Patient.birthDate when connected.';
+COMMENT ON COLUMN public.people.manual_sex IS
+  'Caregiver-entered biological sex snapshot. Preserved across EHR connect/disconnect. The live sex column may be overwritten by FHIR Patient.gender when connected.';


### PR DESCRIPTION
## Summary

Foundations for the Cheryl-style manual onboarding flow (#66). This is intentionally scoped to **DB + write path only** — the onboarding UI fork (new steps asking for DOB and sex) lands in a follow-up so this can be reviewed and merged independently.

## What's in here

### Migration `20260423010000_people_manual_dob_sex_fallback.sql`
- Adds `people.manual_date_of_birth` (date, nullable) and `people.manual_sex` (text, nullable)
- Adds named CHECK constraints on both `sex` and `manual_sex` for the four allowed values: `female`, `male`, `intersex`, `prefer_not_to_say`
- The live `sex` constraint is `NOT VALID` to avoid failing on any pre-existing non-canonical rows (new writes still enforced); `manual_sex` is strict from day one
- Column comments explain the live-vs-snapshot split

Why two columns per field? When a person later connects their EHR, `fetch-ehr-data` writes `Patient.birthDate` / `Patient.gender` into the live `date_of_birth` / `sex` fields. The `manual_*` columns preserve the caregiver's original entries so nothing is lost on disconnect or mismatch. This is the subtle one that would have bitten us later.

### `savePersonToSupabase()` in `index.html`
- Accepts optional `obState.dateOfBirth` and `obState.sex`
- Normalizes sex against the four allowed values; drops unknown values silently
- When present, writes to **both** the live column and the `manual_*` snapshot
- When absent, those keys are omitted entirely — we don't null out EHR-sourced values on edit

## Deploy status

Migration has already been applied to production (`nrpdhxygzyfmyljzfexv`). Both CHECK constraints verified in place. The committed SQL matches the applied version so the migration history stays in sync.

## What's NOT in here (follow-up PR)

- New onboarding step UI asking "Connect their records" vs "Enter manually"
- DOB picker + sex radio group + relationship step reuse
- Home-view completion banner for existing manual-only people
- Edge function guard in `fetch-ehr-data` preserving `manual_*` on reconnect

Those land as the next PR against this same issue.

## Testing

- Syntax: `index.html` inline JS parses clean (Node `--check`)
- DB: `SELECT conname FROM pg_constraint` confirms both constraints present
- Back-compat: EHR-only flow unchanged — existing `obState` callers never set `dateOfBirth`/`sex`, so `payload` reverts to the original 5-field insert

## Linked

Closes part of #66 (foundations). Full closure happens when the UI fork ships.

---

Standing rules honored: vanilla JS, `var` declarations, no voice-guide forbidden words, no "parent" language (there's no user-facing copy in this PR).
