### PR TITLE
refactor(plans): rename tiers Connect→Pro and Supporter→Plus

### DIFF
--- a/index.html
+++ b/index.html
@@ -4984,9 +4984,9 @@ function renderSettingsPlanCard() {
       : (grantedReason.toLowerCase().indexOf('early 100') !== -1 ? 'Early Member'
       : (grantedReason.toLowerCase().indexOf('beta 250') !== -1 ? 'Beta Member'
       : 'Founding Member'));
-    var tierSub = isFounding50 ? 'Free Connect for life. Thank you for believing early.'
-      : (grantedReason.toLowerCase().indexOf('early 100') !== -1 ? 'Free Connect for 12 months. Thank you for joining early.'
-      : (grantedReason.toLowerCase().indexOf('beta 250') !== -1 ? 'Free Supporter for 12 months. Thank you for testing with us.'
+    var tierSub = isFounding50 ? 'Free Pro for life. Thank you for believing early.'
+      : (grantedReason.toLowerCase().indexOf('early 100') !== -1 ? 'Free Pro for 12 months. Thank you for joining early.'
+      : (grantedReason.toLowerCase().indexOf('beta 250') !== -1 ? 'Free Plus for 12 months. Thank you for testing with us.'
       : 'Your plan is on us. Thank you for joining early.'));
     html = '<div class="plan-card plan-card--founding">'
       + '<div class="plan-card-header">'

--- a/supabase/functions/manage-subscription/index.ts
+++ b/supabase/functions/manage-subscription/index.ts
@@ -57,17 +57,17 @@ async function autoGrantFromWaitlist(
   let reason = "";
 
   if (tier === "founding") {
-    plan = "connect";
+    plan = "pro";
     periodEnd = null; // forever
     reason = "Founding 50 member";
   } else if (tier === "early") {
-    plan = "connect";
+    plan = "pro";
     const end = new Date();
     end.setDate(end.getDate() + 365);
     periodEnd = end.toISOString();
     reason = "Early 100 member — 12 months";
   } else if (tier === "beta") {
-    plan = "supporter";
+    plan = "plus";
     const end = new Date();
     end.setDate(end.getDate() + 365);
     periodEnd = end.toISOString();


### PR DESCRIPTION
## What

Aligns in-app tier names with the public pricing page on getwellet.com. The legacy slugs `connect` and `supporter` are replaced with `pro` and `plus` in two places that were still lagging behind the rest of the app.

## Why

getwellet.com copy and the in-app plan picker both use **Pro** and **Plus** publicly. The Settings "Plan" card subtext and the `manage-subscription` auto-grant logic were still writing/displaying the old names, which would confuse Founding Members the first time they checked their plan badge.

## Changes

**1. `index.html` — `renderSettingsPlanCard()` subtext copy**
| Tier | Before | After |
|---|---|---|
| Founding 50 | "Free Connect for life" | "Free Pro for life" |
| Early 100 | "Free Connect for 12 months" | "Free Pro for 12 months" |
| Beta 250 | "Free Supporter for 12 months" | "Free Plus for 12 months" |

**2. `supabase/functions/manage-subscription/index.ts` — `autoGrantFromWaitlist()` plan slug**
| Waitlist tier | Before (written to `subscriptions.plan`) | After |
|---|---|---|
| `founding` | `connect` | `pro` |
| `early` | `connect` | `pro` |
| `beta` | `supporter` | `plus` |

## Schema impact

None. `subscriptions.plan` is free-text. The rest of the app already reads `'pro'` and `'plus'` for plan-gated behavior (confirmed by grep).

## Backfill

Confirmed via SQL: `public.subscriptions` is currently empty, so no existing rows need rewriting. If rows accumulate before this ships, a one-liner would handle it:

```sql
UPDATE public.subscriptions SET plan = 'pro'  WHERE plan = 'connect';
UPDATE public.subscriptions SET plan = 'plus' WHERE plan = 'supporter';
```

## Deploy note

The edge function change requires redeploying `manage-subscription` after merge. Function slug `7d666f74-1714-4653-94b7-4c7aad163d7b`, current v6 on project `nrpdhxygzyfmyljzfexv`.

## Test plan

1. Sign up with a new email that exists in `waitlist` with `reward_tier='founding'` → first call to `manage-subscription` should auto-grant `plan='pro'`.
2. Open Settings → Plan → should read "Free Pro for life. Thank you for believing early." under the Founding Member badge.
3. Repeat for `early` (Pro, 365d) and `beta` (Plus, 365d).