### PR TITLE
Picker: gate to 15 activated Epic orgs + ship pending Netlify config

### DIFF
--- a/.netlify/netlify.toml
+++ b/.netlify/netlify.toml
@@ -1,13 +1,11 @@
 plugins = []
-headers = []
-redirects = []
 
 [functions]
 
 [functions."*"]
 
 [build]
-publish = "/home/user/workspace/wellet-deploy"
+publish = "/home/user/workspace/wellet-app-repo"
 publishOrigin = "default"
 
 [build.environment]
@@ -23,3 +21,111 @@ publishOrigin = "default"
 [build.processing.js]
 
 [build.services]
+
+[[headers]]
+for = "/*"
+
+[headers.values]
+Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://api.perplexity.ai https://api.tryterra.co https://fhir.epic.com https://open.epic.com https://*.epic.com wss://*.supabase.co; img-src 'self' data: blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+X-Frame-Options = "DENY"
+X-Content-Type-Options = "nosniff"
+Referrer-Policy = "strict-origin-when-cross-origin"
+Permissions-Policy = "camera=(), microphone=(self), geolocation=()"
+
+[[headers]]
+for = "/.well-known/jwks-prod.json"
+
+[headers.values]
+Content-Type = "application/json"
+Cache-Control = "public, max-age=300"
+
+[[headers]]
+for = "/.well-known/jwks-nonprod.json"
+
+[headers.values]
+Content-Type = "application/json"
+Cache-Control = "public, max-age=300"
+
+[[redirects]]
+from = "/epic-callback"
+to = "/index.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/share.html"
+to = "/share.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/privacy"
+to = "/privacy.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/terms"
+to = "/terms.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/how-it-works"
+to = "/how-it-works.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/your-data"
+to = "/your-data.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]
+
+[[redirects]]
+from = "/*"
+to = "/index.html"
+status = 200.0
+force = false
+
+[redirects.query]
+
+[redirects.conditions]
+
+[redirects.headers]

--- a/index.html
+++ b/index.html
@@ -11908,10 +11908,53 @@ var _epicEndpoints = null;
 var _epicEndpointsCachedAt = 0;
 var _hospitalPickerDebounce = null;
 
