### PR TITLE
Records: DB-backed fallback for Conditions + Visits tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -7718,6 +7718,48 @@ function openRecordsDetail(section) {
   var labEvents   = liveEvents.filter(function(e){ return e.event_type==='lab_result'; });
   var apptEvents  = liveEvents.filter(function(e){ return e.event_type==='appointment'; });
 
+  // DB-backed fallback for Conditions / Visits when the live EHR cache is empty
+  // (e.g. first paint before sync completes, or identity-check skipped a write).
+  // health_events stores condition + visit rows with shape: {title, event_date,
+  // notes, source, accepted}. We adapt them into the shape Conditions / Visits
+  // detail views already expect (name, recorded_date, onset_date, status / start_date).
+  if (ehrConditions.length === 0) {
+    ehrConditions = liveEvents
+      .filter(function(e){ return e.event_type==='condition' && e.accepted!==false; })
+      .map(function(e){
+        var status = '';
+        var notes = e.notes || '';
+        var m = /^Status:\s*(.+)$/i.exec(notes);
+        if (m) status = (m[1] || '').trim().toLowerCase();
+        return {
+          name: e.title || '',
+          code: '',
+          status: status,
+          onset_date: e.event_date || '',
+          recorded_date: e.event_date || '',
+          source: 'ehr',
+        };
+      });
+  }
+  if (allEhrVisits.length === 0) {
+    var liveVisitEvents = liveEvents
+      .filter(function(e){ return e.event_type==='visit' && e.accepted!==false; })
+      .map(function(e){
+        return {
+          name: e.title || 'Visit',
+          start_date: e.event_date || '',
+          end_date: '',
+          location: '',
+          reason: e.notes || '',
+          providers: [],
+          source: 'ehr',
+        };
+      });
+    allEhrVisits = liveVisitEvents;
+    ehrVisitsRecent = allEhrVisits.filter(function(v){ var t=v.start_date?new Date(v.start_date).getTime():0; return t>=twoYearsAgoMs; });
+    ehrVisitsOlder  = allEhrVisits.filter(function(v){ var t=v.start_date?new Date(v.start_date).getTime():0; return t>0&&t<twoYearsAgoMs; });
+  }
+
   var titles = {
     medications: 'Medications',
     conditions:  'Conditions',
@@ -7774,6 +7816,48 @@ function renderRecordsView() {
   var labEvents     = liveEvents.filter(function(e){ return e.event_type==='lab_result'; });
   var noteEvents    = liveEvents.filter(function(e){ return e.event_type==='note'; });
   var apptEvents    = liveEvents.filter(function(e){ return e.event_type==='appointment'; });
+
+  // DB-backed fallback for Conditions / Visits when the live EHR cache is empty
+  // (e.g. first paint before sync completes, or identity-check skipped a write).
+  // Mirrors the Meds/Allergies/Labs pattern, which already merge live (DB) +
+  // ehr (cache) sources. health_events stores condition + visit rows with shape
+  // {title, event_date, notes, source, accepted}; we adapt to the shape the
+  // Records render path + detail views already expect.
+  if (ehrConditions.length === 0) {
+    ehrConditions = liveEvents
+      .filter(function(e){ return e.event_type==='condition' && e.accepted!==false; })
+      .map(function(e){
+        var status = '';
+        var notes = e.notes || '';
+        var m = /^Status:\s*(.+)$/i.exec(notes);
+        if (m) status = (m[1] || '').trim().toLowerCase();
+        return {
+          name: e.title || '',
+          code: '',
+          status: status,
+          onset_date: e.event_date || '',
+          recorded_date: e.event_date || '',
+          source: 'ehr',
+        };
+      });
+  }
+  if (allEhrVisits.length === 0) {
+    allEhrVisits = liveEvents
+      .filter(function(e){ return e.event_type==='visit' && e.accepted!==false; })
+      .map(function(e){
+        return {
+          name: e.title || 'Visit',
+          start_date: e.event_date || '',
+          end_date: '',
+          location: '',
+          reason: e.notes || '',
+          providers: [],
+          source: 'ehr',
+        };
+      });
+    ehrVisitsRecent = allEhrVisits.filter(function(v){ var t=v.start_date?new Date(v.start_date).getTime():0; return t>=twoYearsAgoMs; });
+    ehrVisitsOlder  = allEhrVisits.filter(function(v){ var t=v.start_date?new Date(v.start_date).getTime():0; return t>0&&t<twoYearsAgoMs; });
+  }
 
   // ── computed counts for tile summaries ───────────────────────────────────
   var totalMeds       = activeMeds.length + ehrMeds.length;


### PR DESCRIPTION
## Why

After v55 deployed, the live sync confirms the API returns 200 conditions + 200 visits and writes 574 health_events to the DB. But on the Records page, Conditions tile shows "None on file" and Visits shows "0 visits" — even after a hard refresh — because those two tiles read **only** from the live EHR response cache (`ehrData.conditions` / `ehrData.visits`).

Meds / Allergies / Labs already merge **live (DB-backed)** + **ehr (cache)** sources, so they render correctly. Conditions and Visits do not — that's a pre-existing gap, not a v55 regression.

## What

In both `renderRecordsView()` and `openRecordsDetail()`, when the live EHR cache is empty for those two resources, fall back to `liveEvents` (already loaded from `health_events`):

- `event_type === 'condition'` → adapt to `{name, recorded_date, onset_date, status, source}`. Status is parsed from `notes` via `/^Status:\s*(.+)$/i`.
- `event_type === 'visit'` → adapt to `{name, start_date, end_date, location, reason, providers, source}`. Recompute `ehrVisitsRecent` / `ehrVisitsOlder` after the swap.
- Both filter out `accepted === false` rows (matches existing event-feed semantics).

## Scope

- Read-only fallback. No writes, no schema changes, no edge function changes.
- Fires only when the live cache is empty — the existing happy path (cache populated) is unchanged.
- Vanilla JS, `var` declarations, single `index.html`. No new helpers.

## Not in scope

- 4 stale allergy rows in DB vs. 1 in latest sync response — separate prune-on-sync question.
- Phase 2 frontend cache v2 / hospital pills / per-connection banners — gated behind `localStorage.welletPhase2 === '1'` flag, lands next.

## Test plan

- Hard reload mywellet.com on Mom's account → Conditions tile shows non-zero, Visits tile shows non-zero.
- Click into Conditions → entries render with names + status where parseable.
- Click into Visits → recent / older split renders.