### PR TITLE
feat(plans): render Founding Member badge (Issue 8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1641,6 +1641,40 @@
   .plan-card-meta { font-size: 12px; color: var(--text-secondary); line-height: 1.5; margin-bottom: 10px; }
   .plan-card-action { display: inline-flex; align-items: center; gap: 5px; font-size: 13px; font-weight: 500; color: var(--moss-text); background: none; border: none; font-family: 'DM Sans', sans-serif; cursor: pointer; padding: 0; }
   .plan-card-action:hover { text-decoration: underline; }
+  /* Founding Member plan card — amber-tinted, more celebratory */
+  .plan-card--founding {
+    background: linear-gradient(135deg, var(--color-amber-light, #f5e6d8) 0%, var(--mint) 100%);
+    border: 1px solid rgba(192, 112, 40, 0.25);
+  }
+  .plan-card-icon--founding {
+    background: var(--color-amber, #C07028);
+    color: white;
+  }
+  .founding-pill {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 9px;
+    border-radius: 11px;
+    background: white;
+    color: var(--color-amber, #C07028);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.2;
+    border: 1px solid rgba(192, 112, 40, 0.25);
+    font-family: 'DM Sans', sans-serif;
+  }
+  [data-theme="dark"] .plan-card--founding,
+  body.dark .plan-card--founding {
+    background: linear-gradient(135deg, rgba(192, 112, 40, 0.2) 0%, rgba(61, 107, 94, 0.25) 100%);
+    border-color: rgba(192, 112, 40, 0.4);
+  }
+  [data-theme="dark"] .founding-pill,
+  body.dark .founding-pill {
+    background: rgba(0,0,0,0.25);
+    border-color: rgba(192, 112, 40, 0.5);
+  }
 
   /* ── OFFLINE BANNER ── */
   .offline-banner {
@@ -4438,6 +4472,7 @@ var _editingMedId = null;     // medications id being edited
 var currentPlan = 'free'; // 'free', 'plus', 'pro'
 var planStatus = 'active'; // 'active', 'granted', 'past_due', 'canceled'
 var planSource = 'default'; // 'stripe', 'granted', 'promo'
+var planGrantedReason = ''; // e.g. 'Founding 50 member', 'Early 100 member — 12 months'
 var planLoaded = false;
 
 var STRIPE_PRICES = {
@@ -4727,6 +4762,7 @@ async function loadUserPlan() {
       currentPlan = data.plan || 'free';
       planStatus = data.status || 'active';
       planSource = data.source || 'default';
+      planGrantedReason = data.granted_reason || '';
       planLoaded = true;
     } else {
       currentPlan = 'free';
@@ -4940,13 +4976,25 @@ function renderSettingsPlanCard() {
   var html = '';
   if (planSource === 'granted') {
     var grantedPlanName = currentPlan.charAt(0).toUpperCase() + currentPlan.slice(1);
-    html = '<div class="plan-card" style="background:var(--mint);">'
+    // Detect Founding 50 vs Early 100 vs Beta 250 from granted reason stored on subscription.
+    // Falls back to generic "Founding" treatment if reason is missing.
+    var grantedReason = (typeof planGrantedReason === 'string') ? planGrantedReason : '';
+    var isFounding50 = grantedReason.toLowerCase().indexOf('founding') !== -1;
+    var tierLabel = isFounding50 ? 'Founding Member'
+      : (grantedReason.toLowerCase().indexOf('early 100') !== -1 ? 'Early Member'
+      : (grantedReason.toLowerCase().indexOf('beta 250') !== -1 ? 'Beta Member'
+      : 'Founding Member'));
+    var tierSub = isFounding50 ? 'Free Connect for life. Thank you for believing early.'
+      : (grantedReason.toLowerCase().indexOf('early 100') !== -1 ? 'Free Connect for 12 months. Thank you for joining early.'
+      : (grantedReason.toLowerCase().indexOf('beta 250') !== -1 ? 'Free Supporter for 12 months. Thank you for testing with us.'
+      : 'Your plan is on us. Thank you for joining early.'));
+    html = '<div class="plan-card plan-card--founding">'
       + '<div class="plan-card-header">'
-      + '<div class="plan-card-icon" style="background:var(--moss);color:white;"><i data-lucide="heart" style="width:13px;height:13px;"></i></div>'
-      + '<div class="plan-card-name" style="color:var(--moss-dark);">' + escHtml(grantedPlanName) + ' \u2014 Founding</div>'
-      + '<div class="plan-card-badge" style="background:white;color:var(--moss);">Granted</div>'
+      + '<div class="plan-card-icon plan-card-icon--founding"><i data-lucide="star" style="width:13px;height:13px;"></i></div>'
+      + '<div class="plan-card-name" style="color:var(--moss-dark);">' + escHtml(grantedPlanName) + '</div>'
+      + '<div class="founding-pill"><i data-lucide="star" style="width:10px;height:10px;"></i><span>' + escHtml(tierLabel) + '</span></div>'
       + '</div>'
-      + '<div class="plan-card-meta">Never expires. Thank you for believing early.</div>'
+      + '<div class="plan-card-meta">' + escHtml(tierSub) + '</div>'
       + '</div>';
   } else if (currentPlan === 'free') {
     html = '<div class="plan-card" style="background:var(--mint);">'

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -1,0 +1,307 @@
+/**
+ * manage-subscription — handles subscription management actions.
+ *
+ * Actions:
+ *   status  — returns current subscription status for the authenticated user.
+ *             On first call, auto-grants founding/early waitlist members.
+ *   portal  — creates a Stripe Customer Portal session (manage billing)
+ *   grant   — grants a free plan to a user (admin only, checks allowlist)
+ *   revoke  — revokes a granted plan back to free
+ */
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getCorsHeaders } from "./_shared/cors.ts";
+
+const STRIPE_SECRET_KEY = Deno.env.get("STRIPE_SECRET_KEY") || "";
+
+// Admin users who can grant plans
+const ADMIN_EMAILS = ["betsy.eble@gmail.com"];
+
+async function stripePost(endpoint: string, params: Record<string, string>): Promise<Record<string, unknown>> {
+  const body = new URLSearchParams(params).toString();
+  const res = await fetch(`https://api.stripe.com/v1${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${STRIPE_SECRET_KEY}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+  return await res.json() as Record<string, unknown>;
+}
+
+/**
+ * Auto-grant a founding/early waitlist member if they've signed up for the app.
+ * Returns the granted subscription row, or null if no grant applied.
+ */
+async function autoGrantFromWaitlist(
+  // deno-lint-ignore no-explicit-any
+  db: any,
+  userId: string,
+  email: string,
+) {
+  if (!email) return null;
+  const normalizedEmail = email.toLowerCase().trim();
+
+  const { data: waitRow } = await db
+    .from("waitlist")
+    .select("reward_tier, signed_up_at")
+    .ilike("email", normalizedEmail)
+    .maybeSingle();
+
+  if (!waitRow || !waitRow.reward_tier) return null;
+
+  const tier = String(waitRow.reward_tier).toLowerCase();
+  let plan: string | null = null;
+  let periodEnd: string | null = null;
+  let reason = "";
+
+  if (tier === "founding") {
+    plan = "connect";
+    periodEnd = null; // forever
+    reason = "Founding 50 member";
+  } else if (tier === "early") {
+    plan = "connect";
+    const end = new Date();
+    end.setDate(end.getDate() + 365);
+    periodEnd = end.toISOString();
+    reason = "Early 100 member — 12 months";
+  } else if (tier === "beta") {
+    plan = "supporter";
+    const end = new Date();
+    end.setDate(end.getDate() + 365);
+    periodEnd = end.toISOString();
+    reason = "Beta 250 member — 12 months";
+  } else {
+    return null;
+  }
+
+  const row = {
+    user_id: userId,
+    plan,
+    status: "granted",
+    source: "granted",
+    granted_by: "auto-waitlist",
+    granted_reason: reason,
+    current_period_start: new Date().toISOString(),
+    current_period_end: periodEnd,
+    cancel_at_period_end: false,
+    updated_at: new Date().toISOString(),
+  };
+
+  await db.from("subscriptions").upsert(row, { onConflict: "user_id" });
+  return row;
+}
+
+Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  const json = (data: unknown, status = 200) =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return json({ error: "No authorization header" }, 401);
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonClient = createClient(
+      supabaseUrl,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const { data: { user }, error: userError } = await anonClient.auth.getUser();
+    if (userError || !user) return json({ error: "Unauthorized" }, 401);
+
+    const db = createClient(supabaseUrl, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const body = await req.json();
+    const { action } = body;
+
+    // ── Status ───────────────────────────────────────────────────────
+    if (action === "status") {
+      let { data: sub } = await db
+        .from("subscriptions")
+        .select("*")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      // First-time login: check if user is a founding/early/beta waitlist member
+      // and auto-grant their reward.
+      if (!sub && user.email) {
+        const granted = await autoGrantFromWaitlist(db, user.id, user.email);
+        if (granted) {
+          sub = granted;
+        }
+      }
+
+      if (!sub) {
+        return json({
+          plan: "free",
+          status: "active",
+          source: "default",
+          interval: null,
+          cancel_at_period_end: false,
+          current_period_end: null,
+        });
+      }
+
+      // Check if granted plan has expired
+      if (sub.source === "granted" && sub.current_period_end) {
+        const endDate = new Date(sub.current_period_end);
+        if (endDate < new Date()) {
+          // Grant expired — revert to free
+          await db.from("subscriptions").update({
+            plan: "free",
+            status: "active",
+            source: "stripe",
+            updated_at: new Date().toISOString(),
+          }).eq("user_id", user.id);
+
+          return json({
+            plan: "free",
+            status: "active",
+            source: "expired_grant",
+            interval: null,
+            cancel_at_period_end: false,
+            current_period_end: null,
+          });
+        }
+      }
+
+      return json({
+        plan: sub.plan,
+        status: sub.status,
+        source: sub.source,
+        interval: sub.interval,
+        cancel_at_period_end: sub.cancel_at_period_end,
+        current_period_end: sub.current_period_end,
+        granted_reason: sub.granted_reason,
+      });
+    }
+
+    // ── Customer Portal ────────────────────────────────────────────
+    if (action === "portal") {
+      const { data: sub } = await db
+        .from("subscriptions")
+        .select("stripe_customer_id")
+        .eq("user_id", user.id)
+        .single();
+
+      if (!sub?.stripe_customer_id) {
+        return json({ error: "No billing account found" }, 404);
+      }
+
+      const session = await stripePost("/billing_portal/sessions", {
+        customer: sub.stripe_customer_id,
+        return_url: body.return_url || "https://mywellet.com",
+      });
+
+      if (session.error) {
+        return json({ error: "Failed to create portal session" }, 500);
+      }
+
+      return json({ url: session.url });
+    }
+
+    // ── Grant Plan (admin only) ────────────────────────────────────
+    if (action === "grant") {
+      if (!ADMIN_EMAILS.includes(user.email || "")) {
+        return json({ error: "Not authorized to grant plans" }, 403);
+      }
+
+      const { target_email, plan, duration_days, reason } = body;
+      if (!target_email || !plan) {
+        return json({ error: "target_email and plan required" }, 400);
+      }
+
+      if (!["plus", "pro", "connect", "supporter"].includes(plan)) {
+        return json({ error: "plan must be 'plus', 'pro', 'connect', or 'supporter'" }, 400);
+      }
+
+      // Find the target user
+      const { data: users } = await db.auth.admin.listUsers();
+      const targetUser = users?.users?.find(
+        (u: { email?: string }) => u.email === target_email
+      );
+
+      if (!targetUser) {
+        return json({ error: "User not found: " + target_email }, 404);
+      }
+
+      // Calculate expiry
+      let periodEnd: string | null = null;
+      if (duration_days && duration_days > 0) {
+        const end = new Date();
+        end.setDate(end.getDate() + duration_days);
+        periodEnd = end.toISOString();
+      }
+      // duration_days = 0 or null means forever
+
+      await db.from("subscriptions").upsert({
+        user_id: targetUser.id,
+        plan,
+        status: "granted",
+        source: "granted",
+        granted_by: user.email,
+        granted_reason: reason || "Manual grant",
+        current_period_start: new Date().toISOString(),
+        current_period_end: periodEnd,
+        cancel_at_period_end: false,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: "user_id" });
+
+      return json({
+        success: true,
+        granted: {
+          email: target_email,
+          plan,
+          expires: periodEnd || "never",
+          reason: reason || "Manual grant",
+        },
+      });
+    }
+
+    // ── Revoke Grant (admin only) ──────────────────────────────────
+    if (action === "revoke") {
+      if (!ADMIN_EMAILS.includes(user.email || "")) {
+        return json({ error: "Not authorized" }, 403);
+      }
+
+      const { target_email } = body;
+      if (!target_email) return json({ error: "target_email required" }, 400);
+
+      const { data: users } = await db.auth.admin.listUsers();
+      const targetUser = users?.users?.find(
+        (u: { email?: string }) => u.email === target_email
+      );
+
+      if (!targetUser) {
+        return json({ error: "User not found" }, 404);
+      }
+
+      await db.from("subscriptions")
+        .update({
+          plan: "free",
+          status: "active",
+          source: "stripe",
+          granted_by: null,
+          granted_reason: null,
+          current_period_end: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("user_id", targetUser.id);
+
+      return json({ success: true, revoked: target_email });
+    }
+
+    return json({ error: "Unknown action: " + action }, 400);
+  } catch (e) {
+    console.error("manage-subscription error:", e);
+    return json({ error: (e as Error).message }, 500);
+  }
+});


### PR DESCRIPTION
Claims audit Issue 8/9: Founding Member badge

## Problem
getwellet.com/early-access promises 'Founding Member badge' for Founding 50 signups, but:
1. The app's existing 'Granted' pill was generic and buried in Settings
2. Waitlist signups were not being auto-promoted to subscriptions.source='granted', so the badge never actually rendered for anyone
3. Marketing site said 'Free Pro for life + your name in credits' — neither matched app reality

## Fix

### Edge function (manage-subscription v5, deployed)
- Auto-grant founding/early/beta waitlist members on first status check
- Founding 50 → 'connect' plan, never expires
- Early 100 → 'connect' plan, 12 months
- Beta 250 → 'supporter' plan, 12 months
- Stores granted_reason so the app can render the tier label

### App (this PR)
- New `.plan-card--founding` style (amber gradient, amber icon, Founding Member pill)
- planGrantedReason state passed through status response
- Tier-aware label + subtext:
  - Founding Member → 'Free Connect for life. Thank you for believing early.'
  - Early Member → 'Free Connect for 12 months. Thank you for joining early.'
  - Beta Member → 'Free Supporter for 12 months.'
- Dark-mode variants included
- Uses Lucide star icon (per voice/design guide)

### Database
- Backfilled reward_tier='founding' for the 6 pre-tracking real signups (excluded QA test accounts)

## Testing
Log in as betsy.eble@gmail.com → Settings → should see amber Founding Member card with 'Connect' plan name and 'Free Connect for life. Thank you for believing early.' subtext.