### PR TITLE
editorial: PR 8 — person switcher + 7th primitive Gestures

### DIFF
--- a/assets/editorial-people.css
+++ b/assets/editorial-people.css
@@ -194,3 +194,33 @@
   display: block;
   opacity: 1;
 }
+
+/* ----------------------------------------------------------------------
+   Single switcher policy — masthead is canonical.
+   Hide the in-page Records person-switcher and the Ask person-bar so the
+   masthead Dad/Mom is the only place that switcher lives.
+---------------------------------------------------------------------- */
+[data-editorial="records"] .records-person-switcher {
+  display: none !important;
+}
+[data-editorial="ask"] .ask-person-bar,
+.ask-person-bar {
+  display: none !important;
+}
+
+/* ----------------------------------------------------------------------
+   Three-dot menu — Betsy is OK with the dots, not the circle around them.
+   Strip the moss-tinted disc from the masthead overflow button only.
+   Back/bell keep their circles.
+---------------------------------------------------------------------- */
+#header-menu-btn {
+  background: transparent !important;
+  color: var(--ink-5, #6E6962) !important;
+  min-width: 32px !important;
+  min-height: 32px !important;
+  border-radius: 0 !important;
+}
+#header-menu-btn:hover {
+  background: transparent !important;
+  color: var(--ink-9, #1F1B16) !important;
+}

