### PR TITLE
Editorial masthead bare icons

### DIFF
--- a/assets/editorial-people.css
+++ b/assets/editorial-people.css
@@ -209,18 +209,25 @@
 }
 
 /* ----------------------------------------------------------------------
-   Three-dot menu — Betsy is OK with the dots, not the circle around them.
-   Strip the moss-tinted disc from the masthead overflow button only.
-   Back/bell keep their circles.
+   Masthead bare-icon treatment — strip moss-tinted discs from bell and
+   three-dot. Back arrow is no longer in the masthead at all (it's now
+   contextual, lives in content). Notification badge stays but quiet.
 ---------------------------------------------------------------------- */
-#header-menu-btn {
+#header-menu-btn,
+#notif-bell-btn {
   background: transparent !important;
   color: var(--ink-5, #6E6962) !important;
   min-width: 32px !important;
   min-height: 32px !important;
   border-radius: 0 !important;
 }
-#header-menu-btn:hover {
+#header-menu-btn:hover,
+#notif-bell-btn:hover {
   background: transparent !important;
   color: var(--ink-9, #1F1B16) !important;
+}
+
+/* Demo back button is hidden via inline style; double-belt to be safe */
+#demo-back-btn {
+  display: none !important;
 }

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
         </div>
       </div>
       <div class="header-actions" style="display:flex;align-items:center;gap:6px;">
-          <button class="icon-btn" id="demo-back-btn" onclick="showLanding()" title="Back to start" aria-label="Back" style="display:none;"><i data-lucide="arrow-left" style="width:16px;height:16px;"></i></button>
+          <button class="icon-btn" id="demo-back-btn" onclick="showLanding()" title="Back to start" aria-label="Back" style="display:none !important;"><i data-lucide="arrow-left" style="width:16px;height:16px;"></i></button>
           <button class="icon-btn" id="bug-report-btn" onclick="openBugReportSheet()" title="Report a bug" aria-label="Report a bug" style="display:none;"><i data-lucide="bug" style="width:16px;height:16px;"></i></button>
           <div class="notif-bell-wrap">
             <button class="icon-btn" id="notif-bell-btn" onclick="openNotifPanel()" title="Reminders" aria-label="Notifications"><i data-lucide="bell" style="width:16px;height:16px;"></i></button>


### PR DESCRIPTION
Strip moss-tinted discs from bell and three-dot. Hide demo back button — back navigation is contextual and lives in content per Betsy's direction.