### PR TITLE
Wellet Connect: short invite codes (alias for invite_token)

### DIFF
--- a/supabase/functions/care-circle-invite/index.ts
+++ b/supabase/functions/care-circle-invite/index.ts
@@ -15,7 +15,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const { action, member_id, invite_token } = await req.json()
+    const { action, member_id, invite_token, short_code } = await req.json()
     const supabase = createClient(supabaseUrl, serviceKey)
 
     // ── CREATE: Generate invite token and return invite link ──
@@ -69,18 +69,31 @@ Deno.serve(async (req) => {
         })
       }
 
-      // Generate a unique invite token
+      // Generate a unique invite token (long, used in invite links)
       const token = crypto.randomUUID()
 
+      // Generate a 6-char short code (used by Wellet Connect Flutter app).
+      // Best-effort: if the RPC isn't available yet (pre-migration), we
+      // continue without a short code rather than failing the whole invite.
+      let shortCode: string | null = null
+      const { data: shortCodeData, error: shortCodeErr } = await supabase
+        .rpc('generate_short_invite_code')
+      if (!shortCodeErr && typeof shortCodeData === 'string') {
+        shortCode = shortCodeData
+      }
+
       // Update the member record with invite info
+      const updatePayload: Record<string, unknown> = {
+        invite_token: token,
+        invited_at: new Date().toISOString(),
+        invited_by: user.id,
+        invite_status: 'invited',
+      }
+      if (shortCode) updatePayload.invite_short_code = shortCode
+
       const { error: updateErr } = await supabase
         .from('care_circle_members')
