### PR TITLE
editorial: PR 7 — ER summary editorial treatment

### DIFF
--- a/assets/editorial-er.css
+++ b/assets/editorial-er.css
@@ -1,0 +1,322 @@
+/* ============================================================
+   editorial-er.css — PR 7
+   ER summary editorial treatment.
+
+   This is the ONE place the editorial system intentionally breaks
+   the linen palette: the ER sheet is full-screen WHITE so a panicked
+   spouse, an EMT under fluorescent light, or a triage nurse can
+   read it at a glance. Everything else still follows the linen +
+   eight-gray ladder + Fraunces editorial DNA — no red, no clinical
+   crimson, no scary alert chrome.
+
+   Trigger surfaces:
+   - long-press on the masthead wordmark (preferred — primitive #7)
+   - the existing "Emergency summary" QA button + header menu item
+   ============================================================ */
+
+/* ---- Overlay shell ---- */
+[data-editorial="er-sheet"].er-overlay {
+  background: #FFFFFF !important;          /* the only white surface in the app */
+  z-index: 9000;
+}
+[data-editorial="er-sheet"] .er-container {
+  max-width: 760px;
+  height: 100%;
+  background: #FFFFFF;
+  overflow-y: auto;
+}
+
+/* ---- Header (was crimson bar) ---- */
+[data-editorial="er-sheet"] .er-header {
+  background: #FFFFFF !important;
+  color: var(--ink-9) !important;
+  padding: 22px 24px 16px !important;
+  border-bottom: 1px solid var(--ink-1, #E8E2D6);
+  align-items: flex-start !important;
+}
+[data-editorial="er-sheet"] .er-header-left {
+  gap: 12px !important;
+  align-items: center;
+}
+[data-editorial="er-sheet"] .er-header-left > i,
+[data-editorial="er-sheet"] .er-header-left > svg,
+[data-editorial="er-sheet"] .er-header-left [data-lucide] {
+  color: var(--signal-warm, #B8835A) !important;
+  width: 18px !important;
+  height: 18px !important;
+  stroke-width: 1.6;
+}
+[data-editorial="er-sheet"] .er-header-title {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 22px !important;
+  font-weight: 500 !important;
+  letter-spacing: -0.005em !important;
+  line-height: 1.15 !important;
+  color: var(--ink-9) !important;
+  font-variation-settings: "opsz" 36, "SOFT" 60 !important;
+}
+
+/* refresh + close glyphs */
+[data-editorial="er-sheet"] .er-close-btn {
+  background: transparent !important;
+  border: 0 !important;
+  color: var(--ink-5) !important;
+  width: 38px !important;
+  height: 38px !important;
+  min-width: 38px !important;
+  min-height: 38px !important;
+  border-radius: 0 !important;
+  transition: color 0.15s ease;
+  box-shadow: none !important;
+}
+[data-editorial="er-sheet"] .er-close-btn:hover {
+  background: transparent !important;
+  color: var(--ink-9) !important;
+}
+[data-editorial="er-sheet"] .er-close-btn:focus { outline: none; }
+[data-editorial="er-sheet"] .er-close-btn:focus-visible {
+  outline: 1px solid var(--ink-3);
+  outline-offset: 2px;
+}
+[data-editorial="er-sheet"] .er-close-btn svg,
+[data-editorial="er-sheet"] .er-close-btn i {
+  width: 20px !important;
+  height: 20px !important;
+  stroke-width: 1.6;
+}
+
+/* ---- Patient banner (was pink with crimson rule) ---- */
+[data-editorial="er-sheet"] .er-patient-banner {
+  background: #FFFFFF !important;
+  border-bottom: 1px solid var(--ink-1, #E8E2D6) !important;
+  padding: 24px !important;
+}
+[data-editorial="er-sheet"] .er-patient-name {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 36px !important;
+  font-weight: 400 !important;
+  letter-spacing: -0.01em !important;
+  line-height: 1.05 !important;
+  color: var(--ink-9) !important;
+  margin-bottom: 6px !important;
+  font-variation-settings: "opsz" 36, "SOFT" 60 !important;
+}
+[data-editorial="er-sheet"] .er-patient-dob {
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 300 !important;
+  font-size: 14px !important;
+  color: var(--ink-6) !important;
+  letter-spacing: 0 !important;
+}
+
+/* ---- Body / sections ---- */
+[data-editorial="er-sheet"] .er-body {
+  background: #FFFFFF !important;
+  padding: 0 !important;
+}
+[data-editorial="er-sheet"] .er-body .emrg-section {
+  margin: 0 !important;
+  padding: 22px 24px !important;
+  border-bottom: 1px solid var(--ink-1, #E8E2D6) !important;
+}
+[data-editorial="er-sheet"] .er-body .emrg-section:last-child {
+  border-bottom: none !important;
+}
+[data-editorial="er-sheet"] .er-body .emrg-section-title {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 11px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--ink-5) !important;
+  margin-bottom: 14px !important;
+  font-variation-settings: "opsz" 14, "SOFT" 60 !important;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+[data-editorial="er-sheet"] .er-body .emrg-section-title i,
+[data-editorial="er-sheet"] .er-body .emrg-section-title svg,
+[data-editorial="er-sheet"] .er-body .emrg-section-title [data-lucide] {
+  width: 13px !important;
+  height: 13px !important;
+  color: var(--moss-deep, #3F5F52) !important;
+  stroke-width: 1.6;
+}
+
+/* rows: label/value as a hairline-divided ladder */
+[data-editorial="er-sheet"] .er-body .emrg-row {
+  display: flex !important;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 9px 0 !important;
+  border-bottom: 1px solid var(--ink-0, #F2EDE2);
+  font-size: 16px !important;
+}
+[data-editorial="er-sheet"] .er-body .emrg-row:last-child {
+  border-bottom: none;
+}
+[data-editorial="er-sheet"] .er-body .emrg-label {
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 300 !important;
+  font-size: 16px !important;
+  color: var(--ink-6) !important;
+  flex: 0 0 auto;
+}
+[data-editorial="er-sheet"] .er-body .emrg-val {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-weight: 500 !important;
+  font-size: 16px !important;
+  color: var(--ink-9) !important;
+  text-align: right;
+  font-variation-settings: "opsz" 24, "SOFT" 60 !important;
+}
+
+/* ---- AI brief section ---- */
+[data-editorial="er-sheet"] #er-ai-section {
+  padding: 22px 24px !important;
+  background: var(--linen, #F7F5F0) !important;   /* gentle linen island so the brief reads as
+                                                       a separate voice, not chart data */
+  border-top: 1px solid var(--ink-1, #E8E2D6);
+  border-bottom: 1px solid var(--ink-1, #E8E2D6);
+}
+[data-editorial="er-sheet"] .er-ai-header {
+  margin-bottom: 12px !important;
+}
+[data-editorial="er-sheet"] .er-ai-label {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 11px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--ink-5) !important;
+  font-variation-settings: "opsz" 14, "SOFT" 60 !important;
+}
+[data-editorial="er-sheet"] .er-ai-label i,
+[data-editorial="er-sheet"] .er-ai-label [data-lucide] {
+  color: var(--moss-deep, #3F5F52) !important;
+  stroke-width: 1.6;
+}
+[data-editorial="er-sheet"] .er-ai-refresh {
+  color: var(--ink-5) !important;
+  background: transparent !important;
+  opacity: 1;
+}
+[data-editorial="er-sheet"] .er-ai-refresh:hover {
+  color: var(--ink-9) !important;
+}
+[data-editorial="er-sheet"] .er-ai-body,
+[data-editorial="er-sheet"] .er-ai-text {
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 17px !important;
+  font-weight: 400 !important;
+  line-height: 1.6 !important;
+  color: var(--ink-9) !important;
+  font-variation-settings: "opsz" 24, "SOFT" 60 !important;
+}
+[data-editorial="er-sheet"] .er-ai-loading {
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 300 !important;
+  color: var(--ink-5) !important;
+}
+[data-editorial="er-sheet"] .er-ai-cached-note {
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 300 !important;
+  font-size: 12px !important;
+  color: var(--ink-5) !important;
+  border-top: 1px solid var(--ink-1, #E8E2D6) !important;
+}
+
+/* ---- Actions footer ---- */
+[data-editorial="er-sheet"] .er-actions {
+  background: #FFFFFF !important;
+  border-top: 1px solid var(--ink-1, #E8E2D6) !important;
+  padding: 16px 24px !important;
+  gap: 12px !important;
+}
+[data-editorial="er-sheet"] .er-action-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 500 !important;
+  font-size: 14px !important;
+  letter-spacing: 0.01em !important;
+  border-radius: 999px !important;
+  padding: 13px 18px !important;
+  border: 0 !important;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+[data-editorial="er-sheet"] .er-action-share {
+  background: var(--moss-deep, #3F5F52) !important;
+  color: #FFFFFF !important;
+  border: 1px solid var(--moss-deep, #3F5F52) !important;
+}
+[data-editorial="er-sheet"] .er-action-share:hover {
+  background: var(--ink-9, #1F1B16) !important;
+  border-color: var(--ink-9, #1F1B16) !important;
+}
+[data-editorial="er-sheet"] .er-action-pdf {
+  background: transparent !important;
+  color: var(--ink-9, #1F1B16) !important;
+  border: 1px solid var(--ink-3, #C8C0B5) !important;
+}
+[data-editorial="er-sheet"] .er-action-pdf:hover {
+  background: transparent !important;
+  border-color: var(--ink-9, #1F1B16) !important;
+  color: var(--ink-9, #1F1B16) !important;
+}
+[data-editorial="er-sheet"] .er-action-btn i,
+[data-editorial="er-sheet"] .er-action-btn [data-lucide] {
+  width: 15px !important;
+  height: 15px !important;
+  stroke-width: 1.6;
+}
+
+[data-editorial="er-sheet"] .er-footer {
+  background: #FFFFFF !important;
+  font-family: 'DM Sans', -apple-system, sans-serif !important;
+  font-weight: 300 !important;
+  color: var(--ink-5) !important;
+}
+
+/* ---- Long-press on wordmark ---- */
+/* Visual affordance: when held, the wordmark dims so the user feels the gesture
+   register before the sheet animates in. No tooltip; this is a primitive, not a
+   discoverable button — Settings > "How Wellet works" will teach it. */
+.app-logo-row [data-longpress="er"] {
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 0.18s ease;
+}
+.app-logo-row [data-longpress="er"].is-pressing {
+  opacity: 0.55;
+}
+
+/* ---- Tablet + desktop tightening ---- */
+@media (min-width: 768px) {
+  [data-editorial="er-sheet"] .er-container {
+    max-width: 720px;
+  }
+  [data-editorial="er-sheet"] .er-patient-name {
+    font-size: 44px !important;
+  }
+  [data-editorial="er-sheet"] .er-body .emrg-row {
+    font-size: 17px !important;
+  }
+  [data-editorial="er-sheet"] .er-ai-body,
+  [data-editorial="er-sheet"] .er-ai-text {
+    font-size: 18px !important;
+  }
+}
+@media (min-width: 1024px) {
+  [data-editorial="er-sheet"] .er-container {
+    max-width: 760px;
+  }
+}

--- a/assets/editorial-er.css
+++ b/assets/editorial-er.css
@@ -232,21 +232,22 @@
 [data-editorial="er-sheet"] .er-actions {
   background: #FFFFFF !important;
   border-top: 1px solid var(--ink-1, #E8E2D6) !important;
-  padding: 16px 24px !important;
-  gap: 12px !important;
+  padding: 16px 20px !important;
+  gap: 10px !important;
 }
 [data-editorial="er-sheet"] .er-action-btn {
   flex: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 7px;
   font-family: 'DM Sans', -apple-system, sans-serif !important;
   font-weight: 500 !important;
   font-size: 14px !important;
   letter-spacing: 0.01em !important;
+  white-space: nowrap !important;
   border-radius: 999px !important;
-  padding: 13px 18px !important;
+  padding: 13px 12px !important;
   border: 0 !important;
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;

--- a/index.html
+++ b/index.html
@@ -1325,7 +1325,7 @@
 
     <div class="er-actions">
       <button class="er-action-btn er-action-share" onclick="shareEmergencySummary()">
-        <i data-lucide="share-2" style="width:16px;height:16px;"></i> Share this summary
+        <i data-lucide="share-2" style="width:16px;height:16px;"></i> Share summary
       </button>
       <button class="er-action-btn er-action-pdf" onclick="downloadEmergencyPDF()">
         <i data-lucide="download" style="width:16px;height:16px;"></i> Download PDF

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 <link rel="stylesheet" href="/assets/editorial-records.css">
 <link rel="stylesheet" href="/assets/editorial-ask.css">
 <link rel="stylesheet" href="/assets/editorial-sheets.css">
+<link rel="stylesheet" href="/assets/editorial-er.css">
 </head>
 <body>
 <div class="page-wrap">
@@ -276,7 +277,7 @@
   <div class="app-header">
     <div class="header-top">
       <div class="app-logo-row">
-        <div>
+        <div data-longpress="er" aria-label="Press and hold for emergency summary">
           <svg class="app-wordmark" viewBox="0 138 150 42" xmlns="http://www.w3.org/2000/svg" aria-label="Wellet">
             <path fill="#608F7C" d="M45.5,142c.94.94,1.4,2.08,1.4,3.42,0,.89-.19,1.73-.58,2.52-.65-.1-1.33-.14-2.05-.14-3.07,0-5.56.97-7.45,2.9-1.9,1.93-3.36,4.34-4.39,7.22-1.03,2.88-2.17,6.86-3.42,11.95l-.47,1.94-.11-.25v.29h-5.15l-4.43-11.2-4.03,11.2h-5.15l-5.69-14.44c-.67-1.34-1.28-2.24-1.82-2.7-.54-.46-1.27-.73-2.18-.83l.25-2.56h12.56l-.04,2.56c-.53.07-1.01.26-1.44.58-.43.31-.65.76-.65,1.33,0,.17.04.38.11.65l3.71,9.47,3.1-8.5c-.48-.96-.88-1.67-1.21-2.14s-.67-.8-1.04-.99c-.37-.19-.87-.32-1.49-.4v-2.56h12.82v2.56c-.86.02-1.49.13-1.87.32-.38.19-.58.55-.58,1.08,0,.34.07.74.22,1.22l3.06,7.78c1.54-7.46,3.49-13.28,5.85-17.44,2.36-4.16,5.15-6.25,8.37-6.25,1.58,0,2.84.47,3.78,1.4Z"/>
             <path fill="#608F7C" d="M57.31,168.14c-1.13,1.44-2.57,2.56-4.32,3.37-1.75.8-3.61,1.21-5.58,1.21s-3.92-.49-5.65-1.48c-1.73-.98-3.1-2.32-4.1-4.01-1.01-1.69-1.51-3.55-1.51-5.56s.5-3.87,1.51-5.56c1.01-1.69,2.38-3.03,4.1-4.01,1.73-.98,3.61-1.48,5.65-1.48,1.92,0,3.62.28,5.09.83s2.62,1.31,3.42,2.29c.8.97,1.21,2.06,1.21,3.26,0,2.62-1.68,4.46-5.04,5.54-1.49.46-3.06.68-4.72.68-1.08,0-2.24-.11-3.49-.32.02,1.13.35,2.16.99,3.1.64.94,1.46,1.67,2.47,2.21s2.05.81,3.13.81c.96,0,1.94-.2,2.93-.61,1-.41,1.82-.98,2.47-1.73l1.44,1.48ZM45.7,155.59c-.8,1.26-1.34,2.86-1.6,4.81.84.17,1.64.25,2.41.25,1.61,0,2.87-.34,3.78-1.01.91-.67,1.51-1.5,1.8-2.48.1-.29.14-.59.14-.9,0-.86-.32-1.56-.95-2.09-.64-.53-1.36-.76-2.18-.68-1.46.14-2.6.85-3.4,2.11Z"/>
@@ -1240,7 +1241,7 @@
 
 
 <!-- EMERGENCY SUMMARY OVERLAY (full-screen, ER-optimized) -->
-<div class="er-overlay" id="emergency-overlay">
+<div class="er-overlay" id="emergency-overlay" data-editorial="er-sheet">
   <div class="er-container">
     <div class="er-header">
       <div class="er-header-left">
@@ -2939,5 +2940,70 @@
   </div>
 </div>
 
+<script>
+/* ────────────────────────────────────────────────────────────
+   Editorial primitive #7 — long-press the wordmark for ER summary.
+   Activates after 600ms of sustained press. Cancels on movement >8px,
+   release, or scroll. Works for mouse, touch, and pen.
+   ──────────────────────────────────────────────────────────── */
+(function(){
+  var HOLD_MS = 600;
+  var MOVE_TOLERANCE = 8;
+  var pressTimer = null;
+  var pressTarget = null;
+  var startX = 0, startY = 0;
+  var fired = false;
+
+  function clear() {
+    if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
+    if (pressTarget) { pressTarget.classList.remove('is-pressing'); pressTarget = null; }
+  }
+
+  function onDown(e) {
+    var t = e.target.closest && e.target.closest('[data-longpress="er"]');
+    if (!t) return;
+    fired = false;
+    pressTarget = t;
+    var p = e.touches ? e.touches[0] : e;
+    startX = p.clientX; startY = p.clientY;
+    t.classList.add('is-pressing');
+    pressTimer = setTimeout(function(){
+      fired = true;
+      if (pressTarget) pressTarget.classList.remove('is-pressing');
+      try { if (typeof openEmergencySummary === 'function') openEmergencySummary(); } catch(err){ /* noop */ }
+      // Light haptic if supported (mobile only — desktop browsers ignore)
+      try { if (navigator.vibrate) navigator.vibrate(12); } catch(err){}
+    }, HOLD_MS);
+  }
+
+  function onMove(e) {
+    if (!pressTimer) return;
+    var p = e.touches ? e.touches[0] : e;
+    if (Math.abs(p.clientX - startX) > MOVE_TOLERANCE || Math.abs(p.clientY - startY) > MOVE_TOLERANCE) {
+      clear();
+    }
+  }
+
+  function onUp(e) {
+    // If the long-press already fired, swallow the trailing click so the page
+    // doesn't double-handle it.
+    if (fired) {
+      e.preventDefault && e.preventDefault();
+      e.stopPropagation && e.stopPropagation();
+    }
+    clear();
+  }
+
+  document.addEventListener('mousedown', onDown, true);
+  document.addEventListener('mousemove', onMove, true);
+  document.addEventListener('mouseup', onUp, true);
+  document.addEventListener('mouseleave', clear, true);
+  document.addEventListener('touchstart', onDown, { capture: true, passive: true });
+  document.addEventListener('touchmove', onMove, { capture: true, passive: true });
+  document.addEventListener('touchend', onUp, true);
+  document.addEventListener('touchcancel', clear, true);
+  document.addEventListener('scroll', clear, true);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
Full-screen WHITE sheet (intentional palette break — only place in app), Fraunces masthead, hairline-divided rows, signal-warm shield-alert glyph (no red, no crimson). Adds long-press wordmark as primitive #7 (600ms hold, 8px tolerance). PR 7 of 8 in the editorial rollout.