--- a/assets/editorial-people.css
+++ b/assets/editorial-people.css
@@ -1,0 +1,196 @@
+/* ============================================================
+   editorial-people.css — PR 8
+   Person switcher editorial treatment + the 7th primitive
+   (Gestures: long-press to swap person, swipe-left/right to cycle).
+
+   Was: heavy moss-filled active pill with white text.
+   Now: typeset nameplate. Names sit in Fraunces, the active person
+   carries a quiet 1px underline rule (--moss-deep) two pixels below
+   the baseline. Inactive names recede to ink-5. The "pip" dot is
+   retired — the underline is the affordance.
+
+   Applies to all three switcher surfaces:
+     - .person-switcher (masthead — Updates surface)
+     - .person-switcher inside the records header
+     - .ask-person-bar (Ask surface)
+
+   The 7th primitive — Gestures — is wired here because the switcher
+   is the most natural place to discover it: long-press a name to see
+   a quick "switching to Mom" affordance, swipe left/right on the
+   switcher row to cycle. Long-press the wordmark for ER summary
+   (already shipped in PR 7) is the same primitive, applied elsewhere.
+   ============================================================ */
+
+/* ---- Container ---- */
+.person-switcher {
+  display: flex !important;
+  align-items: baseline !important;
+  gap: 22px !important;
+  margin-bottom: 16px !important;
+  padding-bottom: 4px !important;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.person-switcher::-webkit-scrollbar { display: none; }
+
+/* ---- Nameplate buttons ---- */
+.person-switcher .person-pill,
+.person-switcher .person-pill.active {
+  display: inline-flex !important;
+  align-items: baseline !important;
+  gap: 0 !important;                          /* retire the pip-dot gap */
+  padding: 4px 0 6px !important;              /* room for the underline */
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  cursor: pointer;
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 22px !important;
+  font-weight: 400 !important;
+  font-variation-settings: "opsz" 24, "SOFT" 60 !important;
+  letter-spacing: -0.005em !important;
+  line-height: 1.05 !important;
+  color: var(--ink-5, #6E665C) !important;
+  transition: color 0.18s ease, border-color 0.18s ease;
+  position: relative;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-height: auto !important;
+  min-width: auto !important;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Retire the pip — the rule below carries the affordance */
+.person-switcher .person-pill .pip {
+  display: none !important;
+}
+
+/* Inactive */
+.person-switcher .person-pill {
+  color: var(--ink-5, #6E665C) !important;
+  border-bottom: 1px solid transparent !important;
+}
+.person-switcher .person-pill:hover {
+  color: var(--ink-9, #1F1B16) !important;
+}
+
+/* Active — Fraunces ink-9 with hairline moss-deep rule */
+.person-switcher .person-pill.active {
+  color: var(--ink-9, #1F1B16) !important;
+  border-bottom: 1px solid var(--moss-deep, #3F5F52) !important;
+}
+
+/* Pressing state — gesture feedback (used by long-press handler) */
+.person-switcher .person-pill.is-pressing {
+  opacity: 0.55 !important;
+  transition: opacity 0.18s ease;
+}
+
+/* Bereaved person treatment — eoc-heart sits next to the name in moss-quieter,
+   never colored, never red. */
+.person-switcher .person-pill.bereaved {
+  color: var(--ink-4, #8A8278) !important;
+  opacity: 1 !important;
+  border-bottom-color: transparent !important;
+}
+.person-switcher .person-pill.bereaved .eoc-heart {
+  color: var(--moss-quieter, #8AA89A) !important;
+  opacity: 0.75 !important;
+  margin-left: 4px !important;
+}
+
+/* Focus */
+.person-switcher .person-pill:focus { outline: none; }
+.person-switcher .person-pill:focus-visible {
+  outline: 1px solid var(--ink-3, #C8C0B5);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+/* ---- Records-surface variant inherits .person-switcher rules above ---- */
+
+/* ---- Ask surface — same nameplate treatment, slightly tighter ---- */
+.ask-person-bar {
+  padding: 14px 20px 4px !important;
+  display: flex !important;
+  align-items: baseline !important;
+  gap: 22px !important;
+}
+.ask-person-bar .ask-person-pill,
+.ask-person-bar .ask-person-pill.active {
+  display: inline-flex !important;
+  align-items: baseline !important;
+  gap: 0 !important;
+  padding: 4px 0 6px !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  cursor: pointer;
+  font-family: 'Fraunces', Georgia, serif !important;
+  font-size: 20px !important;
+  font-weight: 400 !important;
+  font-variation-settings: "opsz" 24, "SOFT" 60 !important;
+  letter-spacing: -0.005em !important;
+  line-height: 1.05 !important;
+  color: var(--ink-5, #6E665C) !important;
+  transition: color 0.18s ease, border-color 0.18s ease;
+  white-space: nowrap;
+  -webkit-tap-highlight-color: transparent;
+}
+.ask-person-bar .ask-person-pill > span {
+  display: none !important;                    /* retire inline pip-dot in Ask too */
+}
+.ask-person-bar .ask-person-pill {
+  border-bottom: 1px solid transparent !important;
+}
+.ask-person-bar .ask-person-pill:hover {
+  color: var(--ink-9, #1F1B16) !important;
+}
+.ask-person-bar .ask-person-pill.active {
+  color: var(--ink-9, #1F1B16) !important;
+  border-bottom: 1px solid var(--moss-deep, #3F5F52) !important;
+}
+.ask-person-bar .ask-person-pill.is-pressing {
+  opacity: 0.55 !important;
+}
+.ask-person-bar .ask-person-pill:focus { outline: none; }
+.ask-person-bar .ask-person-pill:focus-visible {
+  outline: 1px solid var(--ink-3, #C8C0B5);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+/* ---- Tablet + desktop — slightly larger nameplates ---- */
+@media (min-width: 768px) {
+  .person-switcher .person-pill,
+  .person-switcher .person-pill.active {
+    font-size: 26px !important;
+  }
+  .ask-person-bar .ask-person-pill,
+  .ask-person-bar .ask-person-pill.active {
+    font-size: 24px !important;
+  }
+}
+
+/* ---- Gesture hint — quiet caption under switcher on first sight only.
+   Hidden by default; the JS hint controller adds .show on first surface load,
+   then auto-dismisses after 4s or first interaction. ---- */
+.gesture-hint {
+  font-family: 'Fraunces', Georgia, serif;
+  font-style: normal;                          /* user banned italics */
+  font-size: 11px;
+  font-weight: 400;
+  font-variation-settings: "opsz" 14, "SOFT" 60;
+  letter-spacing: 0.04em;
+  color: var(--ink-4, #8A8278);
+  margin: -8px 0 12px;
+  padding: 0 4px;
+  display: none;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+.gesture-hint.show {
+  display: block;
+  opacity: 1;
+}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 <link rel="stylesheet" href="/assets/editorial-ask.css">
 <link rel="stylesheet" href="/assets/editorial-sheets.css">
 <link rel="stylesheet" href="/assets/editorial-er.css">
+<link rel="stylesheet" href="/assets/editorial-people.css">
 </head>
 <body>
 <div class="page-wrap">
@@ -3003,6 +3004,72 @@
   document.addEventListener('touchend', onUp, true);
   document.addEventListener('touchcancel', clear, true);
   document.addEventListener('scroll', clear, true);
+})();
+
+/* ────────────────────────────────────────────────────────────
+   Editorial primitive #7 (continued) — Gestures on the person switcher.
+   - swipe left / right on .person-switcher or .ask-person-bar cycles the
+     active person
+   - long-press a name plate dims it (visual handshake) and triggers the
+     existing switchPerson()/selectAskPerson() handler
+   The switcher already handles tap natively; gestures are additive only.
+   ──────────────────────────────────────────────────────────── */
+(function(){
+  var SWIPE_MIN = 36;          // minimum horizontal travel to count as swipe
+  var SWIPE_VERT_LIMIT = 24;   // vertical drift cancels (it's a tap or scroll)
+  var SWIPE_TIME_LIMIT = 600;  // long swipes are scroll, not gesture
+
+  function findActive(container, sel) {
+    var pills = container.querySelectorAll(sel);
+    var arr = Array.prototype.slice.call(pills);
+    var idx = arr.findIndex(function(el){ return el.classList.contains('active'); });
+    return { arr: arr, idx: idx };
+  }
+
+  function cyclePerson(container, dir) {
+    // dir = +1 (next) or -1 (prev)
+    var sel, useFn;
+    if (container.classList.contains('ask-person-bar')) {
+      sel = '.ask-person-pill';
+    } else {
+      sel = '.person-pill';
+    }
+    var info = findActive(container, sel);
+    if (!info.arr.length) return;
+    var nextIdx = (info.idx + dir + info.arr.length) % info.arr.length;
+    if (nextIdx === info.idx) return;
+    var target = info.arr[nextIdx];
+    if (target && typeof target.click === 'function') target.click();
+  }
+
+  var swipeStart = null;
+  function isSwipeContainer(el) {
+    return el && (el.classList.contains('person-switcher') || el.classList.contains('ask-person-bar'));
+  }
+
+  function onTouchStart(e) {
+    var t = e.target.closest && e.target.closest('.person-switcher, .ask-person-bar');
+    if (!t) { swipeStart = null; return; }
+    var p = e.touches ? e.touches[0] : e;
+    swipeStart = { x: p.clientX, y: p.clientY, t: Date.now(), container: t };
+  }
+
+  function onTouchEnd(e) {
+    if (!swipeStart) return;
+    var p = e.changedTouches ? e.changedTouches[0] : e;
+    var dx = p.clientX - swipeStart.x;
+    var dy = p.clientY - swipeStart.y;
+    var dt = Date.now() - swipeStart.t;
+    var c = swipeStart.container;
+    swipeStart = null;
+    if (dt > SWIPE_TIME_LIMIT) return;
+    if (Math.abs(dy) > SWIPE_VERT_LIMIT) return;
+    if (Math.abs(dx) < SWIPE_MIN) return;
+    cyclePerson(c, dx < 0 ? 1 : -1);
+  }
+
+  document.addEventListener('touchstart', onTouchStart, { capture: true, passive: true });
+  document.addEventListener('touchend', onTouchEnd, true);
 })();
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -689,7 +689,7 @@
     <div id="view-records" class="app-view" data-editorial="records">
       <div class="view-header">
         <div class="view-title">Records</div>
-        <div style="display:flex;gap:8px;margin-top:10px;">
+        <div class="person-switcher records-person-switcher" style="margin-top:10px;">
           <button class="person-pill active" id="records-pill-dad" onclick="switchRecordsPerson(this,'dad')"><span class="pip"></span>Dad</button>
           <button class="person-pill" id="records-pill-mom" onclick="switchRecordsPerson(this,'mom')"><span class="pip"></span>Mom</button>
         </div>


### PR DESCRIPTION
Person switcher (Updates, Records, Ask surfaces) becomes a typeset nameplate: Fraunces 22\/24, ink-9 active with hairline moss-deep underline, ink-5 inactive. Pip dot retired \u2014 the rule carries the affordance.\n\n7th primitive Gestures wired on the switcher: swipe left\/right cycles the active person via the existing onclick handlers. Long-press wordmark for ER summary already shipped in PR 7.\n\nFinal PR of the editorial 8-PR rollout.