### PR TITLE
fetch-ehr-data: confidential client refresh via signed client_assertion

### DIFF
--- a/index.html
+++ b/index.html
@@ -12478,11 +12478,10 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     var session = sessionRes.data.session;
     if (!session) {
       console.warn('[EHR] fetchEhrData bail: no session');
-      try { showToast('Sync bail: no session'); } catch(e){}
+      try { showToast('Session expired \u2014 please reload to sign in'); } catch(e){}
       try { restoreRecordsEhrStatus(); } catch(e){}
       return BAILED;
     }
-    try { showToast('Sync: calling function\u2026'); } catch(e){}
     return fetch(SUPABASE_URL + '/functions/v1/fetch-ehr-data', {
       method: 'POST',
       headers: {
@@ -12494,11 +12493,17 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     });
   }).then(function(res) {
     if (res === BAILED) return BAILED;
-    if (!res) {
-      try { showToast('Sync bail: fetch returned no response'); } catch(e){}
-      return null;
+    if (!res) return null;
+    // 401 + error envelope = every connection failed token refresh.
+    // Surface this as a reconnect prompt instead of a generic "couldn't
+    // reach health records" toast — the network is fine, the token isn't.
+    if (res.status === 401) {
+      console.warn('[EHR] fetch-ehr-data 401 \u2014 token refresh failed for all connections');
+      try { showToast('Please reconnect your health records to refresh access'); } catch(e){}
+      try { restoreRecordsEhrStatus(); } catch(e){}
+      try { evaluateReconnectBanner(); } catch(e) {}
+      return BAILED;
     }
-    try { showToast('Sync: HTTP ' + res.status); } catch(e){}
     // A 404 can happen legitimately (no connection) OR transiently right after a
     // successful OAuth callback (Postgres read-after-write lag on a pooled replica).
     // We never wipe the cache on 404 anymore — that caused the UI to show
@@ -12545,9 +12550,8 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     if (data === BAILED) return;
     if (!data || data.error) {
       // PHI log removed
-      console.warn('[EHR] fetchEhrData bail: no data or data.error', data);
-      var why = !data ? 'no data' : ('data.error=' + String(data.error).slice(0,80));
-      try { showToast('Sync bail: ' + why); } catch(e){}
+      console.warn('[EHR] fetchEhrData bail: no data or data.error');
+      try { showToast("Couldn\u2019t reach health records \u2014 try again"); } catch(e){}
       try { restoreRecordsEhrStatus(); } catch(e){}
       return;
     }
@@ -12592,8 +12596,7 @@ function fetchEhrData(personId, navigateToRecords, _retryAttempt) {
     }
   }).catch(function(err) {
     console.error('EHR fetch error:', err);
-    var msg = (err && (err.message || err.name)) ? (err.name + ': ' + err.message).slice(0, 120) : String(err).slice(0, 120);
-    try { showToast('Sync catch: ' + msg); } catch(e){}
+    try { showToast("Couldn\u2019t reach health records \u2014 try again"); } catch(e){}
     try { restoreRecordsEhrStatus(); } catch(e){}
   });
 }

--- a/supabase/functions/fetch-ehr-data/index.ts
+++ b/supabase/functions/fetch-ehr-data/index.ts
@@ -39,6 +39,92 @@ async function getAuthenticatedUser(req: Request) {
   return user;
 }
 
