### PR TITLE
Issue 4/9: link hospital picker to new proxy access help page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4310,6 +4310,7 @@
       <li class="hospital-picker-loading">Loading hospitals...</li>
     </ul>
     <div class="hospital-picker-missing"><a href="#" role="button" onclick="event.preventDefault(); openConnectRequestModal({source:'picker'}); return false;">Can’t find your hospital? Let us know →</a></div>
+    <div class="hospital-picker-missing"><a href="https://getwellet.com/proxy-access" target="_blank" rel="noopener noreferrer">Don’t have proxy access yet? See how to request it →</a></div>
     <div class="hospital-picker-sandbox"><a href="#" role="button" style="cursor:pointer;" onclick="event.preventDefault(); beginEhrOAuth(null, null, true); return false;">Use Epic sandbox (testing)</a></div>
   </div>
 </div>


### PR DESCRIPTION
Pairs with getwellet-app/getwellet PR #5.

## Change
The hospital picker sheet (Connect Health Records flow) now includes a link: *"Don't have proxy access yet? See how to request it \u2192"* — which opens the new `/proxy-access` help page on getwellet.com in a new tab.

## Why
Before: getwellet.com FAQ promised in-app guidance we don't have.
After: honest FAQ + public help page + in-app link to that page.

Caregivers who open the picker and realize they don't have proxy access yet now have somewhere clear to go — the hospital's own portal-invite or PDF form flow.