### PR TITLE
fix: nav + polish bundle (6 audit findings)

### DIFF
--- a/assets/editorial-foundation.css
+++ b/assets/editorial-foundation.css
@@ -121,7 +121,7 @@ em.fr {
   .masthead .person .name { font-size: var(--type-h2); }
 }
 .masthead .wordmark {
-  color: var(--moss-deep);
+  color: var(--moss-text);
   display: inline-flex;
   align-items: center;
 }

--- a/assets/wellet.css
+++ b/assets/wellet.css
@@ -338,7 +338,7 @@
   .app-logo-row { display: flex; align-items: center; gap: 10px; }
   .app-icon { width: 30px; height: 30px; border-radius: 7px; overflow: hidden; flex-shrink: 0; }
   .app-wordmark { height: 24px; display: block; }
-  .app-wordmark path { fill: #3D6B58; }
+  .app-wordmark path { fill: var(--moss-text, #4F7A68); }
   .header-meta { font-size: var(--type-meta); color: var(--text-muted); margin-top: 1px; }
   .header-actions { display: flex; gap: 8px; }
   .icon-btn { min-width: 44px; min-height: 44px; border-radius: 50%; background: var(--mint); display: flex; align-items: center; justify-content: center; cursor: pointer; border: none; color: var(--moss); transition: background 0.15s; }

--- a/assets/wellet.css
+++ b/assets/wellet.css
@@ -578,7 +578,6 @@
   .contact-card { background: var(--cream); border-radius: 12px; padding: 12px 14px; margin-bottom: 8px; display: flex; align-items: center; gap: 12px; }
   .contact-avatar { width: 36px; height: 36px; border-radius: 50%; background: var(--moss); display: flex; align-items: center; justify-content: center; font-weight: 500; font-size: var(--type-meta); color: white; flex-shrink: 0; }
   .contact-avatar.sage { background: #7AA898; }
-  .contact-avatar.forest { background: var(--forest); }
   .contact-name { font-size: var(--type-body); font-weight: 500; }
   .contact-meta { font-size: var(--type-meta); color: var(--text-muted); margin-top: 1px; }
   .contact-role { font-size: var(--type-micro); font-weight: 500; padding: 2px 8px; border-radius: 8px; margin-left: auto; flex-shrink: 0; }

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -10306,7 +10306,7 @@ async function renderSignalsView() {
       el.innerHTML = '<div class="signals-view">'
         + '<header class="view-header">'
         + '<p class="view-header__eyebrow">Loading\u2026</p>'
-        + '<h1 class="view-header__title">Signals</h1>'
+        + '<h1 class="view-header__title">CareSignals</h1>'
         + '<p class="view-header__lede">Daily rhythms from ' + escHtml(sigFirstName) + '\u2019s wearables, sensors, and medications \u2014 patterns you might miss.</p>'
         + '</header>'
         + '<div class="terra-loading"><i data-lucide="loader" style="width:20px;height:20px;animation:spin 1s linear infinite;"></i>'
@@ -11553,7 +11553,7 @@ async function _paintSignals(el, sigFirstName, activeConns, terraData) {
       var ch = '<div class="signals-view">';
       ch += '<header class="view-header">';
       ch += '<p class="view-header__eyebrow">' + escHtml(_hdrEyebrow) + '</p>';
-      ch += '<h1 class="view-header__title">Signals</h1>';
+      ch += '<h1 class="view-header__title">CareSignals</h1>';
       ch += '<p class="view-header__lede">' + _hdrLede + '</p>';
       ch += '</header>';
       ch += chDevices;
@@ -11792,7 +11792,7 @@ function _renderSignalsDemo(el, data, demoFirstName) {
   var demoName = demoFirstName || 'Dad';
   html += '<header class="view-header">';
   html += '<p class="view-header__eyebrow">Apple Watch \u00b7 Synced 8 min ago</p>';
-  html += '<h1 class="view-header__title">Signals</h1>';
+  html += '<h1 class="view-header__title">CareSignals</h1>';
   html += '<p class="view-header__lede">Daily rhythms from ' + escHtml(demoName) + '\u2019s wearables, sensors, and medications \u2014 patterns you might miss.</p>';
   html += '</header>';
 

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -18378,12 +18378,16 @@ function _headerMenuOutsideClick(e) {
 }
 
 function openSettings() {
-  // P4: Navigate to full-page settings view
-  updateSettingsAccount();
-  updateSettingsEhr();
-  if (!isDemoMode) { renderCareCircle(); }
-  renderSettingsPlanCard();
-  try { updatePhase2ToggleUI(); } catch(e){}
+  // P4: Navigate to full-page settings view.
+  // Defensive try-catch around each update so a single failure can't
+  // prevent the view from rendering.
+  try { updateSettingsAccount(); } catch(_e) {}
+  try { updateSettingsEhr(); } catch(_e) {}
+  if (!isDemoMode) { try { renderCareCircle(); } catch(_e) {} }
+  try { renderSettingsPlanCard(); } catch(_e) {}
+  try { updatePhase2ToggleUI(); } catch(_e) {}
+  // Update the Connected Sources section header with the active person's name.
+  try { _updateSvConnectedSourcesHeader(); } catch(_e) {}
   switchNavTo('settings');
   initIcons();
 }

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -1657,6 +1657,10 @@ function _isIPhone() {
 // Connect; if the page is still visible after 800ms (link didn't resolve),
 // shows the install prompt.
 function connectAppleHealth() {
+  if (isDemoMode) {
+    showToast('In the real app, this connects to Apple Health on your iPhone.');
+    return;
+  }
   if (!_isIPhone()) {
     showAppleHealthWebNotice();
     return;
@@ -13184,6 +13188,73 @@ function updateSettingsEhr() {
   }
 }
 
+// ── Connected Sources section header + per-row status (settings view) ────────
+// Updates the "Connected Sources" section label to "{NAME}'S CONNECTED SOURCES"
+// and syncs connection status into the sv-* rows.
+function _updateSvConnectedSourcesHeader() {
+  var label = document.getElementById('sv-connected-sources-label');
+  if (!label) return;
+  var name = getPersonFirstName();
+  if (name && name !== 'Patient') {
+    label.textContent = name.toUpperCase() + '\u2019S CONNECTED SOURCES';
+  } else {
+    label.textContent = 'Connected Sources';
+  }
+
+  // ── EHR row status ──
+  var ehrMeta = document.getElementById('sv-ehr-meta');
+  var ehrLabel = document.getElementById('sv-ehr-label');
+  var ehrStatus = document.getElementById('sv-ehr-status');
+  var ehrData = getEhrData(currentPersonId);
+  if (ehrData && ehrData.provider && ehrData.synced_at) {
+    // Connected — fold status into the row itself.
+    if (ehrLabel) ehrLabel.textContent = 'Health Records';
+    if (ehrMeta) ehrMeta.innerHTML = '<span style="color:var(--moss);font-weight:500;">Connected</span> \u00b7 '
+      + escHtml(ehrData.provider)
+      + ' \u00b7 <span style="color:var(--text-muted);">synced ' + escHtml(formatEventDate(ehrData.synced_at)) + '</span>';
+    if (ehrStatus) ehrStatus.innerHTML = '';
+  } else if (ehrData && ehrData.provider) {
+    if (ehrLabel) ehrLabel.textContent = 'Health Records';
+    if (ehrMeta) ehrMeta.innerHTML = '<span style="color:var(--moss);font-weight:500;">Connected</span> \u00b7 ' + escHtml(ehrData.provider);
+    if (ehrStatus) ehrStatus.innerHTML = '';
+  } else {
+    if (ehrLabel) ehrLabel.textContent = 'Connect Health Records';
+    if (ehrMeta) ehrMeta.textContent = 'Duke, UNC, WakeMed, and more \u2014 read-only';
+    if (ehrStatus) ehrStatus.innerHTML = '';
+  }
+
+  // ── Apple Health row status ──
+  var appleMeta = document.getElementById('sv-apple-health-meta');
+  if (appleMeta) {
+    var appleTs = null;
+    try { appleTs = localStorage.getItem('wellet_apple_health_last_sync_at_' + currentPersonId); } catch(_e) {}
+    if (appleTs && appleTs !== 'null' && appleTs !== 'None') {
+      var ago = _relativeTime(appleTs);
+      appleMeta.innerHTML = '<span style="color:var(--moss);font-weight:500;">Connected</span>'
+        + (ago ? ' \u00b7 last synced ' + escHtml(ago) : '');
+    } else {
+      appleMeta.textContent = 'Wearables & sensors';
+    }
+  }
+}
+
+// Tiny relative-time helper for connection status display.
+function _relativeTime(isoStr) {
+  try {
+    var then = new Date(isoStr).getTime();
+    var now = Date.now();
+    var mins = Math.round((now - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + ' min ago';
+    var hrs = Math.round(mins / 60);
+    if (hrs < 24) return hrs + ' hr ago';
+    var days = Math.round(hrs / 24);
+    if (days === 1) return 'yesterday';
+    if (days < 7) return days + ' days ago';
+    return formatEventDate(isoStr);
+  } catch(_e) { return ''; }
+}
+
 // Update profile EHR section
 function updateProfileEhr(personId) {
   var section = document.getElementById('profile-ehr-section');
@@ -19205,6 +19276,7 @@ function switchNavTo(view, skipPush) {
   if (view === 'settings') {
     updateSettingsViewAccount();
     if (!isDemoMode) { try { renderCareCircle(); } catch(e){} }
+    try { _updateSvConnectedSourcesHeader(); } catch(e){}
   }
   // Push history state for back button support
   if (!skipPush && view !== _currentNavView) {

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -24883,17 +24883,28 @@ renderPersonSwitcher = function() {
   initIcons();
 };
 
-// Override renderAskView to hide archived/closed in ask person bar
+// Override renderAskView to hide archived/closed in ask person bar and show
+// an empty-state when the active person has no records.
 var _origRenderAskView = renderAskView;
 renderAskView = function() {
   if (isDemoMode) return;
   var personBar = document.querySelector('#view-ask .ask-person-bar');
-  if (!personBar || !currentPeople.length) return;
+
+  // No people at all → fall back to original which renders a "Connect a chart" CTA.
+  if (!currentPeople.length) {
+    try { _origRenderAskView(); } catch(_e) {}
+    return;
+  }
+  if (!personBar) return;
+
+  // Filter out archived/closed people for the pill bar.
+  var visiblePeople = currentPeople.filter(function(p) {
+    var status = p.care_status || 'active';
+    return status !== 'archived' && status !== 'closed';
+  });
 
   var pillsHtml = '';
-  currentPeople.forEach(function(p) {
-    var status = p.care_status || 'active';
-    if (status === 'archived' || status === 'closed') return;
+  visiblePeople.forEach(function(p) {
     var active = p.id === currentPersonId ? ' active' : '';
     pillsHtml += '<button class="ask-person-pill' + active + '" onclick="selectAskRealPerson(this,\'' + p.id + '\')">'
       + '<span style="width:6px;height:6px;border-radius:50%;background:currentColor;opacity:0.7;display:inline-block;"></span>'
@@ -24903,10 +24914,41 @@ renderAskView = function() {
 
   var person = currentPeople.find(function(p){ return p.id === currentPersonId; });
   var firstName = person ? person.name.split(' ')[0] : '';
-  var inputEl = document.getElementById('ask-input');
-  if (inputEl) inputEl.placeholder = 'Ask about ' + escHtml(possSegment(firstName, true)) + ' health\u2026';
+
+  // Check whether the active person has any records.
+  var ehrData = getEhrData(currentPersonId) || {};
+  var hasObs = (ehrData.observations || []).length > 0;
+  var hasMeds = (ehrData.medications || []).length > 0;
+  var hasConds = (ehrData.conditions || []).length > 0;
+  var hasLiveData = (liveEvents || []).length > 0 || (liveMeds || []).length > 0;
+  var hasRecords = hasObs || hasMeds || hasConds || hasLiveData;
 
   var chatArea = document.getElementById('chat-area');
+  var chips = document.getElementById('suggestion-chips');
+  var inputEl = document.getElementById('ask-input');
+
+  if (!hasRecords) {
+    // Empty state — person has no records yet.
+    if (chatArea) {
+      chatArea.innerHTML = '<div style="text-align:center;padding:40px 24px 20px;">'
+        + '<div style="font-size:var(--type-body);color:#2C2A26;line-height:1.6;max-width:320px;margin:0 auto;">'
+        + 'Wellet answers from what\u2019s in your loved one\u2019s records. Add records for ' + escHtml(firstName)
+        + ' to <em style="color:#B8731C;font-style:italic;">unlock</em> Ask Wellet for them.'
+        + '</div>'
+        + '<button onclick="showConnectScreen()" style="margin-top:20px;padding:12px 24px;background:var(--moss);color:#fff;border:none;border-radius:999px;font-size:var(--type-body);font-weight:600;font-family:inherit;cursor:pointer;">'
+        + 'Add records for ' + escHtml(firstName) + '</button>'
+        + '<div style="margin-top:16px;font-size:var(--type-meta);color:var(--text-secondary);line-height:1.5;">'
+        + 'Or <em style="color:#B8731C;font-style:italic;">switch</em> to a different family member at the top of the screen.'
+        + '</div></div>';
+    }
+    if (chips) { chips.innerHTML = ''; chips.style.display = 'none'; }
+    if (inputEl) inputEl.placeholder = 'Add records to ask questions\u2026';
+    return;
+  }
+
+  // Normal state — person has records, render the full Ask interface.
+  if (inputEl) inputEl.placeholder = 'Ask about ' + escHtml(possSegment(firstName, true)) + ' health\u2026';
+
   if (chatArea) {
     var firstBubble = chatArea.querySelector('.chat-group.from-wellet .chat-bubble.wellet');
     if (firstBubble && firstBubble.textContent.indexOf('Ask me anything about') !== -1) {
@@ -24914,8 +24956,19 @@ renderAskView = function() {
     }
   }
 
-  var chips = document.getElementById('suggestion-chips');
   if (chips) {
+    try {
+      if (typeof buildAskChips === 'function') {
+        var smartChips = buildAskChips(firstName, currentPersonId);
+        if (smartChips && smartChips.length) {
+          chips.innerHTML = smartChips.map(function(c) {
+            return '<button class="chip" onclick="askQuestion(this.textContent)">' + escHtml(c) + '</button>';
+          }).join('');
+          chips.style.display = 'flex';
+          return;
+        }
+      }
+    } catch(_e) {}
     chips.innerHTML =
       '<button class="chip" onclick="askQuestion(this.textContent)">What medications is ' + escHtml(firstName) + ' taking?</button>'
       + '<button class="chip" onclick="askQuestion(this.textContent)">Summarize recent health events</button>'

--- a/index.html
+++ b/index.html
@@ -1359,14 +1359,14 @@
             </div>
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>
-          <div class="settings-row" style="cursor:pointer;" onclick="window.open('https://mywellet.com/privacy','_blank')">
+          <div class="settings-row" style="cursor:pointer;" onclick="window.open('https://getwellet.com/privacy','_blank')">
             <div class="settings-row-left">
               <div class="settings-row-icon"><i data-lucide="shield" style="width:15px;height:15px;"></i></div>
               <div><div class="settings-row-label">Privacy policy</div><div class="settings-row-meta">How your data is protected</div></div>
             </div>
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>
-          <div class="settings-row" style="cursor:pointer;" onclick="window.open('https://mywellet.com/terms','_blank')">
+          <div class="settings-row" style="cursor:pointer;" onclick="window.open('https://getwellet.com/terms','_blank')">
             <div class="settings-row-left">
               <div class="settings-row-icon"><i data-lucide="file-text" style="width:15px;height:15px;"></i></div>
               <div><div class="settings-row-label">Terms of service</div></div>
@@ -1384,10 +1384,18 @@
             </div>
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>
+          <div class="settings-row" style="cursor:pointer;" onclick="openBugReportSheet()">
+            <div class="settings-row-left">
+              <div class="settings-row-icon" style="background:#FEF0EE;color:var(--red);"><i data-lucide="bug" style="width:15px;height:15px;"></i></div>
+              <div><div class="settings-row-label">Report a bug</div><div class="settings-row-meta">Something broken? Let us know</div></div>
+            </div>
+            <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
+          </div>
           <div class="settings-row">
             <div class="settings-row-left">
               <div class="settings-row-icon"><i data-lucide="info" style="width:15px;height:15px;"></i></div>
-              <div><div class="settings-row-label">About Wellet</div><div class="settings-row-meta" style="font-family:var(--serif),serif;font-style:italic;">A record that belongs to your family, not the hospital. · v1.0</div></div>
+              <!-- TODO: replace hardcoded version with build-time constant -->
+              <div><div class="settings-row-label">About Wellet</div><div class="settings-row-meta" style="font-family:var(--serif),serif;font-style:italic;">A record that belongs to your family, not the hospital. &middot; v0.1.0-soft-launch</div></div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -1319,21 +1319,21 @@
             <i data-lucide="user-plus" style="width:15px;height:15px;"></i> Invite family member
           </button>
         </div>
-        <!-- Connected Sources -->
+        <!-- Connected Sources (per-person header updated by JS) -->
         <div class="settings-section" style="margin-top:12px;">
-          <div class="settings-section-label">Connected Sources</div>
+          <div class="settings-section-label" id="sv-connected-sources-label">Connected Sources</div>
           <div id="sv-ehr-status"></div>
-          <div class="settings-row" style="cursor:pointer;" onclick="startEhrConnect()">
+          <div class="settings-row" id="sv-ehr-row" style="cursor:pointer;" onclick="startEhrConnect()">
             <div class="settings-row-left">
               <div class="settings-row-icon" style="background:var(--mint);color:var(--moss);"><i data-lucide="hospital" style="width:15px;height:15px;"></i></div>
-              <div><div class="settings-row-label" id="sv-ehr-label">Connect Health Records</div><div class="settings-row-meta" id="sv-ehr-meta">Epic, Cerner, MyChart — read-only</div></div>
+              <div><div class="settings-row-label" id="sv-ehr-label">Connect Health Records</div><div class="settings-row-meta" id="sv-ehr-meta">Duke, UNC, WakeMed, and more &mdash; read-only</div></div>
             </div>
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>
-          <div class="settings-row">
+          <div class="settings-row" id="sv-apple-health-row" style="cursor:pointer;" onclick="connectAppleHealth()">
             <div class="settings-row-left">
               <div class="settings-row-icon"><i data-lucide="heart-pulse" style="width:15px;height:15px;"></i></div>
-              <div><div class="settings-row-label">Apple Health</div><div class="settings-row-meta">Wearables &amp; sensors</div></div>
+              <div><div class="settings-row-label">Apple Health</div><div class="settings-row-meta" id="sv-apple-health-meta">Wearables &amp; sensors</div></div>
             </div>
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>

--- a/index.html
+++ b/index.html
@@ -1338,9 +1338,9 @@
             <div class="settings-chevron"><i data-lucide="chevron-right" style="width:16px;height:16px;"></i></div>
           </div>
         </div>
-        <!-- Care Signals: what Wellet is watching for -->
+        <!-- CareSignals: what Wellet is watching for -->
         <div class="settings-section" style="margin-top:12px;">
-          <div class="settings-section-label">Care Signals</div>
+          <div class="settings-section-label">CareSignals</div>
           <div class="settings-row" style="cursor:pointer;" onclick="openWatchesSheet()">
             <div class="settings-row-left">
               <div class="settings-row-icon" style="background:#FFF6E2;color:#6B4F12;"><i data-lucide="bell" style="width:15px;height:15px;"></i></div>


### PR DESCRIPTION
## Summary

Pre-launch polish bundle addressing 6 findings from the mywellet.com audit. Each fix is one commit.

### FIX 1 — Ask Wellet bottom-nav routing (P0)
**Symptom:** Tapping Ask Wellet in bottom nav was a no-op when the active person had no records, or when navigating from CareSignals.
**Root cause:** The `renderAskView` override (line ~24888) silently returned when `currentPeople.length === 0` instead of falling through to the original function's CTA fallback.
**Fix:** Override now delegates to `_origRenderAskView()` for the no-people case. When a person exists but has no records, renders an editorial empty state with a "Add records for {name}" CTA. Also restores `buildAskChips()` for EHR-aware suggestion chips.

### FIX 2 — Settings kebab item dead (P1)
**Symptom:** Kebab → Settings dismissed the menu but didn't navigate.
**Root cause:** `openSettings()` called several preparatory functions without try-catch — if any threw (common in demo mode), `switchNavTo('settings')` never ran.
**Fix:** Wrapped each prep call in try-catch. Also added "Report a bug" row to the Settings view App section, updated version to `v0.1.0-soft-launch`, and changed Privacy/Terms links to getwellet.com.

### FIX 3 — "Signals" H1 → "CareSignals" (brand rule)
**Symptom:** Bottom nav said "CareSignals" but the page title said "Signals".
**Fix:** Updated 3 code paths (loading shell, connected-device branch, demo renderer) from "Signals" → "CareSignals". Fixed Settings section label from "Care Signals" (two words) to "CareSignals".

### FIX 4 — Wordmark color regression
**Symptom:** Wordmark rendered darker than spec. `.masthead .wordmark` used `--moss-deep` (#3F5F52), `.app-wordmark path` used hardcoded `#3D6B58`.
**Fix:** Both now use `var(--moss-text)` (#4F7A68) per brand spec.

### FIX 5 — Missing `--forest` CSS variable
**Symptom:** `.contact-avatar.forest` referenced undefined `var(--forest)`, rendering transparent.
**Fix:** Removed the orphan rule — `.forest` class is never assigned in JS.

### FIX 6 — Connected Sources rework (P1)
**6a.** Subtitle: "Epic, Cerner, MyChart — read-only" → "Duke, UNC, WakeMed, and more — read-only"
**6b.** Apple Health row: added `onclick="connectAppleHealth()"` — iPhone deep-link, non-iPhone toast, demo-mode toast
**6c.** Connection status per row: EHR shows "Connected · {provider} · synced {date}", Apple Health shows "Connected · last synced {ago}"
**6d.** Section header: "Connected Sources" → "{NAME}'S CONNECTED SOURCES" with active person's name

## Files changed

| File | What |
|------|------|
| `assets/wellet.js` | FIX 1 (Ask override), FIX 2 (openSettings), FIX 3 (3x Signals→CareSignals), FIX 6 (connectAppleHealth demo guard, _updateSvConnectedSourcesHeader, _relativeTime) |
| `index.html` | FIX 2 (bug report row, version, getwellet links), FIX 3 (CareSignals label), FIX 6 (Connected Sources HTML) |
| `assets/editorial-foundation.css` | FIX 4 (wordmark --moss-text) |
| `assets/wellet.css` | FIX 4 (app-wordmark tokenized), FIX 5 (.forest removed) |

## Test plan (90 seconds)

**FIX 1** — Sign in → tap Ask Wellet in bottom nav → view loads. Switch to a person with no records → empty state shows "{name}" CTA. Navigate to CareSignals → tap Ask Wellet → navigates correctly.

**FIX 2** — Tap kebab (⋮) → Settings → Settings page loads. Verify: email shown, Sign out works, Report a bug opens sheet, version says "v0.1.0-soft-launch", Privacy/Terms open getwellet.com.

**FIX 3** — Tap CareSignals in bottom nav → page H1 says "CareSignals" (not "Signals"). Open Settings → section label says "CareSignals" (not "Care Signals").

**FIX 4** — Look at the "wellet" wordmark in the header — should be lighter moss (#4F7A68), not dark green.

**FIX 5** — No visible regression (removed dead CSS).

**FIX 6** — Open Settings → "Connected Sources" section header should say "{NAME}'S CONNECTED SOURCES". EHR row says "Duke, UNC, WakeMed, and more". If connected, shows "Connected · {provider}". Apple Health row is tappable. In demo mode, tapping Apple Health shows toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)