### PR TITLE
fix(onboarding): gate 'Welcome back' on server-side people count

### DIFF
--- a/index.html
+++ b/index.html
@@ -9690,11 +9690,26 @@ function showOnboarding() {
   history.pushState({ type: 'onboarding' }, '');
   window.scrollTo(0, 0);
   initIcons();
-  // Start chat onboarding (or resume if state exists)
+  // Decide: first-time user vs. resume mid-onboarding vs. add-another-person.
+  //
+  // Source of truth is the server — specifically `currentPeople.length`, which
+  // loadUserData() populates from public.people before calling showOnboarding().
+  // If this authenticated user has zero people on the server they are, by
+  // definition, a first-time user regardless of what localStorage says. This
+  // prevents "Welcome back, <name>" from greeting a user whose account was
+  // wiped server-side but who still has `wellet_ob_chat` cached locally.
+  var peopleCount = Array.isArray(currentPeople) ? currentPeople.length : 0;
   var hasState = obLoadChatState();
-  if (hasState && obChat.phase !== 'welcome' && obChat.phase !== 'done') {
+  var hasMeaningfulState = hasState && obChat.phase !== 'welcome' && obChat.phase !== 'done';
+  // Only resume when the server confirms the user actually has saved people.
+  if (hasMeaningfulState && peopleCount > 0) {
     obResumeChat();
   } else {
+    // First-time user OR stale localStorage after a server-side wipe.
+    // Nuke cached chat state so obInit() starts from a clean slate.
+    if (peopleCount === 0 && hasState) {
+      obClearChatState();
+    }
     obInit();
   }
 }


### PR DESCRIPTION
## What

Fixes a bug where a brand-new user (or a user whose account was just wiped server-side) was greeted with "Welcome back, <previous name>! Let's pick up where we left off." in the onboarding chat.

## Why

`showOnboarding()` was deciding resume-vs-init purely from `obLoadChatState()` (localStorage `wellet_ob_chat`). localStorage survives server-side account wipes, so stale state from a deleted account would greet a fresh signup as if they were returning.

Reproduced this morning: wiped `betsy.eble@gmail.com` via `wipe_test_users.sql`, signed up fresh, and the app said "Welcome back, Betsy! Let's pick up where we left off" + "What would you like to add to Betsy's record?" even though there were zero `public.people` rows for the new user_id.

## How

Consult the server truth before trusting localStorage. `loadUserData()` already populates `currentPeople` from `public.people` before calling `showOnboarding()`, so we gate the resume path on `currentPeople.length > 0`. If the user has zero people on the server, we clear any stale `wellet_ob_chat` and call `obInit()` for a clean start.

## Preserved behavior

- Legitimate mid-onboarding resume: user has at least one `people` row + a non-terminal chat phase → `obResumeChat()` (unchanged).
- Add-another-person from Home: `currentPeople.length > 0`, so the resume path still runs (unchanged).
- Fresh signup after wipe or first-ever visit: `currentPeople.length === 0` → stale state cleared, `obInit()` runs the full welcome flow.

## Test plan

1. Sign out, sign up fresh with a new email → expect the language picker + "Hi — I'm Wellet. I help you stay on top of your loved one's health…" (no "Welcome back").
2. Wipe an existing account via `wipe_test_users.sql`, sign up with the same email → expect the same fresh flow (no stale name).
3. Start onboarding, quit after entering your name, come back → expect "Welcome back, <name>!" ONLY IF `public.people` has a row for this user_id (it won't until the person is created, so this path only triggers once onboarding has progressed far enough to create a person row).
4. From Home, tap "Start my own story" or "+" to add a person → expect the existing resume/add-person flow (unchanged).

## Files

- `index.html` — 17 insertions, 2 deletions in `showOnboarding()`