+// Allow-list of FHIR base URLs for orgs where Wellet's confidential client is
+// activated. Picker only shows these so users don't hit Epic's OAuth2 Error
+// at unactivated orgs. URLs are normalized (lowercased, trailing slash stripped)
+// before comparison since Epic's endpoint list is inconsistent.
+var ACTIVATED_FHIR_URLS = [
+  // NC Tier 1 (Mom's likely care network)
+  'https://epsoap.conehealth.com/FHIRProxy/api/FHIR/R4',                              // Cone Health
+  'https://health-apis.duke.edu/FHIR/api/FHIR/R4',                                    // Duke Health
+  'https://epicrp.firsthealth.org/FHIR-PRD/FHMYCHART/api/FHIR/R4',                    // FirstHealth of the Carolinas
+  'https://epicproxy.et0798.epichosted.com/APIProxyPRD/api/FHIR/R4',                  // Novant
+  'https://epicfe.unch.unc.edu/FHIR/api/FHIR/R4',                                     // UNC Health Care
+  'https://epic-soap.wakemed.org/FHIR/api/FHIR/R4',                                   // WakeMed
+  'https://epicproxy.et0905.epichosted.com/FHIRProxy/api/FHIR/R4',                    // Atrium Health
+  'https://spp.caromonthealth.org/FhirProxy/CAROMONT/api/FHIR/R4',                    // CaroMont Health
+  'https://prd-proxy.vidanthealth.com/FHIR/api/FHIR/R4',                              // ECU Health
+  'https://epicproxy.et1385.epichosted.com/FHIRProxyPRD/CarolinaEast/api/FHIR/R4',    // CarolinaEast Health System
+  // National anchors
+  'https://api.ccf.org/mu/api/FHIR/R4',                                               // Cleveland Clinic
+  'https://ws-interconnect-fhir.partners.org/Interconnect-FHIR-MU-PRD/api/FHIR/R4',   // Mass General Brigham
+  'https://tls.mcc.apix.mayo.edu/epic-fhir/api/FHIR/R4',                              // Mayo Clinic
+  'https://unified-api.ucsf.edu/clinical/apex/UCSF/api/FHIR/R4',                      // UCSF
+  'https://fhir.kp.org/service/ptnt_care/EpicEdiFhirRoutingSvc/v2014/esb-envlbl/226/api/FHIR/R4' // Kaiser Permanente - Southern California
+];
+
+function _normFhirUrl(u) {
+  if (!u) return '';
+  return String(u).toLowerCase().replace(/\/+$/, '');
+}
+
+var _ACTIVATED_FHIR_SET = (function() {
+  var s = {};
+  for (var i = 0; i < ACTIVATED_FHIR_URLS.length; i++) {
+    s[_normFhirUrl(ACTIVATED_FHIR_URLS[i])] = true;
+  }
+  return s;
+})();
+
+function isActivatedHospital(fhirBaseUrl) {
+  return !!_ACTIVATED_FHIR_SET[_normFhirUrl(fhirBaseUrl)];
+}
+
 // Load Epic endpoint list from open.epic.com (cached 24h in localStorage)
 function loadEpicEndpoints(cb) {
-  var CACHE_KEY = 'wellet_epic_endpoints';
-  var CACHE_TS_KEY = 'wellet_epic_endpoints_ts';
+  // Bump v when ACTIVATED_FHIR_URLS changes so existing users don't see
+  // a stale unfiltered list from localStorage.
+  var CACHE_KEY = 'wellet_epic_endpoints_v2';
+  var CACHE_TS_KEY = 'wellet_epic_endpoints_v2_ts';
   var CACHE_TTL = 24 * 60 * 60 * 1000;
 
   // Check in-memory cache first
@@ -11945,7 +11988,11 @@ function loadEpicEndpoints(cb) {
           city: e.City || '',
           state: e.State || ''
         };
-      }).filter(function(e) { return e.name && e.fhirBaseUrl; });
+      }).filter(function(e) {
+        // Drop entries missing required fields, then gate by activation allow-list
+        // so users only see hospitals where our confidential client is enabled.
+        return e.name && e.fhirBaseUrl && isActivatedHospital(e.fhirBaseUrl);
+      });
 
       _epicEndpoints = endpoints;
       _epicEndpointsCachedAt = Date.now();


### PR DESCRIPTION
## What

**Picker (`index.html`)**
- Add `ACTIVATED_FHIR_URLS` allow-list of 15 FHIR base URLs where Wellet's Confidential client is enabled (10 NC Tier 1 + 5 national anchors).
- Add `_normFhirUrl()` (lowercase + strip trailing slash) so Epic's inconsistent endpoint formatting can't slip through.
- Add `_ACTIVATED_FHIR_SET` map and `isActivatedHospital()` helper.
- Wire the gate into `loadEpicEndpoints().filter()` so the picker only shows hospitals where OAuth will succeed.
- Bump cache key to `wellet_epic_endpoints_v2` so existing users don't see a stale unfiltered list from localStorage.
- The 'Can't find your hospital? Let us know' link already routes to the existing CR modal that POSTs to `submit-connect-request`, so demand capture for unactivated orgs is already wired.

**Netlify config (`.netlify/netlify.toml`)**
- Add Content-Security-Policy + X-Frame-Options + X-Content-Type-Options + Referrer-Policy + Permissions-Policy headers.
- Add JWKS routes (`/.well-known/jwks-prod.json` + `jwks-nonprod.json`) for the Epic Confidential client.
- Add SPA redirects (`/epic-callback`, `/privacy`, `/how-it-works`, `/your-data`, catch-all).
- Update publish path to `wellet-app-repo` (was `wellet-deploy`).

## Why

The full Epic endpoint list has 1,193 orgs. Sending users to non-activated orgs causes Epic OAuth2 errors and a dead-end UX. Gating to the 15 we've activated keeps the connect flow successful while we capture demand for the rest via the existing 'Can't find your hospital' form.

## Sanity

`node --check` on extracted inline JS passes.

## Activated orgs (15)

NC Tier 1: UNC, Cone Health, Duke, FirstHealth, Novant, WakeMed, Atrium, CaroMont, ECU Health, CarolinaEast.
National anchors: Mass General Brigham, Cleveland Clinic, Mayo Clinic, UCSF, Kaiser Permanente Southern California.