### PR TITLE
fix(connect): Google Health mobile return + dedupe duplicate Terra connections

### DIFF
--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -2296,6 +2296,11 @@ function connectFromMeOnboarding(source) {
   if (source === 'google') {
     // Google Health = Terra widget pre-locked to provider=GOOGLE so the user
     // skips the full provider picker and lands straight on Google's OAuth.
+    // Mark that the user launched this from the Connect screen so the Terra
+    // callback restores them to Connections (not Home/Summary). Without this
+    // flag, openTerraConnect's mobile branch stashes _currentNavView, which
+    // showAuthenticatedApp() just reset to the default tab.
+    try { sessionStorage.setItem('wellet_terra_return_to_connect', '1'); } catch(_e) {}
     var screenG = document.getElementById('connect-data-screen');
     if (screenG) screenG.style.display = 'none';
     document.body.classList.remove('connect-data-open');
@@ -2304,6 +2309,7 @@ function connectFromMeOnboarding(source) {
     return;
   }
   if (source === 'terra') {
+    try { sessionStorage.setItem('wellet_terra_return_to_connect', '1'); } catch(_e) {}
     var screen2 = document.getElementById('connect-data-screen');
     if (screen2) screen2.style.display = 'none';
     document.body.classList.remove('connect-data-open');
@@ -28391,14 +28397,35 @@ function _onTerraAuthSuccessInParent(payload) {
     invalidateSignalsCache(payload.person_id);
     showToast('Wearable connected successfully', 'success');
     if (typeof renderSignalsView === 'function') { try { renderSignalsView(); } catch(e){} }
-    // Higher priority: if onboarding connect screen is active, return user to it with \u2713
-    if (typeof _isConnectScreenActive === 'function' && _isConnectScreenActive()) {
-      try { showConnectScreen(); } catch(e) { console.warn('[Terra] showConnectScreen failed:', e); }
-      return;
-    }
-    if (obChat && obChat.phase === 'connect') {
-      obOnDeviceConnected(payload.provider || 'your device');
-    }
+    // Refresh the in-memory Terra connections cache so refreshConnectScreenStatus
+    // sees the new row and lights up the Google Health / Other wearables card.
+    // Without this, _terraConnections is whatever it was at page load (often
+    // empty after a mobile top-level redirect) and the card stays grey even
+    // though the row is in Postgres. Mirrors the EHR + Apple flows which both
+    // refresh their source-of-truth before re-rendering Connections.
+    var reload = (typeof loadTerraConnections === 'function')
+      ? loadTerraConnections(payload.person_id).then(function(conns) {
+          try { _terraConnections = conns || []; } catch(_e) {}
+        }).catch(function(_e){})
+      : Promise.resolve();
+    Promise.resolve(reload).then(function() {
+      // Re-open the Connect screen if either (a) it's still active, or
+      // (b) the user launched the flow from a Connect card on mobile and
+      // we stashed the return-to-connect flag in sessionStorage. Higher
+      // priority: if onboarding connect screen is active, return user to
+      // it with \u2713.
+      var returnToConnect = false;
+      try { returnToConnect = sessionStorage.getItem('wellet_terra_return_to_connect') === '1'; } catch(_e) {}
+      var connectActive = (typeof _isConnectScreenActive === 'function' && _isConnectScreenActive());
+      if (connectActive || returnToConnect) {
+        try { sessionStorage.removeItem('wellet_terra_return_to_connect'); } catch(_e) {}
+        try { showConnectScreen(); } catch(e) { console.warn('[Terra] showConnectScreen failed:', e); }
+        return;
+      }
+      if (obChat && obChat.phase === 'connect') {
+        obOnDeviceConnected(payload.provider || 'your device');
+      }
+    });
   });
 }
 
@@ -28620,9 +28647,29 @@ function handleTerraCallback() {
     _onTerraAuthFailureInParent();
   }
 
-  // Mobile came back via top-level redirect \u2014 send the user back to the
-  // CareSignals view they were on when they started the connect flow.
-  if (pending && pending.view) {
+  // Mobile came back via top-level redirect. Two cases:
+  //   1. User launched from the Connect screen (Google Health / Other
+  //      wearables card) \u2014 honor that flag and re-open Connections so
+  //      they see the freshly-lit card. Without this, _currentNavView was
+  //      reset to the default tab (Home/Summary) by showAuthenticatedApp()
+  //      before the redirect, so pending.view would route to Summary.
+  //   2. User launched from elsewhere (e.g. CareSignals "+ Connect a
+  //      wearable") \u2014 restore that view as before.
+  var fromConnect = false;
+  try {
+    fromConnect = sessionStorage.getItem('wellet_terra_return_to_connect') === '1';
+    // Don't remove the flag here \u2014 _onTerraAuthSuccessInParent reads it
+    // too, after the async storeTerraConnection + loadTerraConnections
+    // round-trip, and clears it itself.
+  } catch(_e) {}
+  if (fromConnect) {
+    try { showAuthenticatedApp(); } catch(_e) {}
+    // showConnectScreen() is also called from _onTerraAuthSuccessInParent
+    // (success path) once the connections cache reloads. Calling it here
+    // too means the overlay opens immediately on return; the later call
+    // just re-renders with the now-Connected card.
+    try { if (typeof showConnectScreen === 'function') showConnectScreen(); } catch(_e) {}
+  } else if (pending && pending.view) {
     try { switchNavTo(pending.view); } catch(e) { console.warn('[Terra] restore view failed:', e); }
   }
 }

--- a/supabase/functions/terra-auth/index.ts
+++ b/supabase/functions/terra-auth/index.ts
@@ -220,6 +220,52 @@ Deno.serve(async (req) => {
         return json({ error: "Person not found" }, 404);
       }
 
+      const normalizedProvider = provider || "unknown";
+
+      // Look up any existing ACTIVE connection for this (user, person, provider).
+      // Terra mints a fresh terra_user_id for every widget session, so a user
+      // who taps "Connect Google Health" twice would otherwise create two
+      // active rows (the old code's onConflict='terra_user_id' never matched
+      // because the keys differed). We detect the existing row up-front so we
+      // can (a) deauthenticate the stale terra_user_id with Terra to free up
+      // the slot, and (b) reuse the row so downstream FKs (e.g.
+      // wearable_observations.terra_connection_id) stay stable.
+      const { data: existing } = await db
+        .from("terra_connections")
+        .select("id, terra_user_id")
+        .eq("user_id", user.id)
+        .eq("person_id", person_id)
+        .eq("provider", normalizedProvider)
+        .eq("status", "active")
+        .maybeSingle();
+
+      // If we're replacing a different terra_user_id, deauth the old one with
+      // Terra so we don't keep paying for a zombie connection that will never
+      // be used again. Best-effort — don't block the store on network failure.
+      if (existing && existing.terra_user_id && existing.terra_user_id !== terra_user_id) {
+        const terraApiKey = Deno.env.get("TERRA_API_KEY");
+        const terraDevId = Deno.env.get("TERRA_DEV_ID");
+        if (terraApiKey && terraDevId) {
+          try {
+            await fetch("https://api.tryterra.co/v2/auth/deauthenticateUser", {
+              method: "DELETE",
+              headers: {
+                "dev-id": terraDevId,
+                "x-api-key": terraApiKey,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ user_id: existing.terra_user_id }),
+            });
+          } catch (e) {
+            console.error("Terra deauth (replace) error:", e);
+          }
+        }
+      }
+
+      // Upsert against the partial unique index on (user_id, person_id, provider)
+      // WHERE status='active'. With the new index in place, a retry updates the
+      // existing active row instead of creating a duplicate. Disconnected rows
+      // are preserved as audit history (the partial index doesn't cover them).
       const { data: conn, error: connErr } = await db
         .from("terra_connections")
         .upsert(
@@ -227,12 +273,12 @@ Deno.serve(async (req) => {
             user_id: user.id,
             person_id: person_id,
             terra_user_id: terra_user_id,
-            provider: provider || "unknown",
+            provider: normalizedProvider,
             status: "active",
             connected_at: new Date().toISOString(),
             disconnected_at: null,
           },
-          { onConflict: "terra_user_id" },
+          { onConflict: "user_id,person_id,provider" },
         )
         .select()
         .single();

--- a/supabase/migrations/20260523180000_terra_connections_active_unique.sql
+++ b/supabase/migrations/20260523180000_terra_connections_active_unique.sql
@@ -1,0 +1,18 @@
+-- 2026-05-23: prevent duplicate active Terra connections per (user, person, provider).
+--
+-- Bug: terra-auth/store upserts with onConflict='terra_user_id', but Terra mints a
+-- brand-new terra_user_id for every widget session. So a user who taps "Connect
+-- Google Health" twice ends up with two active rows instead of one updated row.
+-- Real-world impact discovered today: one user had 4 active GOOGLE rows for
+-- themselves; only the first was actually receiving data.
+--
+-- Fix: partial unique index scoped to status='active'. Disconnected rows are
+-- preserved as audit history (we don't want to lose the trail), but at most one
+-- active row can exist per (user_id, person_id, provider) tuple.
+--
+-- Pre-check before applying: existing duplicate active rows have been cleaned up.
+-- This migration will fail loudly if duplicates remain — that's intentional.
+
+create unique index if not exists terra_connections_active_unique
+  on public.terra_connections (user_id, person_id, provider)
+  where status = 'active';


### PR DESCRIPTION
Two bugs discovered while tracing Betsy's account after she reported the Google Health connect return going to Summary and the card not lighting up.

## Bugs

### Bug 1 — UI: wrong return view + grey card (`assets/wellet.js`)

The Google Health card uses Terra OAuth via top-level redirect on mobile. On return:

- **Wrong tab.** `_handleConnectDataSource('google')` calls `showAuthenticatedApp()` before `openTerraConnect`, which resets `_currentNavView` to Home. `openTerraConnect` then stashes that as `pending.view`, so `handleTerraCallback` routes the user to Summary instead of Connections.
- **Grey card.** `refreshConnectScreenStatus` reads `_terraConnections` (in-memory cache), but `_onTerraAuthSuccessInParent` writes to Postgres without ever reloading the cache. After a top-level redirect the cache is empty, so the card stays grey even though the row exists.

### Bug 2 — DB: duplicate active rows on every retry (`supabase/functions/terra-auth/index.ts`)

`terra-auth/store` upserts with `onConflict: "terra_user_id"`, but Terra mints a **fresh `terra_user_id` per widget session**. So every retry creates a new row. Betsy had 4 active GOOGLE rows for herself; only the May 12 one was actually receiving data.

## Fixes

**Bug 1 (`assets/wellet.js`)**
1. `google` and `terra` card handlers stash `wellet_terra_return_to_connect=1` in sessionStorage before redirecting.
2. `handleTerraCallback` honors that flag and re-opens the Connect overlay instead of restoring `pending.view`.
3. `_onTerraAuthSuccessInParent` awaits `loadTerraConnections()` and refreshes `_terraConnections` before calling `showConnectScreen()`, so `refreshConnectScreenStatus` sees the new row.

**Bug 2 (Edge Function + migration)**
1. New partial unique index `terra_connections_active_unique` on `(user_id, person_id, provider) WHERE status='active'`. Disconnected rows preserved as audit history.
2. `store` upserts with `onConflict: "user_id,person_id,provider"` — retries update the existing row instead of inserting a duplicate.
3. On reconnect with a different `terra_user_id`, the Edge Function deauthenticates the old one with Terra before storing the new one. Stops zombie connections from eating Terra quota / spamming webhooks.

## Pre-merge cleanup already done

Betsy's 3 dataless duplicate GOOGLE rows (today 15:04, 16:23, 16:24 UTC) were marked `status='disconnected'` before commit. Global check confirmed zero remaining duplicate active rows across all users — the new partial unique index will apply cleanly.

## Deploy order (important)

1. **Apply migration first**: `20260523180000_terra_connections_active_unique.sql` (adds the partial unique index). Safe — verified zero duplicates.
2. **Deploy Edge Function**: `terra-auth` v24 (uses the new conflict target — would fail without the index from step 1).
3. **Merge PR + Netlify deploy**: ships the UI fix.

If you flip the order, the Edge Function deploy will start returning 500s from `store` because `onConflict: "user_id,person_id,provider"` requires the unique index to exist.

## Test plan

On iPhone Safari at mywellet.com after deploy:
1. Sign in, open Connections.
2. Tap **Google Health** → complete OAuth.
3. Verify: returns to **Connections** (not Summary), card shows **Connected**.
4. Tap **Google Health** again (same person). Verify: still one active GOOGLE row in `terra_connections` (updated, not duplicated); old `terra_user_id` deauthed with Terra.
5. Tap **Other wearables** → connect Fitbit. Same return + Connected.
6. From CareSignals "+ Connect a wearable" — old behavior preserved (returns to CareSignals, not Connect).

## Files

- `assets/wellet.js` (UI fix)
- `supabase/functions/terra-auth/index.ts` (dedupe + deauth)
- `supabase/migrations/20260523180000_terra_connections_active_unique.sql` (partial unique index)