-        .update({
-          invite_token: token,
-          invited_at: new Date().toISOString(),
-          invited_by: user.id,
-          invite_status: 'invited',
-        })
+        .update(updatePayload)
         .eq('id', member_id)
 
       if (updateErr) {
@@ -95,6 +108,7 @@ Deno.serve(async (req) => {
       return new Response(JSON.stringify({
         success: true,
         invite_link: inviteLink,
+        short_code: shortCode,
         person_name: member.people.name,
         member_name: member.member_name,
         member_email: member.email,
@@ -104,18 +118,29 @@ Deno.serve(async (req) => {
     }
 
     // ── LOOKUP: Public lookup of invite metadata (no auth needed) ──
-    if (action === 'lookup') {
-      if (!invite_token) {
-        return new Response(JSON.stringify({ error: 'invite_token required' }), {
+    // Accepts either invite_token (UUID, from invite link) or
+    // short_code (6-char A-Z/2-9, from Wellet Connect Flutter app).
+    if (action === 'lookup' || action === 'lookup_short_code') {
+      const isShortCode = action === 'lookup_short_code' || (!invite_token && short_code)
+      const lookupValue = isShortCode
+        ? (short_code ? String(short_code).trim().toUpperCase() : null)
+        : invite_token
+
+      if (!lookupValue) {
+        return new Response(JSON.stringify({
+          error: isShortCode ? 'short_code required' : 'invite_token required',
+        }), {
           status: 400,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         })
       }
 
+      const lookupColumn = isShortCode ? 'invite_short_code' : 'invite_token'
+
       const { data: member, error: lookupErr } = await supabase
         .from('care_circle_members')
-        .select('member_name, role, email, invite_status, invited_by, people!inner(name)')
-        .eq('invite_token', invite_token)
+        .select('member_name, role, email, invite_status, invited_by, invite_token, people!inner(name)')
+        .eq(lookupColumn, lookupValue)
         .single()
 
       if (lookupErr || !member) {
@@ -147,12 +172,16 @@ Deno.serve(async (req) => {
         member_name: member.member_name,
         member_role: member.role,
         inviter_name: inviterName,
+        // Returned only on short-code lookups so Flutter can call accept
+        // with the canonical token afterward.
+        invite_token: isShortCode ? member.invite_token : undefined,
       }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       })
     }
 
     // ── ACCEPT: Link the authenticated user to the member record ──
+    // Accepts either invite_token (UUID) or short_code (6-char).
     if (action === 'accept') {
       const authHeader = req.headers.get('Authorization')
       if (!authHeader) {
@@ -173,18 +202,23 @@ Deno.serve(async (req) => {
         })
       }
 
-      if (!invite_token) {
-        return new Response(JSON.stringify({ error: 'invite_token required' }), {
+      if (!invite_token && !short_code) {
+        return new Response(JSON.stringify({ error: 'invite_token or short_code required' }), {
           status: 400,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         })
       }
 
-      // Find the member record by token
+      // Find the member record by either token or short code
+      const acceptColumn = invite_token ? 'invite_token' : 'invite_short_code'
+      const acceptValue = invite_token
+        ? invite_token
+        : String(short_code).trim().toUpperCase()
+
       const { data: member, error: findErr } = await supabase
         .from('care_circle_members')
         .select('id, invite_status, person_id')
-        .eq('invite_token', invite_token)
+        .eq(acceptColumn, acceptValue)
         .single()
 
       if (findErr || !member) {

--- a/supabase/migrations/20260427210000_add_short_invite_code.sql
+++ b/supabase/migrations/20260427210000_add_short_invite_code.sql
@@ -1,0 +1,48 @@
+-- Add short alphanumeric invite codes to care_circle_members.
+-- Short codes are an alias for the existing invite_token (UUID), used by the
+-- Wellet Connect Flutter app where typing a 6-char code is friendlier than
+-- pasting a deep link. Both the long invite_token and the short_code resolve
+-- to the same member row via the care-circle-invite edge function.
+
+ALTER TABLE care_circle_members
+  ADD COLUMN IF NOT EXISTS invite_short_code text UNIQUE;
+
+CREATE INDEX IF NOT EXISTS idx_care_circle_invite_short_code
+  ON care_circle_members(invite_short_code)
+  WHERE invite_short_code IS NOT NULL;
+
+-- Generate a 6-char A-Z/2-9 code, excluding ambiguous chars (0,O,1,I,L).
+-- Retries on collision up to 5 times. Uses gen_random_bytes for entropy.
+CREATE OR REPLACE FUNCTION generate_short_invite_code() RETURNS text AS $$
+DECLARE
+  alphabet text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  alphabet_len int := length(alphabet);
+  code text;
+  attempt int := 0;
+  exists_already boolean;
+BEGIN
+  LOOP
+    code := '';
+    FOR i IN 1..6 LOOP
+      code := code || substr(
+        alphabet,
+        (get_byte(gen_random_bytes(1), 0) % alphabet_len) + 1,
+        1
+      );
+    END LOOP;
+
+    SELECT EXISTS (
+      SELECT 1 FROM care_circle_members WHERE invite_short_code = code
+    ) INTO exists_already;
+
+    IF NOT exists_already THEN
+      RETURN code;
+    END IF;
+
+    attempt := attempt + 1;
+    IF attempt > 5 THEN
+      RAISE EXCEPTION 'Could not generate unique short invite code after 5 attempts';
+    END IF;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql VOLATILE;


### PR DESCRIPTION
## What

Adds 6-char short invite codes as an alias for the existing UUID `invite_token` on `care_circle_members`. Both resolve to the same member row through the `care-circle-invite` edge function.

## Why

Wellet Connect (Flutter care-recipient app) onboarding asks for a 6-char code, not a UUID link. Rather than building a parallel `care_circle_invites` table (Flutter's original assumption), this aliases short codes onto the production `invite_token` already in `care_circle_members`.

## Changes

- **Migration** `20260427210000_add_short_invite_code.sql`
  - `care_circle_members.invite_short_code text UNIQUE` + partial index
  - `generate_short_invite_code()` PL/pgSQL function (6 chars from `ABCDEFGHJKMNPQRSTUVWXYZ23456789`, no ambiguous chars, retries on collision)
- **Edge function** `care-circle-invite`
  - `create`: now also issues a `short_code` alongside `invite_link` (best-effort — won't fail invite if RPC missing)
  - `lookup_short_code` (new): public lookup by 6-char code, returns same payload as `lookup` plus the canonical `invite_token`
  - `accept`: now accepts either `invite_token` OR `short_code`
  - **Backward compatible** — existing web app `lookup`/`accept` flows untouched

## Deploy state

- ✅ Migration applied to prod
- ✅ Edge function v15 deployed (verify_jwt=false preserved)
- ✅ Smoke tested: unknown codes → 404, missing fields → 400, existing token lookup still works

## Flutter side (separate, not in this PR)

`wellet-connect-0eb6ed96/lib/models/person.dart` and `lib/services/pairing_service.dart` updated locally to call `lookup_short_code` + `accept`. The Flutter project is not yet in git.