### PR TITLE
Records: temporary diagnostic toasts in fetchEhrData

### DIFF
--- a/index.html
+++ b/index.html
@@ -12478,10 +12478,11 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     var session = sessionRes.data.session;
     if (!session) {
       console.warn('[EHR] fetchEhrData bail: no session');
-      try { showToast('Session expired \u2014 please reload to sign in'); } catch(e){}
+      try { showToast('Sync bail: no session'); } catch(e){}
       try { restoreRecordsEhrStatus(); } catch(e){}
       return BAILED;
     }
+    try { showToast('Sync: calling function\u2026'); } catch(e){}
     return fetch(SUPABASE_URL + '/functions/v1/fetch-ehr-data', {
       method: 'POST',
       headers: {
@@ -12493,7 +12494,11 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     });
   }).then(function(res) {
     if (res === BAILED) return BAILED;
-    if (!res) return null;
+    if (!res) {
+      try { showToast('Sync bail: fetch returned no response'); } catch(e){}
+      return null;
+    }
+    try { showToast('Sync: HTTP ' + res.status); } catch(e){}
     // A 404 can happen legitimately (no connection) OR transiently right after a
     // successful OAuth callback (Postgres read-after-write lag on a pooled replica).
     // We never wipe the cache on 404 anymore — that caused the UI to show
@@ -12540,8 +12545,9 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     if (data === BAILED) return;
     if (!data || data.error) {
       // PHI log removed
-      console.warn('[EHR] fetchEhrData bail: no data or data.error');
-      try { showToast("Couldn\u2019t reach health records \u2014 try again"); } catch(e){}
+      console.warn('[EHR] fetchEhrData bail: no data or data.error', data);
+      var why = !data ? 'no data' : ('data.error=' + String(data.error).slice(0,80));
+      try { showToast('Sync bail: ' + why); } catch(e){}
       try { restoreRecordsEhrStatus(); } catch(e){}
       return;
     }
@@ -12586,7 +12592,8 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     }
   }).catch(function(err) {
     console.error('EHR fetch error:', err);
-    try { showToast("Couldn\u2019t reach health records \u2014 try again"); } catch(e){}
+    var msg = (err && (err.message || err.name)) ? (err.name + ': ' + err.message).slice(0, 120) : String(err).slice(0, 120);
+    try { showToast('Sync catch: ' + msg); } catch(e){}
     try { restoreRecordsEhrStatus(); } catch(e){}
   });
 }


### PR DESCRIPTION
Diagnostic-only. DB shows fetchEhrData isn't reaching the function. Surfacing each checkpoint as a toast to identify the bail point without DevTools. Reverts in the next PR.