### PR TITLE
Update Me: long-press summary to open Ask Wellet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5733,7 +5733,22 @@ function renderUpdateMe() {
     var viewedAt = new Date();
     var viewedStr = viewedAt.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
     var viewedLine = 'Viewed ' + escHtml(viewedStr);
-    summarySection = '<div class="update-summary-card">'
+    // Register Ask-Wellet long-press context for this summary so a long-press opens the Ask sheet
+    try {
+      if (!window._askCtxRegistry) window._askCtxRegistry = {};
+      var summaryAskKey = 'update_summary_' + currentPersonId;
+      window._askCtxRegistry[summaryAskKey] = {
+        kind: 'summary',
+        name: 'Update Me for ' + name,
+        title: 'Update Me for ' + name,
+        date: meta && meta.generated_at ? meta.generated_at : null,
+        meta: sourceCount > 0 ? ('Written from ' + sourceCount + ' source' + (sourceCount === 1 ? '' : 's')) : '',
+        summary_text: getSummaryText(currentPersonId),
+        window_class: wc,
+        sources: meta && meta.sources ? meta.sources : null
+      };
+    } catch(_e){}
+    summarySection = '<div class="update-summary-card" data-ask-lp="' + escHtml(summaryAskKey) + '">'
       + '<div class="update-summary-header">'
       + '<div class="update-summary-titlerow"><span class="update-summary-label">Wellet summary</span>' + verdictPill + '</div>'
       + '<button class="update-summary-refresh" onclick="fetchUpdateMeSummary(true)" title="Refresh summary"><i data-lucide="refresh-cw" style="width:13px;height:13px;"></i></button>'
@@ -6456,6 +6471,13 @@ function _askSheetStartersFor(ctx) {
         { icon: 'help-circle', text: 'Explain this section in plain language' },
         { icon: 'file-text', text: 'What\u2019s most important here for an ER visit?' }
       ];
+    case 'summary':
+      return [
+        { icon: 'message-circle-question', text: 'Tell me more about this' },
+        { icon: 'eye', text: 'What should I watch for next?' },
+        { icon: 'stethoscope', text: 'What should I ask the doctor?' },
+        { icon: 'share-2', text: 'Draft a note to the family' }
+      ];
     default:
       return [
         { icon: 'help-circle', text: 'What does this mean?' },
@@ -6470,7 +6492,8 @@ function _askSheetKindLabel(kind) {
     lab: 'Lab result', medication: 'Medication', med: 'Medication', vital: 'Vital',
     visit: 'Visit', appointment: 'Appointment', document: 'Document', note: 'Note',
     event: 'Health event', pattern: 'Pattern', symptom: 'Symptom',
-    emergency_section: 'Emergency summary', share: 'Shared item'
+    emergency_section: 'Emergency summary', share: 'Shared item',
+    summary: 'Wellet summary'
   };
   return map[kind] || 'This item';
 }
@@ -6562,6 +6585,10 @@ function _askSheetDispatch(questionText) {
     meta:  ctx.meta || '',
     selection: ctx.selection || ''
   };
+  // For summary context, pass the full paragraph as notes so Ask Wellet can reference it
+  if (ctx.kind === 'summary' && ctx.summary_text && !finalCtx.notes) {
+    finalCtx.notes = ctx.summary_text;
+  }
   window._pendingAskContext = finalCtx;
 
   // Hide the sheet visually FIRST, but DON'T call history.back() — it races


### PR DESCRIPTION
## What

Long-press (500ms) anywhere on the Wellet summary card in Update Me to open the Ask Wellet sheet, pre-seeded with the summary as context.

## Why

The summary paragraph is the hero of the app, but it's a read-only artifact. Long-press makes it interactive — users can jump from a statement in the paragraph to a conversation about it, without leaving the page or retyping anything.

## How

- Added a new `summary` kind to `_askSheetStartersFor` with 4 starters tuned to the summary paragraph:
  - Tell me more about this
  - What should I watch for next?
  - What should I ask the doctor?
  - Draft a note to the family
- Added `'Wellet summary'` to `_askSheetKindLabel`
- In `renderUpdateMe` populated branch, register a context object in `window._askCtxRegistry` with kind, name, date, meta, `summary_text`, `window_class`, and `sources`, then add `data-ask-lp="update_summary_\${pid}"` to the summary card wrapper
- In `_askSheetDispatch`, pass `summary_text` through as `notes` so the Ask backend sees the actual paragraph as context
- No new wiring needed in `renderUpdateMe` itself — the existing MutationObserver auto-binds `[data-ask-lp]` on every re-render

## Bonus

If the user has text selected inside the card when they long-press, that selection becomes the focal point (existing long-press behavior). So you can hold on a specific phrase like 'cholesterol trending down' and Ask Wellet will focus on just that.

## Deploy status

- Briefly lived on main as commit `1c6deab` (deployed, tested working)
- Reverted on main (`948e1b2`) to route through review on this PR instead
- Live site: unchanged from pre-1c6deab state until this merges

## Testing

1. Hard-refresh mywellet.com
2. Open Update Me for Mom
3. Press and hold on the Wellet summary paragraph for ~500ms
4. Verify: Ask sheet opens with 'Wellet summary' label, summary preview, and 4 starter questions
5. Try selecting text first, then long-pressing — that selection should appear in the sheet preview
6. Tap a starter → should route to Ask Wellet tab with the summary as context