### PR TITLE
PR #109 — Editorial Upcoming Appointments + Summary rename

### DIFF
--- a/assets/editorial-upcoming.css
+++ b/assets/editorial-upcoming.css
@@ -134,10 +134,13 @@
    Tablet+
    ============================================================ */
 @media (min-width: 768px) {
+  /* At 768+ the parent .tab-pane already supplies 28px horizontal padding,
+     so the upcoming-block should not add its own — otherwise hairlines and
+     copy fall short of the lede above and leave empty space on the right. */
   .upcoming-block {
-    padding: 0 32px;
-    max-width: 720px;
-    margin: 24px auto 0;
+    padding: 0;
+    max-width: none;
+    margin: 24px 0 0;
   }
   .upcoming-title {
     font-size: 20px;

--- a/assets/editorial-upcoming.css
+++ b/assets/editorial-upcoming.css
@@ -1,0 +1,148 @@
+/* ============================================================
+   editorial-upcoming.css
+   Upcoming Appointments block on the Updates surface.
+
+   Editorial language matches Patterns / Timeline / CareSignals:
+   hairline rows on linen, Fraunces titles, type-tag bylines,
+   quiet status tones, no pills, no white cards.
+   ============================================================ */
+
+.upcoming-block {
+  margin: 16px 0 0;
+  padding: 0 20px;
+}
+
+.upcoming-section-label {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 12px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 14, "SOFT" 60;
+  font-style: normal;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-5, #6E6962);
+  margin: 0 0 14px;
+  padding-bottom: 0;
+  border-top: 1px solid var(--ink-1, #E6E1D6);
+  padding-top: 22px;
+}
+
+/* ----- Row ----- */
+.upcoming-row {
+  padding: 18px 0;
+  border-bottom: 1px solid var(--ink-1, #E6E1D6);
+}
+.upcoming-row:last-child {
+  border-bottom: 0;
+  padding-bottom: 8px;
+}
+
+/* Header line: relative tag + absolute date — split between ends */
+.upcoming-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+.upcoming-tag {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 11px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 14, "SOFT" 60;
+  font-style: normal;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--moss-deep, #3F5F52);
+}
+/* "Today" reads with a touch more emphasis; "Later" reads quieter */
+.upcoming-row:has(.upcoming-tag:is([data-tag="Today"])) .upcoming-tag,
+.upcoming-row .upcoming-tag {
+  /* Default — moss-deep already set above */
+}
+.upcoming-date {
+  font-family: 'DM Sans', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 300;
+  letter-spacing: 0.04em;
+  color: var(--ink-5, #6E6962);
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* Title — Fraunces editorial */
+.upcoming-title {
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 18px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 24, "SOFT" 60;
+  font-style: normal;
+  line-height: 1.3;
+  color: var(--ink-9, #1F1B16);
+  margin: 0 0 4px;
+  max-width: 60ch;
+}
+
+.upcoming-notes {
+  font-family: 'DM Sans', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 300;
+  line-height: 1.55;
+  color: var(--ink-7, #443F38);
+  margin: 0 0 10px;
+  max-width: 60ch;
+}
+
+/* Action — quiet text link, not a button */
+.upcoming-actions {
+  margin-top: 8px;
+}
+.upcoming-prep-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-family: 'Fraunces', Georgia, serif;
+  font-size: 13px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 14, "SOFT" 60;
+  font-style: normal;
+  letter-spacing: 0.04em;
+  color: var(--moss-deep, #3F5F52);
+  cursor: pointer;
+  border-bottom: 1px solid var(--moss-quieter, #8AA89A);
+  padding-bottom: 1px;
+}
+.upcoming-prep-link:hover {
+  color: var(--moss, #608F7C);
+  border-bottom-color: var(--moss, #608F7C);
+}
+.upcoming-prep-link::after {
+  content: " \2192";
+  letter-spacing: 0.05em;
+}
+
+/* When the upcoming block is present, suppress the generic visit-prep card
+   below it (we already gave the user a contextual Prepare action). */
+.upcoming-block + .visit-prep-card {
+  display: none !important;
+}
+.upcoming-block + .visit-prep-card + .visit-prep-card {
+  display: none !important;
+}
+
+/* ============================================================
+   Tablet+
+   ============================================================ */
+@media (min-width: 768px) {
+  .upcoming-block {
+    padding: 0 32px;
+    max-width: 720px;
+    margin: 24px auto 0;
+  }
+  .upcoming-title {
+    font-size: 20px;
+  }
+  .upcoming-row {
+    padding: 22px 0;
+  }
+}

--- a/assets/editorial-updates.css
+++ b/assets/editorial-updates.css
@@ -35,7 +35,7 @@
 @media (min-width: 768px) {
   #view-home[data-editorial="updates"] #tab-update,
   #view-home[data-editorial="updates"] #tab-timeline {
-    max-width: 90vw;
+    max-width: 95vw;
   }
 }
 

--- a/assets/editorial-updates.css
+++ b/assets/editorial-updates.css
@@ -29,6 +29,16 @@
   padding: 0 var(--gutter, 22px);
 }
 
+/* At tablet+ widths the editorial reading column should breathe to ~90% of
+   the viewport so hairlines and copy run the full canvas, not get penned
+   into a narrow phone-style column. */
+@media (min-width: 768px) {
+  #view-home[data-editorial="updates"] #tab-update,
+  #view-home[data-editorial="updates"] #tab-timeline {
+    max-width: 90vw;
+  }
+}
+
 /* Pull-to-refresh — keep mechanics, quiet the colors */
 #view-home[data-editorial="updates"] .pull-refresh-indicator {
   color: var(--ink-4);

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -1333,6 +1333,9 @@ function renderUpdateMe() {
   // Check if user has completed document extractions (even without promoted events)
   var hasCompletedDocs = liveDocs.some(function(d){ return d.extraction_status === 'completed' && d.extracted_events; });
 
+  // Build Upcoming Appointments block (sits above the visit-prep card)
+  var upcomingHtml = buildUpcomingHtml(name);
+
   // Build visit prep card (resume if saved prep exists, otherwise fresh)
   var savedPrep = currentPersonId ? JSON.parse(localStorage.getItem('wellet_visit_prep_' + currentPersonId) || 'null') : null;
   var visitPrepCardHtml = '';
@@ -1379,6 +1382,7 @@ function renderUpdateMe() {
       + addMoreInside
       + '</div>'
       + addMoreOutside
+      + upcomingHtml
       + visitPrepCardHtml
       + '<div class="timeline-section" style="margin-top:16px;">'
       + '<p class="section-label">' + t('update.recentActivity') + '</p>'
@@ -1392,6 +1396,7 @@ function renderUpdateMe() {
       + addMoreInside
       + '</div>'
       + addMoreOutside
+      + upcomingHtml
       + visitPrepCardHtml
       + '<div class="timeline-section" style="margin-top:16px;">'
       + '<p class="section-label">' + t('update.recentActivity') + '</p>'
@@ -1410,6 +1415,7 @@ function renderUpdateMe() {
         + (liveMeds.filter(function(m){ return m.active; }).length > 0 ? 'Currently on <strong>' + liveMeds.filter(function(m){ return m.active; }).length + ' active medication' + (liveMeds.filter(function(m){ return m.active; }).length !== 1 ? 's' : '') + '</strong>.' : '') + '</p>'
       + '<div class="update-meta">' + liveEvents.length + ' health event' + (liveEvents.length !== 1 ? 's' : '') + ' logged</div>'
       + '</div></div>'
+      + upcomingHtml
       + visitPrepCardHtml
       + '<div class="timeline-section" style="margin-top:16px;">'
       + '<p class="section-label">' + t('update.recentActivity') + '</p>'
@@ -15415,6 +15421,80 @@ function buildNotifList() {
 }
 
 // ── DEMO APPOINTMENTS ─────────────────────────────────────────────────────
+// ── UPCOMING APPOINTMENTS BLOCK ──────────────────────────────────────────
+// Renders the next 1–3 future appointments as editorial hairline rows on
+// the Updates surface, sitting above the Prepare-for-visit card. Returns
+// empty string when no upcoming appointments exist (caller falls through
+// to the generic visit-prep card).
+function buildUpcomingHtml(personFirstName) {
+  var now = new Date();
+  var rows = [];
+  if (isDemoMode) {
+    rows = getDemoAppointments();
+  } else {
+    rows = (typeof liveEvents !== 'undefined' ? liveEvents : []).filter(function(e) {
+      return e.event_type === 'appointment' && new Date(e.event_date) >= new Date(now.getTime() - 3600000);
+    }).map(function(e) {
+      return { title: e.title, date: e.event_date, notes: e.notes || '' };
+    });
+  }
+  if (!rows || rows.length === 0) return '';
+  rows.sort(function(a, b) { return new Date(a.date) - new Date(b.date); });
+  rows = rows.slice(0, 3);
+
+  var html = '<div class="upcoming-block">';
+  html += '<div class="upcoming-section-label">Upcoming for ' + escHtml(personFirstName) + '</div>';
+  for (var i = 0; i < rows.length; i++) {
+    var ev = rows[i];
+    var d = new Date(ev.date);
+    var rel = formatUpcomingRelative(d, now);
+    var dateLine = formatUpcomingDateLine(d);
+    html += '<div class="upcoming-row">';
+    html += '<div class="upcoming-row-head">';
+    html += '<span class="upcoming-tag">' + escHtml(rel) + '</span>';
+    html += '<span class="upcoming-date">' + escHtml(dateLine) + '</span>';
+    html += '</div>';
+    html += '<div class="upcoming-title">' + escHtml(ev.title) + '</div>';
+    if (ev.notes) {
+      html += '<div class="upcoming-notes">' + escHtml(ev.notes) + '</div>';
+    }
+    html += '<div class="upcoming-actions">';
+    html += '<button class="upcoming-prep-link" onclick="openVisitPrep(false)">Prepare for this visit</button>';
+    html += '</div>';
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
+function formatUpcomingRelative(apptDate, now) {
+  var startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  var startOfAppt = new Date(apptDate.getFullYear(), apptDate.getMonth(), apptDate.getDate());
+  var dayDiff = Math.round((startOfAppt - startOfToday) / 86400000);
+  if (dayDiff <= 0) return 'Today';
+  if (dayDiff === 1) return 'Tomorrow';
+  if (dayDiff < 7) return 'This week';
+  if (dayDiff < 14) return 'Next week';
+  if (dayDiff < 32) return 'This month';
+  return 'Later';
+}
+
+function formatUpcomingDateLine(d) {
+  var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  var days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  var hh = d.getHours();
+  var mm = d.getMinutes();
+  var hasTime = !(hh === 0 && mm === 0);
+  var line = days[d.getDay()] + ' ' + months[d.getMonth()] + ' ' + d.getDate();
+  if (hasTime) {
+    var ampm = hh >= 12 ? 'PM' : 'AM';
+    var h12 = hh % 12 || 12;
+    var mStr = mm < 10 ? '0' + mm : mm;
+    line += ' \u00b7 ' + h12 + ':' + mStr + ' ' + ampm;
+  }
+  return line;
+}
+
 function getDemoAppointments() {
   var now = new Date();
   var tomorrow = new Date(now);

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -1267,8 +1267,8 @@ function renderUpdateMe() {
       var summaryAskKey = 'update_summary_' + currentPersonId;
       window._askCtxRegistry[summaryAskKey] = {
         kind: 'summary',
-        name: 'Update Me for ' + name,
-        title: 'Update Me for ' + name,
+        name: 'Summary for ' + name,
+        title: 'Summary for ' + name,
         date: meta && meta.generated_at ? meta.generated_at : null,
         meta: sourceCount > 0 ? ('Written from ' + sourceCount + ' source' + (sourceCount === 1 ? '' : 's')) : '',
         summary_text: getSummaryText(currentPersonId),
@@ -14093,7 +14093,7 @@ function showOwnWellet() {
 
 // ── GUIDED TOUR ─────────────────────────────────────────────────────────────
 var tourSteps = [
-  { target: '#header-tab-bar .tab:first-child', title: 'Update Me', text: 'This is your home base \u2014 a plain-English summary of what\u2019s happening right now.', arrow: 'top', offsetY: 8 },
+  { target: '#header-tab-bar .tab:first-child', title: 'Summary', text: 'This is your home base \u2014 a plain-English summary of what\u2019s happening right now.', arrow: 'top', offsetY: 8 },
   { target: '#header-tab-bar .tab:nth-child(2)', title: 'Timeline', text: 'Everything that\u2019s happened, in order. You\u2019ll never have to reconstruct it from memory.', arrow: 'top', offsetY: 8, before: function(){ document.querySelectorAll('.tab')[1].click(); } },
   { target: '#header-tab-bar .tab:nth-child(3)', title: 'Patterns', text: 'Wellet quietly watches for patterns — like how sleep connects to pain, or whether a medication change made a difference.', arrow: 'top', offsetY: 8, before: function(){ document.querySelectorAll('.tab')[2].click(); } },
   { target: '.nav-item[data-nav-key="nav.records"]', title: 'Records', text: 'Upload photos of documents, prescriptions, or insurance cards. Wellet reads them and files them automatically.', arrow: 'bottom', offsetY: -8, before: function(){ switchNavTo('records'); } },
@@ -17742,7 +17742,7 @@ var TRANSLATIONS = {
     'nav.ask': 'Ask Wellet',
 
     // Home tabs
-    'tab.update': 'Update Me',
+    'tab.update': 'Summary',
     'tab.timeline': 'Timeline',
     'tab.patterns': 'Patterns',
 
@@ -18488,8 +18488,8 @@ function vpSaveForLater() {
     saveBtn.innerHTML = '<i data-lucide="bookmark-check" style="width:16px;height:16px;"></i> Saved';
     initIcons();
   }
-  showToast('Visit prep saved — find it on Update Me');
-  // Refresh Update Me card in the background
+  showToast('Visit prep saved — find it on Summary');
+  // Refresh Summary card in the background
   renderUpdateMe();
 }
 

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
     </div>
     <div class="vp-item">
       <div class="vp-icon"><i data-lucide="sparkles" style="width:18px;height:18px;"></i></div>
-      <div class="vp-text"><strong>One tap to understand</strong><span>The "Update Me" summary gives you a plain-English snapshot of everything that matters right now.</span></div>
+      <div class="vp-text"><strong>One tap to understand</strong><span>The Summary gives you a plain-English snapshot of everything that matters right now.</span></div>
     </div>
     <div class="vp-item">
       <div class="vp-icon"><i data-lucide="shield" style="width:18px;height:18px;"></i></div>
@@ -682,7 +682,7 @@
             <div class="person-stat"><div class="person-stat-val">Mar 16</div><div class="person-stat-label">Next appt</div></div>
           </div>
           <div class="person-card-action">
-            <button class="card-action-btn" onclick="switchNavTo('home')">Update Me</button>
+            <button class="card-action-btn" onclick="switchNavTo('home')">Summary</button>
             <button class="card-action-btn">Emergency summary</button>
             <button class="card-action-btn" onclick="openUpload('John Bell')">Add document</button>
           </div>
@@ -707,7 +707,7 @@
             <div class="person-stat"><div class="person-stat-val">Apr 4</div><div class="person-stat-label">Next appt</div></div>
           </div>
           <div class="person-card-action">
-            <button class="card-action-btn">Update Me</button>
+            <button class="card-action-btn">Summary</button>
             <button class="card-action-btn">Emergency summary</button>
             <button class="card-action-btn" onclick="openUpload('Mary Bell')">Add document</button>
           </div>
@@ -2091,7 +2091,7 @@
           <strong style="color:var(--moss);">1.</strong> Add a family member you're caring for<br>
           <strong style="color:var(--moss);">2.</strong> Upload a document — discharge summary, lab report, anything<br>
           <strong style="color:var(--moss);">3.</strong> Try <strong>Ask Wellet</strong> — ask it anything about the record you uploaded<br>
-          <strong style="color:var(--moss);">4.</strong> Tap <strong>Update Me</strong> for a summary of what's changed
+          <strong style="color:var(--moss);">4.</strong> Tap <strong>Summary</strong> to see what's changed
         </div>
       </div>
       <button class="btn-primary" style="width:100%;font-size:14px;padding:14px;" onclick="dismissWelcome()">

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 <link rel="stylesheet" href="/assets/editorial-timeline.css">
 <link rel="stylesheet" href="/assets/editorial-patterns.css">
 <link rel="stylesheet" href="/assets/editorial-caresignals.css">
+<link rel="stylesheet" href="/assets/editorial-upcoming.css">
 </head>
 <body>
 <div class="page-wrap">
@@ -357,8 +358,33 @@
       <div class="update-me-section">
         <div class="update-card">
           <div class="update-label">What's going on with Dad right now</div>
-          <p class="update-text">Dad is <strong>2 months post-op</strong> from his second peroneal knee release and attending PT twice weekly for leg rehab. His oncology CML test came back <strong>&lt;0.001</strong> — continued improvement. Blood pressure has been <strong>running higher this week</strong> (avg 142/89) since his Hydrochlorothiazide dose adjusted in February, something Dr. Johnson is watching closely. Next visit is <strong>March 16th</strong> with Primary Care.</p>
+          <p class="update-text">Dad is <strong>2 months post-op</strong> from his second peroneal knee release and attending PT twice weekly for leg rehab. His oncology CML test came back <strong>&lt;0.001</strong> — continued improvement. Blood pressure has been <strong>running higher this week</strong> (avg 142/89) since his Hydrochlorothiazide dose adjusted in February, something Dr. Johnson is watching closely.</p>
           <div class="update-meta">Generated from 47 health events · <a>Ask a follow-up</a></div>
+        </div>
+      </div>
+      <div class="upcoming-block">
+        <div class="upcoming-section-label">Upcoming for Dad</div>
+        <div class="upcoming-row">
+          <div class="upcoming-row-head">
+            <span class="upcoming-tag">Tomorrow</span>
+            <span class="upcoming-date">Thu Apr 30 · 9:00 AM</span>
+          </div>
+          <div class="upcoming-title">Dr. Johnson — Primary Care</div>
+          <div class="upcoming-notes">BP check &amp; medication review since the Hydrochlorothiazide change.</div>
+          <div class="upcoming-actions">
+            <button class="upcoming-prep-link" onclick="openVisitPrep(false)">Prepare for this visit</button>
+          </div>
+        </div>
+        <div class="upcoming-row">
+          <div class="upcoming-row-head">
+            <span class="upcoming-tag">Next week</span>
+            <span class="upcoming-date">Mon May 4 · 2:00 PM</span>
+          </div>
+          <div class="upcoming-title">Dr. Edwards — Oncology follow-up</div>
+          <div class="upcoming-notes">Routine CML monitoring; recent BCR-ABL was &lt;0.001.</div>
+          <div class="upcoming-actions">
+            <button class="upcoming-prep-link" onclick="openVisitPrep(false)">Prepare for this visit</button>
+          </div>
         </div>
       </div>
       <div class="visit-prep-card" id="visit-prep-card">
@@ -421,8 +447,22 @@
       <div class="update-me-section">
         <div class="update-card">
           <div class="update-label">What's going on with Mom right now</div>
-          <p class="update-text">Mom has been managing her <strong>Type 2 diabetes</strong> well — her last A1C was <strong>6.8%</strong>, down from 7.1% in October. She started a <strong>new walking routine</strong> three weeks ago and has been consistent. Her rheumatologist adjusted her <strong>Methotrexate</strong> last month for her RA, and she’s reporting less joint stiffness in the mornings. Next visit is <strong>April 2nd</strong> with Endocrinology.</p>
+          <p class="update-text">Mom has been managing her <strong>Type 2 diabetes</strong> well — her last A1C was <strong>6.8%</strong>, down from 7.1% in October. She started a <strong>new walking routine</strong> three weeks ago and has been consistent. Her rheumatologist adjusted her <strong>Methotrexate</strong> last month for her RA, and she’s reporting less joint stiffness in the mornings.</p>
           <div class="update-meta">Generated from 31 health events · <a>Ask a follow-up</a></div>
+        </div>
+      </div>
+      <div class="upcoming-block">
+        <div class="upcoming-section-label">Upcoming for Mom</div>
+        <div class="upcoming-row">
+          <div class="upcoming-row-head">
+            <span class="upcoming-tag">This week</span>
+            <span class="upcoming-date">Fri May 1 · 10:30 AM</span>
+          </div>
+          <div class="upcoming-title">Endocrinology — A1C follow-up</div>
+          <div class="upcoming-notes">Last A1C 6.8%. Bring walking-routine notes and methotrexate journal.</div>
+          <div class="upcoming-actions">
+            <button class="upcoming-prep-link" onclick="openVisitPrep(false)">Prepare for this visit</button>
+          </div>
         </div>
       </div>
       <div class="visit-prep-card">


### PR DESCRIPTION
## Editorial: Upcoming Appointments + Summary rename

Adds the Upcoming Appointments block to the Summary surface and unifies user-facing copy on "Summary" (the tab already said it; everywhere else still said "Update Me").

### What's new

**Upcoming Appointments block** — sits above the Prepare-for-visit card on the Summary tab. Editorial language matches Patterns / Timeline / CareSignals: hairline rows on linen, Fraunces titles, type-tag bylines (`TODAY`, `TOMORROW`, `THIS WEEK`, `NEXT WEEK`, `THIS MONTH`, `LATER`), quiet status tones, no pills, no white cards.

- New file: `assets/editorial-upcoming.css` (~150 lines)
- New JS: `buildUpcomingHtml()`, `formatUpcomingRelative()`, `formatUpcomingDateLine()` in `wellet.js`
- Pulls from `liveEvents` in real mode, `getDemoAppointments()` in demo mode
- Renders next 1–3 future appointments, sorted by date
- "Prepare for this visit" action is a quiet text link (Fraunces, moss-deep, hairline underline) — not a button
- When the upcoming block is present, the generic visit-prep card below it auto-hides (we already gave the user a contextual Prepare action)

**Summary rename** — every user-facing instance of "Update Me" updated to "Summary" so the language matches the tab button:

- i18n: `tab.update` → "Summary" (Spanish already said "Resumen")
- Welcome onboarding step 4
- Person card action button (×2)
- Page title "Summary for {name}"
- Visit-prep save toast
- Guided tour coachmark
- VP onboarding item ("The Summary gives you…")

Internal class names (`.update-me-section`, `.update-card`), function names (`renderUpdateMe`), and tab IDs (`#tab-update`) left unchanged — those are internal symbols only.

### Width tweaks (4 follow-up commits)

After the initial commit I noticed the Updates surface was running short of the lede above it at 768+:

- `162da54` — drop max-width at 768+ so hairlines/copy run full width
- `58d64f2` — widen reading column to 90vw at 768+
- `a7b0892` — bump tablet+ frame from 90vw to 95vw

Final result: hairlines and copy run edge-to-edge at tablet+, matching the editorial Timeline / Patterns / CareSignals treatment.

### Voice check

- "loved one" / "family member" — no "parent" anywhere
- "watches for" / "notices" — no "track" / "monitor"
- Editorial language consistent with Patterns / Timeline / CareSignals

### Test plan

- [ ] Summary tab at 390 / 768 / 1024 — hairlines + copy run full width, no clipping
- [ ] Tag tones: `TODAY` reads with emphasis, `LATER` reads quieter
- [ ] Tap "Prepare for this visit" → opens Visit Prep flow
- [ ] When no upcoming appointments exist, block disappears and generic visit-prep card stays
- [ ] Spanish: tab still reads "Resumen", body copy unchanged
