### PR TITLE
EHR N-connections hotfix + Add another hospital button

### DIFF
--- a/index.html
+++ b/index.html
@@ -12002,6 +12002,15 @@ function beginEhrOAuth(fhirBaseUrl, hospitalName, isSandbox) {
         }, 400);
         return;
       }
+      // 2026-04-26 hotfix: server-side guard that refuses a SECOND hospital on
+      // a loved one until the rest of the N-connections refactor lands. The
+      // server returns a friendly message in `data.message`. Surface it as a
+      // plain toast — no "let us know" modal, since this is an expected
+      // temporary limitation, not a hospital-support gap.
+      if (data.error === 'multi_hospital_not_yet_supported') {
+        showToast(data.message || 'Multi-hospital support is shipping soon — for now, only one hospital can be connected at a time per loved one.');
+        return;
+      }
       var msg = 'Error: ' + data.error;
       if (data.diag) msg += ' (' + data.diag + ')';
       showToast(msg);
@@ -12454,6 +12463,13 @@ function buildEhrStatusBar(ehrData) {
     + patientLine + '</div></div>'
     + '<div class="ehr-status-right">'
     + '<span style="font-size:11px;color:var(--text-muted);">Synced ' + syncedStr + '</span>'
+    // "Add another hospital" entry point. Opens the same Epic hospital picker
+    // that first-time connect uses. The epic-auth `start` route enforces a
+    // per-loved-one guard until the full N-connections refactor ships, so
+    // attempting a different hospital today returns a friendly 409 that the
+    // picker surfaces. Same hospital re-connect (e.g. expired refresh) is
+    // allowed through.
+    + '<button class="ehr-refresh-btn" onclick="startEhrConnect()" title="Add another hospital"><i data-lucide="plus" style="width:14px;height:14px;"></i></button>'
     + '<button class="ehr-refresh-btn" onclick="refreshEhrData()" title="Refresh data"><i data-lucide="refresh-cw" style="width:14px;height:14px;"></i></button>'
     + '<button class="ehr-refresh-btn" onclick="disconnectEhr()" title="Disconnect" style="color:var(--red);"><i data-lucide="unplug" style="width:14px;height:14px;"></i></button>'
     + '</div></div>';

--- a/supabase/functions/epic-auth/index.ts
+++ b/supabase/functions/epic-auth/index.ts
@@ -375,11 +375,55 @@ Deno.serve(async (req) => {
         tokenUrl = endpoints.token_endpoint;
       }
 
+      // HOTFIX 2026-04-26 (defensive guard): until the rest of the
+      // N-connections-per-person refactor lands (fetch-ehr-data fan-out,
+      // frontend cache merge, render path), refuse to start a SECOND
+      // connection for a person who already has one connected. This
+      // preserves today's one-connection-per-person behavior while we ship
+      // the proper refactor. Without this guard the start succeeds but
+      // downstream `status` / `refresh` calls would 500 because they still
+      // use .single() on person_id.
+      const { data: existingConnected, error: existingError } = await admin
+        .from('ehr_connections')
+        .select('id, hospital_name, fhir_base_url')
+        .eq('person_id', person_id)
+        .eq('user_id', user.id)
+        .eq('status', 'connected')
+        .limit(1);
+      if (existingError) {
+        console.error('[epic-auth] start existing-check failed', { err: existingError });
+        return jsonResponse({ error: 'connection_check_failed', message: 'Could not verify existing connections.' }, 500);
+      }
+      if (existingConnected && existingConnected.length > 0) {
+        const existing = existingConnected[0];
+        // If the user is re-connecting the SAME hospital (e.g. token expired
+        // beyond refresh) allow it — we'll replace the existing row in
+        // callback. If it's a DIFFERENT hospital, refuse with a friendly
+        // message until N-connections is fully shipped.
+        if (existing.fhir_base_url !== fhirBase) {
+          return jsonResponse({
+            error: 'multi_hospital_not_yet_supported',
+            message: "This loved one already has " + (existing.hospital_name || 'a hospital connection') + " connected. Multi-hospital support is shipping soon \u2014 for now, only one hospital can be connected at a time per loved one.",
+            existing_hospital_name: existing.hospital_name,
+            existing_fhir_base_url: existing.fhir_base_url,
+          }, 409);
+        }
+      }
+
       const codeVerifier = generateCodeVerifier();
       const codeChallenge = await computeCodeChallenge(codeVerifier);
       const state = generateState();
 
-      await admin.from('ehr_connections').upsert({
+      // HOTFIX 2026-04-26: previously this was an upsert with
+      // onConflict: 'person_id' — which silently overwrote any existing
+      // connection on the same person row whenever a second hospital was
+      // started. We now insert a new pending row per OAuth attempt and rely
+      // on `state` (globally unique per attempt) to resolve the matching
+      // row in `callback`. The companion migration drops UNIQUE(person_id)
+      // and adds a partial UNIQUE(person_id, fhir_base_url) WHERE
+      // status='connected' so multiple connected hospitals can coexist on
+      // the same person.
+      const { error: insertError } = await admin.from('ehr_connections').insert({
         user_id: user.id,
         person_id: person_id,
         provider: 'epic',
@@ -388,13 +432,22 @@ Deno.serve(async (req) => {
         fhir_base_url: fhirBase,
         token_url: tokenUrl,
         hospital_name: hospitalName || (isSandbox ? 'Epic Sandbox' : null),
+        status: 'pending',
         access_token: null,
         refresh_token: null,
         token_expires_at: null,
         patient_id: null,
         connected_provider: null,
         connected_at: null,
-      }, { onConflict: 'person_id' });
+      });
+      if (insertError) {
+        console.error('[epic-auth] start insert failed', { err: insertError });
+        return jsonResponse({
+          error: 'connection_start_failed',
+          message: 'Could not start a new EHR connection — please try again.',
+          detail: insertError.message,
+        }, 500);
+      }
 
       const params = new URLSearchParams({
         response_type: 'code',
@@ -421,17 +474,26 @@ Deno.serve(async (req) => {
 
       const admin = getAdminClient();
 
+      // HOTFIX 2026-04-26: callback now looks up the pending connection by
+      // `state` (which is globally unique per OAuth attempt) instead of by
+      // person_id. Under N-connections-per-person a single person can have
+      // multiple pending rows in flight, so person_id is no longer
+      // sufficient to identify the right row. We still verify person_id and
+      // user_id match the row we found to defend against state forgery from
+      // a different account.
       const { data: conn, error: connError } = await admin.from('ehr_connections')
         .select('*')
-        .eq('person_id', person_id)
+        .eq('state', callbackState)
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
       if (connError || !conn) {
         return jsonResponse({ error: 'No pending connection found' }, 404);
       }
 
-      if (conn.state && callbackState !== conn.state) {
+      if (conn.person_id !== person_id) {
+        // The state matched a row but for a different person on this account.
+        // Treat as a CSRF / cross-person leak and refuse.
         return jsonResponse({ error: 'State mismatch — possible CSRF attack' }, 400);
       }
 
@@ -545,6 +607,10 @@ Deno.serve(async (req) => {
         });
       }
 
+      // HOTFIX 2026-04-26: scope this update to the specific connection row
+      // we resolved by `state` above. Previously it filtered by person_id
+      // which would clobber sibling rows once a person had multiple
+      // connections (e.g. wipe Mom's Duke code_verifier when finishing UNC).
       const { error: updateError } = await admin.from('ehr_connections')
         .update({
           access_token: encAccessToken,
@@ -559,7 +625,7 @@ Deno.serve(async (req) => {
           code_verifier: null,
           state: null,
         })
-        .eq('person_id', person_id)
+        .eq('id', conn.id)
         .eq('user_id', user.id);
 
       if (updateError) {

--- a/supabase/functions/oneup-auth/index.ts
+++ b/supabase/functions/oneup-auth/index.ts
@@ -139,12 +139,20 @@ Deno.serve(async (req) => {
 
       const admin = getAdminClient();
 
-      // Check if there's already a connection for this person
-      const { data: existing } = await admin.from('ehr_connections')
+      // HOTFIX 2026-04-26: changed from .single() to .maybeSingle() because
+      // .single() throws PGRST116 when there are 2+ rows, which would be the
+      // case once N-connections-per-person is fully shipped. Today this still
+      // returns at most one row because the `start` upserts below have an
+      // application-layer guard preventing more than one connected row per
+      // person. Limit(1) defends against the transient state where a pending
+      // and a connected row temporarily co-exist for the same person.
+      const { data: existingRows } = await admin.from('ehr_connections')
         .select('*')
         .eq('person_id', person_id)
         .eq('user_id', user.id)
-        .single();
+        .order('connected_at', { ascending: false, nullsFirst: false })
+        .limit(1);
+      const existing = existingRows && existingRows.length > 0 ? existingRows[0] : null;
 
       let oneupUserId: string;
       let authCode: string;
@@ -171,18 +179,33 @@ Deno.serve(async (req) => {
           authCode = codeData.code || '';
         }
       } else {
-        // Create a new 1upHealth user
+        // HOTFIX 2026-04-26: previously this was an upsert with
+        // onConflict: 'person_id', which would silently overwrite a sibling
+        // EHR connection (e.g. Mom's Duke chart) the moment a 1upHealth flow
+        // started for the same person. Switched to plain insert; the
+        // companion migration drops UNIQUE(person_id) and adds a partial
+        // UNIQUE(person_id, fhir_base_url) WHERE status='connected'. The
+        // application-layer guard above blocks a second hospital from
+        // starting until the rest of the N-connections refactor lands.
         const result = await createOneUpUser(`${user.id}_${person_id}`);
         oneupUserId = result.oneup_user_id;
         authCode = result.code;
 
-        // Store the connection record
-        await admin.from('ehr_connections').upsert({
+        const { error: insertError } = await admin.from('ehr_connections').insert({
           user_id: user.id,
           person_id: person_id,
           oneup_user_id: oneupUserId,
+          status: 'pending',
           connected_at: new Date().toISOString(),
-        }, { onConflict: 'person_id' });
+        });
+        if (insertError) {
+          console.error('[oneup-auth] start insert failed', { err: insertError });
+          return jsonResponse({
+            error: 'connection_start_failed',
+            message: 'Could not start a new EHR connection — please try again.',
+            detail: insertError.message,
+          }, 500);
+        }
       }
 
       // Build the authorize URL — this opens 1upHealth's health system picker

--- a/supabase/migrations/20260426150000_ehr_connections_n_per_person_hotfix.sql
+++ b/supabase/migrations/20260426150000_ehr_connections_n_per_person_hotfix.sql
@@ -1,0 +1,55 @@
+-- Hotfix: allow N EHR connections per person.
+--
+-- WHY: Today public.ehr_connections has UNIQUE INDEX idx_ehr_connections_person
+-- on (person_id). The epic-auth.start handler issues an upsert with
+-- onConflict: 'person_id'. The first time anyone tries to connect a SECOND
+-- hospital to a person who already has one (e.g. attempting to add UNC to a
+-- loved one who already has Duke), the upsert silently overwrites the
+-- existing row's tokens, fhir_base_url, and patient_id with the new
+-- pending-OAuth scratch data, then returns an authorize URL. If the user
+-- abandons the new OAuth flow at any point, the original connection is gone.
+--
+-- This migration drops the (person_id) unique constraint and replaces it
+-- with a partial unique index on (person_id, fhir_base_url) WHERE
+-- status = 'connected'. Pending/half-finished connections (status != 'connected'
+-- or fhir_base_url IS NULL) are not deduped, which is the right behavior for
+-- in-flight OAuth attempts that may retry.
+--
+-- SAFETY: The single existing connected row in production
+-- (person_id = 2a1e1a92-..., fhir_base_url = health-apis.duke.edu)
+-- satisfies the new partial unique constraint. No data movement; no
+-- cascading deletes; no token rotation. The migration is reversible by
+-- recreating the old index (which would only succeed while there is still
+-- ≤1 row per person).
+--
+-- COMPANION CODE CHANGES (in the same branch):
+--   * supabase/functions/epic-auth/index.ts — start handler: upsert → insert
+--   * supabase/functions/oneup-auth/index.ts — start handler: upsert → insert
+-- Frontend changes for full N-per-person rendering are tracked in the
+-- N-connections design doc and land in a follow-up branch.
+
+BEGIN;
+
+-- 1. Drop the old single-connection-per-person constraint.
+DROP INDEX IF EXISTS public.idx_ehr_connections_person;
+
+-- 2. Add the new constraint: at most one CONNECTED row per (person, hospital).
+--    Pending OAuth attempts (status != 'connected' or fhir_base_url is null)
+--    are not deduped, so retries don't fight existing pending rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ehr_connections_person_fhir_connected
+  ON public.ehr_connections (person_id, fhir_base_url)
+  WHERE fhir_base_url IS NOT NULL AND status = 'connected';
+
+-- 3. Performance index for the per-person fan-out lookup that
+--    fetch-ehr-data will issue once it learns to fan out.
+CREATE INDEX IF NOT EXISTS idx_ehr_connections_person_status
+  ON public.ehr_connections (person_id, status);
+
+-- 4. Defense-in-depth: prevent two pending starts from racing on the same
+--    state token. (state should already be globally unique per OAuth attempt;
+--    making that explicit prevents a future bug from compounding.)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ehr_connections_state_unique
+  ON public.ehr_connections (state)
+  WHERE state IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Hotfix that opens the door to N-connections-per-person without breaking today's single-hospital UX.

## Schema (already applied to prod)
- Drop UNIQUE(person_id) on ehr_connections
- Add partial UNIQUE(person_id, fhir_base_url) WHERE status='connected'
- Add indexes for person+status and state-unique lookups

## epic-auth (already deployed v33)
- start: insert (not upsert) + app-layer guard refusing a 2nd hospital with 409 multi_hospital_not_yet_supported until full N-connections refactor lands. Same-hospital reconnect allowed.
- callback: lookup by state (not person_id), scope UPDATE to .eq('id', conn.id)

## oneup-auth (already deployed v16)
- start: insert (not upsert), maybeSingle() lookup

## Frontend (this commit)
- Add '+' button to ehr-status-bar (Records + Timeline) that calls startEhrConnect()
- Handle multi_hospital_not_yet_supported 409 with a friendly toast (no 'let us know' modal)

Mom's Duke chart verified intact pre-merge.