+// ── Epic confidential client config (must match epic-auth) ──────────────────
+// Confidential clients authenticate to Epic's token endpoint using a signed
+// `client_assertion` JWT (RFC 7523) instead of a client_secret. The matching
+// public keys are published at mywellet.com/.well-known/jwks-{prod,nonprod}.json.
+// Connections minted by the legacy public client (a00e2e38…) still refresh
+// with just client_id; everything else uses client_assertion.
+const EPIC_PROD_CLIENT_ID = 'e550b8b1-8a3f-4f56-99e9-4870a616d5ab';
+const EPIC_NONPROD_CLIENT_ID = '6307e012-4778-40ed-bd24-c042b932312e';
+const EPIC_LEGACY_PUBLIC_CLIENT_ID = 'a00e2e38-f814-4946-9b7c-a92901a8aebc';
+const EPIC_PROD_KID = 'wellet-prod-2026-04';
+const EPIC_NONPROD_KID = 'wellet-nonprod-2026-04';
+const EPIC_SANDBOX_FHIR_BASE = 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4';
+
+function base64UrlEncode(buffer: Uint8Array): string {
+  let binary = '';
+  for (const byte of buffer) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlEncodeString(s: string): string {
+  return base64UrlEncode(new TextEncoder().encode(s));
+}
+
+// PKCS#8 PEM → CryptoKey for RS384 signing. Same import path as epic-auth.
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemBody = pem
+    .replace(/-----BEGIN (RSA )?PRIVATE KEY-----/g, '')
+    .replace(/-----END (RSA )?PRIVATE KEY-----/g, '')
+    .replace(/\s+/g, '');
+  if (!pemBody) throw new Error('Empty private key PEM');
+  const der = Uint8Array.from(atob(pemBody), (c) => c.charCodeAt(0));
+  return await crypto.subtle.importKey(
+    'pkcs8',
+    der,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' },
+    false,
+    ['sign'],
+  );
+}
+
+async function loadPrivateKey(pemEnv: string): Promise<CryptoKey> {
+  const pem = Deno.env.get(pemEnv) || '';
+  if (!pem) throw new Error(`Missing Supabase secret: ${pemEnv}`);
+  return await importPrivateKey(pem);
+}
+
+// Build a signed client_assertion JWT for refresh.
+// jti must be unique per request — Epic rejects replays.
+// exp ≤ 5 min — Epic requires this.
+async function buildClientAssertion(
+  tokenUrl: string,
+  clientId: string,
+  kid: string,
+  privateKey: CryptoKey,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS384', typ: 'JWT', kid };
+  const payload = {
+    iss: clientId,
+    sub: clientId,
+    aud: tokenUrl,
+    jti: crypto.randomUUID(),
+    iat: now,
+    exp: now + 300,
+    nbf: now,
+  };
+  const signingInput = `${base64UrlEncodeString(JSON.stringify(header))}.${base64UrlEncodeString(JSON.stringify(payload))}`;
+  const signature = await crypto.subtle.sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+function resolveClientCreds(isSandboxOrNonProd: boolean): {
+  clientId: string;
+  kid: string;
+  pemEnv: string;
+} {
+  if (isSandboxOrNonProd) {
+    return { clientId: EPIC_NONPROD_CLIENT_ID, kid: EPIC_NONPROD_KID, pemEnv: 'EPIC_JWT_PRIVATE_KEY_NONPROD' };
+  }
+  return { clientId: EPIC_PROD_CLIENT_ID, kid: EPIC_PROD_KID, pemEnv: 'EPIC_JWT_PRIVATE_KEY_PROD' };
+}
+
 // Per-resource telemetry captured during a fetch. Each connection maintains
 // its own local telemetry array (see fetchAndPersistOneConnection) so that
 // parallel fan-out calls never interleave their diagnostic data.
@@ -873,12 +959,46 @@ async function refreshAccessTokenIfNeeded(
     return { ok: false, detail: 'decrypt_refresh_failed' };
   }
 
-  // POST to the provider's token endpoint with grant_type=refresh_token
-  const body = new URLSearchParams({
-    grant_type: 'refresh_token',
-    refresh_token: decRefresh as string,
-    client_id: conn.client_id_used as string,
-  });
+  // Build the refresh body. Confidential clients (everything except the
+  // legacy public client) authenticate via a signed client_assertion JWT.
+  // Public clients use just `client_id`. epic-auth's callback path already
+  // does this correctly — we mirror that here so subsequent token refreshes
+  // don't quietly fail and force users into a reconnect loop.
+  const isLegacyPublic = conn.client_id_used === EPIC_LEGACY_PUBLIC_CLIENT_ID;
+  const isSandbox = conn.fhir_base_url === EPIC_SANDBOX_FHIR_BASE;
+
+  let body: URLSearchParams;
+  if (isLegacyPublic) {
+    body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: decRefresh as string,
+      client_id: EPIC_LEGACY_PUBLIC_CLIENT_ID,
+    });
+  } else {
+    let clientAssertion: string;
+    try {
+      const creds = resolveClientCreds(isSandbox);
+      const privateKey = await loadPrivateKey(creds.pemEnv);
+      clientAssertion = await buildClientAssertion(
+        conn.token_url as string,
+        creds.clientId,
+        creds.kid,
+        privateKey,
+      );
+    } catch (e) {
+      console.error('[fetch-ehr-data] refresh client_assertion build failed', {
+        err: (e as Error).message,
+        conn_id: conn.id,
+      });
+      return { ok: false, detail: 'client_assertion_failed' };
+    }
+    body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: decRefresh as string,
+      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion: clientAssertion,
+    });
+  }
 
   const res = await fetch(conn.token_url as string, {
     method: 'POST',


### PR DESCRIPTION
## The real bug behind the stuck Sync now spinner

Mom's Duke access token expired at 4:34 PM EDT today. `fetch-ehr-data` tried to refresh it inline using public-client semantics (just `client_id`), but the connection was minted with the Confidential Epic client which Epic requires to authenticate via a signed `client_assertion` JWT (RFC 7523) — same as the OAuth code exchange.

Duke's `/token` rejected the unauthenticated refresh, `fetch-ehr-data` set `needs_reconnect=true` and returned 401 with `{ error: 'Token refresh failed for all connections...' }`. The client saw `data.error` and showed the misleading "Couldn't reach health records" toast.

`epic-auth`'s callback path already does confidential client_assertion correctly. `fetch-ehr-data`'s inline refresh never got the same treatment.

## What changes

**Server (fetch-ehr-data, deployed as v57):**
- New JWT helpers (importPrivateKey, buildClientAssertion, base64Url helpers, resolveClientCreds) + Epic constants matching `epic-auth`.
- In `refreshAccessTokenIfNeeded()`, branch on `client_id_used`:
  - Legacy public client → public-client refresh (unchanged, supports the 1 holdover user)
  - Everything else (including Mom's Confidential Duke connection) → sign client_assertion JWT and POST as RFC 7523 token exchange.
- Reuses the same `EPIC_JWT_PRIVATE_KEY_PROD` secret epic-auth already uses.

**Frontend (index.html):**
- Revert the temporary diagnostic toasts from PR #87.
- Add a 401-aware path: when fetch-ehr-data returns 401, show "Please reconnect your health records to refresh access" and surface the reconnect banner instead of the generic toast.

## Verification plan
1. After Netlify deploys this PR, hard-reload mywellet.com and tap Sync now on Mom's chart.
2. Expected: refresh succeeds transparently, fresh access token mints, FHIR fetch runs, "Health records updated" toast.
3. New row appears in `ehr_sync_log` for Mom's Duke chart.
4. `token_expires_at` advances to ~1 hour from now.

## Risk
If `EPIC_JWT_PRIVATE_KEY_PROD` is missing or wrong → new refresh path returns `client_assertion_failed` → existing `needs_reconnect` prompt path. Same blast radius as today. epic-auth uses the same secret, so we know it's set.

## Reversible
Redeploy fetch-ehr-data v55 from HEAD~1, revert this PR.