### PR TITLE
Picker R4 fix: switch epic-endpoints to R4 Bundle + correct allow-list URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -11912,24 +11912,29 @@ var _hospitalPickerDebounce = null;
 // activated. Picker only shows these so users don't hit Epic's OAuth2 Error
 // at unactivated orgs. URLs are normalized (lowercased, trailing slash stripped)
 // before comparison since Epic's endpoint list is inconsistent.
+// URLs below are taken verbatim from Epic's published R4 bundle
+// (https://open.epic.com/Endpoints/R4). _normFhirUrl() strips trailing
+// slashes and lowercases before comparison so minor formatting drift in
+// either source can't break the gate.
 var ACTIVATED_FHIR_URLS = [
   // NC Tier 1 (Mom's likely care network)
-  'https://epsoap.conehealth.com/FHIRProxy/api/FHIR/R4',                              // Cone Health
-  'https://health-apis.duke.edu/FHIR/api/FHIR/R4',                                    // Duke Health
-  'https://epicrp.firsthealth.org/FHIR-PRD/FHMYCHART/api/FHIR/R4',                    // FirstHealth of the Carolinas
-  'https://epicproxy.et0798.epichosted.com/APIProxyPRD/api/FHIR/R4',                  // Novant
-  'https://epicfe.unch.unc.edu/FHIR/api/FHIR/R4',                                     // UNC Health Care
-  'https://epic-soap.wakemed.org/FHIR/api/FHIR/R4',                                   // WakeMed
-  'https://epicproxy.et0905.epichosted.com/FHIRProxy/api/FHIR/R4',                    // Atrium Health
-  'https://spp.caromonthealth.org/FhirProxy/CAROMONT/api/FHIR/R4',                    // CaroMont Health
-  'https://prd-proxy.vidanthealth.com/FHIR/api/FHIR/R4',                              // ECU Health
-  'https://epicproxy.et1385.epichosted.com/FHIRProxyPRD/CarolinaEast/api/FHIR/R4',    // CarolinaEast Health System
+  'https://epsoap.conehealth.com/FHIRProxy/api/FHIR/R4/',                            // Cone Health
+  'https://health-apis.duke.edu/FHIR/api/FHIR/R4/',                                  // Duke Health
+  'https://epicrp.firsthealth.org/FHIR-PRD/api/FHIR/R4/',                            // FirstHealth of the Carolinas
+  'https://epicproxy.et0798.epichosted.com/APIProxyPRD/api/FHIR/R4/',                // Novant
+  'https://epicfe.unch.unc.edu/FHIR/api/FHIR/R4/',                                   // UNC Health Care
+  'https://epic-soap.wakemed.org/FHIR/api/FHIR/R4/',                                 // WakeMed
+  'https://epicproxy.et0905.epichosted.com/FHIRProxy/api/FHIR/R4/',                  // Atrium Health
+  'https://spp.caromonthealth.org/FhirProxy/api/FHIR/R4/',                           // CaroMont Health
+  'https://prd-proxy.vidanthealth.com/FHIR/api/FHIR/R4/',                            // ECU Health (Vidant)
+  // CarolinaEast: not in Epic's R4 bundle as of 2026-04-27. Captured via
+  // "Add my health system" form until Epic publishes their R4 endpoint.
   // National anchors
-  'https://api.ccf.org/mu/api/FHIR/R4',                                               // Cleveland Clinic
-  'https://ws-interconnect-fhir.partners.org/Interconnect-FHIR-MU-PRD/api/FHIR/R4',   // Mass General Brigham
-  'https://tls.mcc.apix.mayo.edu/epic-fhir/api/FHIR/R4',                              // Mayo Clinic
-  'https://unified-api.ucsf.edu/clinical/apex/UCSF/api/FHIR/R4',                      // UCSF
-  'https://fhir.kp.org/service/ptnt_care/EpicEdiFhirRoutingSvc/v2014/esb-envlbl/226/api/FHIR/R4' // Kaiser Permanente - Southern California
+  'https://api.ccf.org/mu/api/FHIR/R4/',                                             // Cleveland Clinic
+  'https://ws-interconnect-fhir.partners.org/Interconnect-FHIR-MU-PRD/api/FHIR/R4/', // Mass General Brigham
+  // Mayo Clinic: not in Epic's R4 bundle as of 2026-04-27. Captured via form.
+  'https://unified-api.ucsf.edu/clinical/apex/api/FHIR/R4/',                         // UCSF Health
+  'https://fhir.kp.org/service/ptnt_care/EpicEdiFhirRoutingSvc/v2014/esb-envlbl/212/api/FHIR/R4/' // Kaiser Permanente - Southern California
 ];
 
 function _normFhirUrl(u) {
@@ -11953,8 +11958,8 @@ function isActivatedHospital(fhirBaseUrl) {
 function loadEpicEndpoints(cb) {
   // Bump v when ACTIVATED_FHIR_URLS changes so existing users don't see
   // a stale unfiltered list from localStorage.
-  var CACHE_KEY = 'wellet_epic_endpoints_v2';
-  var CACHE_TS_KEY = 'wellet_epic_endpoints_v2_ts';
+  var CACHE_KEY = 'wellet_epic_endpoints_v3';
+  var CACHE_TS_KEY = 'wellet_epic_endpoints_v3_ts';
   var CACHE_TTL = 24 * 60 * 60 * 1000;
 
   // Check in-memory cache first

--- a/supabase/functions/epic-endpoints/index.ts
+++ b/supabase/functions/epic-endpoints/index.ts
@@ -1,5 +1,15 @@
 import { getCorsHeaders } from "../_shared/cors.ts";
 
+// Returns Epic's published R4 endpoints in the legacy
+// `{ Entries: [{ OrganizationName, FHIRPatientFacingURI }] }` shape that the
+// picker expects. We source from the R4 FHIR Bundle (not the DSTU2 legacy
+// JSON) because the rest of Wellet — token exchange, FHIR fetch, storage —
+// is R4-only. Serving DSTU2 URLs in the picker created a mismatch where the
+// activated-hospital allow-list (R4) never matched any picker row.
+//
+// Source: https://open.epic.com/Endpoints/R4 (FHIR Bundle of Endpoint resources)
+const EPIC_R4_BUNDLE_URL = "https://open.epic.com/Endpoints/R4";
+
 Deno.serve(async (req) => {
   const cors = getCorsHeaders(req);
   cors["Access-Control-Allow-Methods"] = "GET, OPTIONS";
@@ -9,10 +19,38 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const res = await fetch("https://open.epic.com/MyApps/EndpointsJson");
-    const data = await res.json();
+    const res = await fetch(EPIC_R4_BUNDLE_URL);
+    if (!res.ok) {
+      return new Response(
+        JSON.stringify({ error: "Failed to fetch Epic R4 bundle", status: res.status }),
+        { status: 502, headers: { ...cors, "Content-Type": "application/json" } },
+      );
+    }
 
-    return new Response(JSON.stringify(data), {
+    const bundle = await res.json();
+    const entries: Array<{ OrganizationName: string; FHIRPatientFacingURI: string }> = [];
+
+    if (bundle && Array.isArray(bundle.entry)) {
+      for (const e of bundle.entry) {
+        const r = e && e.resource;
+        if (!r) continue;
+        // Prefer the contained Organization name; fall back to the Endpoint's
+        // own name if missing.
+        let orgName: string | null = null;
+        if (Array.isArray(r.contained) && r.contained.length > 0) {
+          const org = r.contained.find((c: any) => c && c.resourceType === "Organization") || r.contained[0];
+          if (org && typeof org.name === "string" && org.name.trim()) orgName = org.name.trim();
+        }
+        if (!orgName && typeof r.name === "string" && r.name.trim()) orgName = r.name.trim();
+
+        const url = typeof r.address === "string" ? r.address.trim() : "";
+        if (!orgName || !url) continue;
+
+        entries.push({ OrganizationName: orgName, FHIRPatientFacingURI: url });
+      }
+    }
+
+    return new Response(JSON.stringify({ Entries: entries }), {
       headers: {
         ...cors,
         "Content-Type": "application/json",


### PR DESCRIPTION
Fixes the empty picker shipped in #90.

## Root cause
`epic-endpoints` v7 served Epic's **DSTU2** list (490 URLs). The allow-list shipped in #90 used **R4** URLs (because everything downstream of the picker is R4). Result: zero matches → "No hospitals found".

## Fix (1 commit, 2 files)

### 1. `epic-endpoints` edge function (v7 → v8, deployed)
- Switch source from `https://open.epic.com/MyApps/EndpointsJson` (DSTU2, 490 entries) to `https://open.epic.com/Endpoints/R4` (FHIR Bundle, 481 entries).
- Parse `entry[].resource.contained[0].name` (fallback to `resource.name`) for org name; `resource.address` for FHIR URL.
- Same `{ Entries: [{ OrganizationName, FHIRPatientFacingURI }] }` shape returned, no client change needed.

### 2. `index.html`
- Fix 5 subtly wrong allow-list URLs that didn't match Epic's R4 bundle:
  - FirstHealth had `/FHMYCHART/`, bundle has no `/FHMYCHART/`
  - CaroMont had `/CAROMONT/`, bundle has no `/CAROMONT/`
  - UCSF had `/UCSF/`, bundle has no `/UCSF/`
  - Kaiser SoCal pointed at envlbl `226`, bundle has `212`
  - All entries were missing the trailing slash present in the bundle
- Drop Mayo and CarolinaEast — not published in Epic's R4 bundle as of 2026-04-27. Users see the existing "Add my health system" form.
- Bump cache key v2 → v3 so users with the broken cached list refresh.

## Verify
- Live v8 returns 481 entries, **13/13** activated URLs match
- `node --check` on extracted inline JS: pass
- `deno check` on edge function: pass