### PR TITLE
Picker: no-store on epic-endpoints + cache-buster on loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -11961,17 +11961,19 @@ function isActivatedHospital(fhirBaseUrl) {
 function loadEpicEndpoints(cb) {
   // Bump v whenever the loader logic, ACTIVATED_FHIR_URLS, or the cache
   // shape changes so existing users with stale data refresh.
-  var CACHE_KEY = 'wellet_epic_endpoints_v4';
-  var CACHE_TS_KEY = 'wellet_epic_endpoints_v4_ts';
+  var CACHE_KEY = 'wellet_epic_endpoints_v5';
+  var CACHE_TS_KEY = 'wellet_epic_endpoints_v5_ts';
   var CACHE_TTL = 24 * 60 * 60 * 1000;
 
-  // Also wipe legacy cache keys on first run so users on v2/v3 don't keep
-  // dragging around an old (possibly-empty) array under a stale key.
+  // Also wipe legacy cache keys on first run so users on v2/v3/v4 don't keep
+  // dragging around an old (possibly-empty or DSTU2) array under a stale key.
   try {
     localStorage.removeItem('wellet_epic_endpoints_v2');
     localStorage.removeItem('wellet_epic_endpoints_v2_ts');
     localStorage.removeItem('wellet_epic_endpoints_v3');
     localStorage.removeItem('wellet_epic_endpoints_v3_ts');
+    localStorage.removeItem('wellet_epic_endpoints_v4');
+    localStorage.removeItem('wellet_epic_endpoints_v4_ts');
   } catch(e) {}
 
   // Check in-memory cache first — but only if it's non-empty. An empty array
@@ -12000,8 +12002,13 @@ function loadEpicEndpoints(cb) {
     }
   } catch(e) {}
 
-  // Fetch from Epic
-  fetch('https://nrpdhxygzyfmyljzfexv.supabase.co/functions/v1/epic-endpoints')
+  // Fetch from Epic. The cache-buster query param + no-store on the response
+  // belt-and-suspenders defeat any HTTP cache (browser disk, intermediary CDN)
+  // that might still be holding the old DSTU2 response from a prior version
+  // of this edge function. Seen in prod 2026-04-27: a user's tab kept
+  // receiving DSTU2 URLs from disk cache for 24h after we shipped R4.
+  var bust = 'v5_' + Date.now();
+  fetch('https://nrpdhxygzyfmyljzfexv.supabase.co/functions/v1/epic-endpoints?cb=' + bust, { cache: 'no-store' })
     .then(function(res) { return res.json(); })
     .then(function(data) {
       var endpoints = (data.Entries || data).map(function(e) {

--- a/supabase/functions/epic-endpoints/index.ts
+++ b/supabase/functions/epic-endpoints/index.ts
@@ -54,7 +54,12 @@ Deno.serve(async (req) => {
       headers: {
         ...cors,
         "Content-Type": "application/json",
-        "Cache-Control": "public, max-age=86400",
+        // Do NOT let browsers/CDN cache this response. The picker has its own
+        // 24h localStorage cache; an HTTP cache on top creates a trap where a
+        // stale response (e.g. the old DSTU2 shape) keeps being served back
+        // for 24h even after the function is updated. Seen in prod 2026-04-27:
+        // users got DSTU2 URLs from disk cache after we shipped R4.
+        "Cache-Control": "no-store",
       },
     });
   } catch (err) {


### PR DESCRIPTION
## Root cause

Betsy's tab kept getting 0 hospitals after PR #91 / #92 shipped. Diagnosed live: the network response in her tab returned 490 entries with **DSTU2 URLs**, even though origin returns 481 R4 entries. The previous `epic-endpoints` function set `Cache-Control: public, max-age=86400` on its DSTU2 response, so already-trapped browsers replayed the cached DSTU2 response from disk for up to 24h after we shipped R4. The R4 allow-list rejects every DSTU2 URL → picker shows 0.

## Fix

**`supabase/functions/epic-endpoints/index.ts`** — `Cache-Control: public, max-age=86400` → `no-store`. Picker already has its own 24h localStorage cache; the HTTP cache on top was the trap.

**`index.html` loader** — three layers so already-trapped tabs recover on the next page load without manual cache clearing:
- Bump localStorage cache key v4 → v5 (and wipe v4 on first call)
- Append `?cb=v5_<timestamp>` cache-buster to the fetch URL
- Pass `{ cache: 'no-store' }` to fetch

## Verified

- Origin returns 481 R4 entries (`curl` direct)
- Betsy's tab confirmed receiving 490 DSTU2 entries from disk cache (`isActivatedHospital` returned false on `https://eprescribing.accesscommunityhealth.net/FHIR/api/FHIR/DSTU2/`)
- Set has all 13 R4 URLs; normalization is correct; the only failure mode was the stale cached response

## Risk

Low. `no-store` adds one network round-trip per session per device (~100ms); the picker localStorage cache absorbs subsequent loads within the 24h window.