### PR TITLE
feat(reimbursements): in-app Reimbursements surface (PR 1)

### DIFF
--- a/assets/editorial-reimbursements.css
+++ b/assets/editorial-reimbursements.css
@@ -1,0 +1,373 @@
+/* ============================================================
+   Editorial pass · Reimbursements view (PR 1)
+   Scoped to #view-reimbursements[data-editorial="reimbursements"]
+
+   Matches the signals/resources editorial pattern (Fraunces
+   masthead + DM Sans body). Brand colors only:
+     CREAM  background  → var(--cream)   (#F7F5F0 in tokens; spec #faf6f0)
+     MOSS   primary CTA → var(--moss)    (#608F7C in tokens; spec #2d6a4f)
+     TERRA  stale ribbon→ #c07028        (spec; ribbon only)
+     INK    text        → var(--ink-9) / var(--ink-7)
+   The spec lists slightly different hexes; we use the existing
+   design tokens so the surface stays consistent with the rest of
+   the app, and reserve TERRA strictly for the stale ribbon.
+   ============================================================ */
+
+/* Confidence pip tokens (spec checklist). */
+#view-reimbursements[data-editorial="reimbursements"] {
+  --reimb-confidence-high: var(--moss);
+  --reimb-confidence-medium: var(--ink-7, #3C362F);
+  --reimb-confidence-low: var(--ink-4, #8A8278);
+  --reimb-terra: #c07028;
+}
+
+/* Only force block layout when this view is active — otherwise leave the
+   global .app-view { display:none } rule in charge. */
+#view-reimbursements[data-editorial="reimbursements"].active { display: block; }
+
+#view-reimbursements[data-editorial="reimbursements"] .reimb-view {
+  display: block;
+  padding: 0 0 48px;
+}
+
+/* ── View header (shared editorial masthead pattern) ─────────── */
+#view-reimbursements[data-editorial="reimbursements"] .view-header {
+  display: block;
+  padding: 18px 0 14px;
+  margin: 0 0 8px;
+  border-bottom: 1px solid var(--ink-2, rgba(0,0,0,0.08));
+}
+#view-reimbursements[data-editorial="reimbursements"] .view-header__eyebrow {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-5, #6E665C);
+  margin: 0 0 6px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .view-header__title {
+  font-family: var(--serif, "Fraunces", Georgia, serif);
+  font-weight: 400;
+  font-size: var(--type-display, 32px);
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  color: var(--ink-9, #1F1B16);
+  margin: 0 0 6px;
+  font-variation-settings: "opsz" 72, "SOFT" 60;
+}
+#view-reimbursements[data-editorial="reimbursements"] .view-header__lede {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  line-height: 1.45;
+  color: var(--ink-5, #6E665C);
+  margin: 0;
+}
+
+/* ── Section heads ───────────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-section-head {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-5, #6E665C);
+  margin: 22px 0 10px;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  background: var(--moss);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 15px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+  margin-top: 16px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-btn-primary:hover {
+  background: var(--moss-deep, #3F5F52);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--moss);
+  border: 1.5px solid var(--moss);
+  border-radius: 12px;
+  padding: 11px 16px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  font-weight: 500;
+  cursor: pointer;
+  margin-top: 12px;
+  transition: background 0.15s;
+}
+
+/* ── Empty state ─────────────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-empty {
+  padding: 24px 0 8px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-empty-body {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  color: var(--ink-5, #6E665C);
+  line-height: 1.5;
+}
+
+/* ── Stale ribbon (TERRA — soft, the only TERRA in this surface) ─ */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-ribbon {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  background: rgba(192, 112, 40, 0.10);
+  border: 1px solid rgba(192, 112, 40, 0.30);
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin: 14px 0 6px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  color: var(--reimb-terra, #c07028);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-ribbon-btn {
+  flex-shrink: 0;
+  background: var(--reimb-terra, #c07028);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 7px 16px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+/* ── Situation summary + prefill chips ───────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-situation {
+  margin: 8px 0 4px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-prefill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--cream, #F7F5F0);
+  border: 1px solid var(--ink-2, #C8C0B5);
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  color: var(--ink-9, #1F1B16);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-chip-prov {
+  font-size: var(--type-micro, 11px);
+  color: var(--ink-4, #8A8278);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-chip-edit {
+  background: none;
+  border: none;
+  color: var(--moss);
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-assessed {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  color: var(--ink-4, #8A8278);
+  margin-top: 8px;
+}
+
+/* ── Question flow ───────────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-q {
+  margin: 0 0 18px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-q-label {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  font-weight: 500;
+  color: var(--ink-9, #1F1B16);
+  margin: 0 0 8px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--cream, #F7F5F0);
+  border: 1.5px solid var(--ink-2, #C8C0B5);
+  border-radius: 11px;
+  padding: 11px 14px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  color: var(--ink-9, #1F1B16);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-option:hover {
+  border-color: var(--moss);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1.5px solid var(--ink-2, #C8C0B5);
+  border-radius: 12px;
+  padding: 13px 16px;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  color: var(--ink-9, #1F1B16);
+  background: #fff;
+  outline: none;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-input:focus {
+  border-color: var(--moss);
+}
+
+/* ── Program cards ───────────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-programs {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 20px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card {
+  background: var(--cream, #F7F5F0);
+  border: 1px solid var(--ink-2, #C8C0B5);
+  border-left: 4px solid var(--moss);
+  border-radius: 12px;
+  padding: 18px 18px 16px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-name {
+  font-family: var(--serif, "Fraunces", Georgia, serif);
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+  color: var(--ink-9, #1F1B16);
+  margin: 0 0 4px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-amount {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  font-weight: 600;
+  color: var(--moss-text, #4F7A68);
+  margin: 0 0 10px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-pip {
+  display: inline-block;
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: capitalize;
+  padding: 3px 10px;
+  border-radius: 999px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-pip--high {
+  color: #fff;
+  background: var(--reimb-confidence-high, var(--moss));
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-pip--medium {
+  color: var(--reimb-confidence-medium, #3C362F);
+  background: rgba(60, 54, 47, 0.10);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-pip--low {
+  color: var(--reimb-confidence-low, #8A8278);
+  background: rgba(138, 130, 120, 0.12);
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-sub {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-5, #6E665C);
+  margin: 14px 0 6px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-why ul,
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-caveats ul {
+  margin: 0;
+  padding-left: 18px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-why li,
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-caveats li {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  line-height: 1.5;
+  color: var(--ink-7, #3C362F);
+  margin: 0 0 4px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-caveats {
+  margin-top: 12px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-caveats summary {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  font-weight: 500;
+  color: var(--ink-5, #6E665C);
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-cta {
+  display: inline-block;
+  margin-top: 14px;
+  color: var(--moss);
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  font-weight: 600;
+  text-decoration: none;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-card-cta:hover {
+  text-decoration: underline;
+}
+
+/* ── Signals (lower priority) ────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-signals {
+  margin-top: 28px;
+  padding-top: 18px;
+  border-top: 1px solid var(--ink-2, rgba(0,0,0,0.08));
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-signal-row {
+  margin: 0 0 12px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-signal-title {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-body, 14px);
+  font-weight: 600;
+  color: var(--ink-9, #1F1B16);
+  margin: 0 0 3px;
+}
+#view-reimbursements[data-editorial="reimbursements"] .reimb-signal-why {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-meta, 13px);
+  line-height: 1.5;
+  color: var(--ink-5, #6E665C);
+}
+
+/* ── Footer disclaimer ───────────────────────────────────────── */
+#view-reimbursements[data-editorial="reimbursements"] .reimb-footer {
+  font-family: var(--sans, "DM Sans", system-ui, sans-serif);
+  font-size: var(--type-micro, 11px);
+  line-height: 1.6;
+  color: var(--ink-4, #8A8278);
+  margin-top: 32px;
+}

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -23859,6 +23859,394 @@ async function renderResourcesView() {
   initIcons();
 }
 
+// Question wording mirrors the public /scorecard2 form (already user-tested).
+var _REIMB_QUESTIONS = {
+  loved_one_age_band: {
+    label: 'About how old is your loved one?',
+    type: 'single',
+    options: [
+      ['under_60', 'Under 60'], ['60_69', '60–69'], ['70_79', '70–79'],
+      ['80_89', '80–89'], ['90_plus', '90 or older'], ['prefer_not_say', 'Prefer not to say'],
+    ],
+  },
+  conditions: {
+    label: 'What is your loved one living with? Add or remove as needed.',
+    type: 'multi',
+    options: [
+      ['diabetes', 'Diabetes'], ['heart', 'Heart condition'], ['cancer', 'Cancer'],
+      ['dementia', 'Dementia or memory loss'], ['kidney', 'Kidney condition'], ['lung', 'Lung condition'],
+      ['mental_health', 'Mental health'], ['mobility', 'Mobility or falls'], ['multiple', 'Several conditions'],
+      ['none_known', 'None known'], ['prefer_not_say', 'Prefer not to say'],
+    ],
+  },
+  current_tools: {
+    label: 'How do you keep track of their care today?',
+    type: 'multi',
+    options: [
+      ['mychart', 'MyChart'], ['another_portal', 'Another portal'], ['paper_notes', 'Paper notes'],
+      ['spreadsheet', 'A spreadsheet'], ['memory', 'Mostly memory'], ['shared_doc', 'A shared document'],
+    ],
+  },
+  biggest_worry: {
+    label: 'What worries you most right now?',
+    type: 'single',
+    options: [
+      ['missing_something', 'Missing something important'], ['medication_changes', 'Medication changes'],
+      ['appointment_chaos', 'Keeping appointments straight'], ['multiple_doctors', 'Coordinating many doctors'],
+      ['declining_changes', 'Noticing slow declines'], ['other', 'Something else'],
+    ],
+  },
+  coverage: {
+    label: 'What coverage does your loved one have? Confirm anything we inferred.',
+    type: 'multi',
+    options: [
+      ['medicare', 'Medicare'], ['medicaid', 'Medicaid'], ['veteran', 'Veteran (VA)'],
+      ['private', 'Private insurance'], ['marketplace', 'Marketplace plan'], ['none', 'None'], ['unsure', 'Not sure'],
+    ],
+  },
+  adl_level: {
+    label: 'How much help do they need with daily activities (bathing, dressing, eating)?',
+    type: 'single',
+    options: [
+      ['none', 'No help needed'], ['1_2', 'Help with 1–2'], ['3_plus', 'Help with 3 or more'],
+      ['supervision', 'Needs supervision'], ['unsure', 'Not sure'],
+    ],
+  },
+  hospital_system: {
+    label: 'Which hospital or health system do they use?',
+    type: 'text',
+  },
+  caregiver_role: {
+    label: 'What is your role in their care?',
+    type: 'single',
+    options: [
+      ['primary', 'Primary caregiver'], ['shared', 'Shared with others'], ['distance', 'Caring from a distance'],
+      ['professional', 'Professional caregiver'], ['other', 'Other'],
+    ],
+  },
+  state: {
+    label: 'Which state does your loved one live in? (2-letter, e.g. NC)',
+    type: 'text',
+  },
+};
+
+var _REIMB_PROVENANCE_LABEL = {
+  ehr: 'From the chart', user: 'You told us', inferred: 'Inferred', asked: 'You told us',
+};
+
+function _reimbFirstName() {
+  var person = (currentPeople || []).find(function(p){ return p.id === currentPersonId; });
+  return person && person.name ? person.name.split(' ')[0] : 'your loved one';
+}
+
+// Read the current assessment row for the active loved one (RLS-scoped).
+async function _loadReimbursements(personId) {
+  if (!personId || typeof db === 'undefined' || !db) return null;
+  try {
+    var r = await db.from('reimbursement_assessments')
+      .select('id, result_programs, result_signals, input_provenance, needs_refresh, assessed_at, stale_at, loved_one_age_band, conditions, current_tools, biggest_worry, coverage, adl_level, hospital_system, caregiver_role, state')
+      .eq('person_id', personId)
+      .maybeSingle();
+    if (r && r.data) {
+      // 90-day staleness is evaluated client-side (no cron); the triggers
+      // only cover chart/connection changes.
+      if (r.data.stale_at && new Date(r.data.stale_at) < new Date()) {
+        r.data.needs_refresh = true;
+      }
+    }
+    return r && r.data ? r.data : null;
+  } catch (e) {
+    console.warn('[Reimbursements] load error', e);
+    return null;
+  }
+}
+
+// Call the JWT-verified "reimbursements" edge function.
+async function _callReimbursementsFn(personId, partialInput, mode) {
+  var sessRes = await db.auth.getSession();
+  var session = sessRes && sessRes.data ? sessRes.data.session : null;
+  if (!session) throw new Error('Not signed in');
+  var res = await fetch(SUPABASE_URL + '/functions/v1/reimbursements', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': SUPABASE_ANON_KEY,
+      'Authorization': 'Bearer ' + session.access_token,
+    },
+    body: JSON.stringify({ person_id: personId, partial_input: partialInput || {}, mode: mode || undefined }),
+  });
+  if (!res.ok) {
+    var msg = 'Request failed';
+    try { var j = await res.json(); msg = j.error || msg; } catch (_e) {}
+    throw new Error(msg);
+  }
+  return await res.json();
+}
+
+async function renderReimbursementsView() {
+  var el = document.getElementById('view-reimbursements');
+  if (!el) return;
+  if (isDemoMode) {
+    el.innerHTML = '<div class="reimb-view"><div class="reimb-empty"><div class="reimb-empty-body">Reimbursements are available once you connect a real account.</div></div></div>';
+    return;
+  }
+  el.innerHTML = '<div class="reimb-view" style="text-align:center;padding:60px 20px;"><div style="color:var(--text-muted);font-size:var(--type-meta);">Loading…</div></div>';
+
+  try { if (typeof _wa !== 'undefined' && _wa.track) _wa.track('feature', 'reimbursement_view_opened', { entry_point: 'header_menu' }); } catch (_e) {}
+
+  var assessment = await _loadReimbursements(currentPersonId);
+  if (!assessment) {
+    _renderReimbursementsEmpty(el);
+    return;
+  }
+  _renderReimbursementsPopulated(el, assessment);
+}
+
+function _renderReimbursementsEmpty(el) {
+  var name = _reimbFirstName();
+  var html = '<div class="reimb-view">'
+    + '<div class="view-header">'
+    +   '<div class="view-header__eyebrow">Reimbursements</div>'
+    +   '<h1 class="view-header__title">Programs that may pay for the care you’re giving</h1>'
+    +   '<p class="view-header__lede">We can show you programs that may apply for ' + escHtml(name) + '. About 3 quick questions — we’ll fill in what we already know.</p>'
+    + '</div>'
+    + '<div class="reimb-empty">'
+    +   '<button type="button" class="reimb-btn-primary" onclick="_startReimbursementsFlow()">See programs</button>'
+    + '</div>'
+    + '<p class="reimb-footer">Wellet does not pay caregivers. We aggregate your loved one’s health records and surface programs that may pay for the care you’re already giving.</p>'
+    + '</div>';
+  el.innerHTML = html;
+  initIcons();
+}
+
+// Server-first: resolve prefilled vs asked fields, then show the single-page form.
+async function _startReimbursementsFlow() {
+  var el = document.getElementById('view-reimbursements');
+  if (!el) return;
+  el.innerHTML = '<div class="reimb-view" style="text-align:center;padding:60px 20px;"><div style="color:var(--text-muted);font-size:var(--type-meta);">Pulling what we know…</div></div>';
+  try {
+    var pre = await _callReimbursementsFn(currentPersonId, {}, 'prefill');
+    _renderReimbursementsQuestionFlow(pre.prefilled_fields || [], pre.asked_fields || [], pre.input_provenance || {});
+  } catch (e) {
+    console.warn('[Reimbursements] prefill error', e);
+    showToast('Could not start — please try again');
+    renderReimbursementsView();
+  }
+}
+
+// Single-page form: prefilled chips on top, asked questions below.
+function _renderReimbursementsQuestionFlow(prefilledFields, askedFields, provenance) {
+  var el = document.getElementById('view-reimbursements');
+  if (!el) return;
+  var name = _reimbFirstName();
+
+  var html = '<div class="reimb-view reimb-flow">'
+    + '<div class="view-header">'
+    +   '<div class="view-header__eyebrow">Reimbursements</div>'
+    +   '<h1 class="view-header__title">A few quick questions</h1>'
+    +   '<p class="view-header__lede">Here’s what we pulled from ' + escHtml(name) + '’s record. Edit anything that’s off.</p>'
+    + '</div>';
+
+  // Prefilled (read-only) chips.
+  if (prefilledFields && prefilledFields.length) {
+    html += '<div class="reimb-section"><div class="reimb-section-head">What we already know</div><div class="reimb-prefill-chips">';
+    prefilledFields.forEach(function(f){
+      var q = _REIMB_QUESTIONS[f];
+      var prov = provenance && provenance[f] ? provenance[f] : 'ehr';
+      html += '<div class="reimb-chip" data-field="' + escHtml(f) + '">'
+        + '<span class="reimb-chip-label">' + escHtml(q ? q.label : f) + '</span>'
+        + '<span class="reimb-chip-prov">' + escHtml(_REIMB_PROVENANCE_LABEL[prov] || 'From the chart') + '</span>'
+        + '<button type="button" class="reimb-chip-edit" onclick="_reimbEditField(\'' + escHtml(f) + '\')">Edit</button>'
+        + '</div>';
+    });
+    html += '</div></div>';
+  }
+
+  // Asked questions.
+  html += '<form id="reimb-form" class="reimb-section" onsubmit="return false;"><div class="reimb-section-head">A few quick questions</div>';
+  (askedFields || []).forEach(function(f){
+    html += _reimbQuestionFieldHtml(f);
+  });
+  html += '<div id="reimb-edit-fields"></div>';
+  html += '<button type="button" class="reimb-btn-primary" onclick="_submitReimbursementsAnswers()">See my programs</button>';
+  html += '</form>';
+  html += '</div>';
+
+  el.innerHTML = html;
+  initIcons();
+}
+
+function _reimbQuestionFieldHtml(field) {
+  var q = _REIMB_QUESTIONS[field];
+  if (!q) return '';
+  var out = '<div class="reimb-q" data-field="' + escHtml(field) + '"><div class="reimb-q-label">' + escHtml(q.label) + '</div>';
+  if (q.type === 'text') {
+    out += '<input type="text" class="reimb-input" data-field="' + escHtml(field) + '" />';
+  } else {
+    out += '<div class="reimb-options">';
+    q.options.forEach(function(opt){
+      var val = opt[0], lbl = opt[1];
+      out += '<label class="reimb-option"><input type="' + (q.type === 'multi' ? 'checkbox' : 'radio') + '" name="reimb_' + escHtml(field) + '" value="' + escHtml(val) + '" /> ' + escHtml(lbl) + '</label>';
+    });
+    out += '</div>';
+  }
+  out += '</div>';
+  return out;
+}
+
+// Convert a prefilled chip into an editable question appended to the form.
+function _reimbEditField(field) {
+  var container = document.getElementById('reimb-edit-fields');
+  if (!container) return;
+  if (container.querySelector('[data-field="' + field + '"]')) return; // already editing
+  var chip = document.querySelector('.reimb-chip[data-field="' + field + '"]');
+  if (chip) chip.style.display = 'none';
+  container.insertAdjacentHTML('beforeend', _reimbQuestionFieldHtml(field));
+  initIcons();
+}
+
+// Gather all answered fields (asked + edited) into a partial_input object.
+function _reimbCollectInput() {
+  var input = {};
+  var form = document.getElementById('reimb-form');
+  if (!form) return input;
+  form.querySelectorAll('.reimb-q').forEach(function(qEl){
+    var field = qEl.getAttribute('data-field');
+    var q = _REIMB_QUESTIONS[field];
+    if (!q) return;
+    if (q.type === 'text') {
+      var inp = qEl.querySelector('input[type="text"]');
+      if (inp && inp.value.trim()) input[field] = inp.value.trim();
+    } else if (q.type === 'multi') {
+      var vals = [];
+      qEl.querySelectorAll('input:checked').forEach(function(c){ vals.push(c.value); });
+      if (vals.length) input[field] = vals;
+    } else {
+      var sel = qEl.querySelector('input:checked');
+      if (sel) input[field] = sel.value;
+    }
+  });
+  return input;
+}
+
+async function _submitReimbursementsAnswers() {
+  var el = document.getElementById('view-reimbursements');
+  var input = _reimbCollectInput();
+  if (el) el.innerHTML = '<div class="reimb-view" style="text-align:center;padding:60px 20px;"><div style="color:var(--text-muted);font-size:var(--type-meta);">Finding programs…</div></div>';
+  try {
+    var result = await _callReimbursementsFn(currentPersonId, input, 'submit');
+    try {
+      if (typeof _wa !== 'undefined' && _wa.track) {
+        _wa.track('feature', 'reimbursement_assessment_completed', {
+          prefilled_count: (result.prefilled_fields || []).length,
+          asked_count: (result.asked_fields || []).length,
+        });
+      }
+    } catch (_e) {}
+    // Re-render from the freshly saved row.
+    renderReimbursementsView();
+  } catch (e) {
+    console.warn('[Reimbursements] submit error', e);
+    showToast('Could not save — please try again');
+    renderReimbursementsView();
+  }
+}
+
+function _renderReimbursementsPopulated(el, a) {
+  var name = _reimbFirstName();
+  var programs = Array.isArray(a.result_programs) ? a.result_programs : [];
+  var signals = Array.isArray(a.result_signals) ? a.result_signals : [];
+  var n = programs.length;
+
+  var html = '<div class="reimb-view">';
+
+  if (a.needs_refresh) {
+    html += '<div class="reimb-ribbon">'
+      + '<span>Your situation may have changed — update your answers.</span>'
+      + '<button type="button" class="reimb-ribbon-btn" onclick="_startReimbursementsFlow()">Update</button>'
+      + '</div>';
+  }
+
+  html += '<div class="view-header">'
+    +   '<div class="view-header__eyebrow">' + n + (n === 1 ? ' program may apply for ' : ' programs may apply for ') + escHtml(name) + '</div>'
+    +   '<h1 class="view-header__title">Reimbursements</h1>'
+    +   '<p class="view-header__lede">Programs that may pay for the care you’re already giving. Eligibility varies — these are starting points, not guarantees.</p>'
+    + '</div>';
+
+  // Your situation summary.
+  html += '<div class="reimb-situation"><div class="reimb-section-head">Your situation</div><div class="reimb-prefill-chips">';
+  var fieldOrder = ['loved_one_age_band','conditions','coverage','adl_level','caregiver_role','hospital_system','state','current_tools','biggest_worry'];
+  var prov = a.input_provenance || {};
+  fieldOrder.forEach(function(f){
+    var val = a[f];
+    if (val == null || (Array.isArray(val) && val.length === 0) || val === '') return;
+    var display = Array.isArray(val) ? val.join(', ') : String(val);
+    var pv = prov[f] || 'user';
+    html += '<div class="reimb-chip">'
+      + '<span class="reimb-chip-label">' + escHtml(display) + '</span>'
+      + '<span class="reimb-chip-prov">' + escHtml(_REIMB_PROVENANCE_LABEL[pv] || 'You told us') + '</span>'
+      + '</div>';
+  });
+  html += '</div>';
+  html += '<button type="button" class="reimb-btn-secondary" onclick="_startReimbursementsFlow()">Update my situation</button>';
+  if (a.assessed_at) {
+    html += '<div class="reimb-assessed">Last reviewed ' + escHtml(new Date(a.assessed_at).toLocaleDateString()) + '</div>';
+  }
+  html += '</div>';
+
+  // Program cards.
+  html += '<div class="reimb-programs">';
+  programs.forEach(function(p, i){
+    html += _reimbProgramCardHtml(p, i, a.id);
+  });
+  html += '</div>';
+
+  // Signals (lower priority).
+  if (signals.length) {
+    html += '<div class="reimb-signals"><div class="reimb-section-head">While you handle the paperwork</div>';
+    signals.forEach(function(s){
+      html += '<div class="reimb-signal-row"><div class="reimb-signal-title">' + escHtml(s.title) + '</div><div class="reimb-signal-why">' + escHtml(s.why) + '</div></div>';
+    });
+    html += '</div>';
+  }
+
+  html += '<p class="reimb-footer">Wellet does not pay caregivers. We aggregate your loved one’s health records and surface programs that may pay for the care you’re already giving.</p>';
+  html += '</div>';
+
+  el.innerHTML = html;
+  initIcons();
+}
+
+function _reimbProgramCardHtml(p, idx, assessmentId) {
+  var conf = (p.confidence || 'low');
+  var why = Array.isArray(p.why) ? p.why : [];
+  var caveats = Array.isArray(p.caveats) ? p.caveats : [];
+  var acc = 'reimb-acc-' + idx;
+  var html = '<div class="reimb-card">'
+    + '<div class="reimb-card-head">'
+    +   '<div class="reimb-card-name">' + escHtml(p.name || '') + '</div>'
+    +   '<div class="reimb-card-amount">' + escHtml(p.amount || '') + '</div>'
+    +   '<span class="reimb-pip reimb-pip--' + escHtml(conf) + '">' + escHtml(conf) + ' confidence</span>'
+    + '</div>';
+  if (why.length) {
+    html += '<div class="reimb-card-why"><div class="reimb-card-sub">Why this may apply</div><ul>';
+    why.forEach(function(w){ html += '<li>' + escHtml(w) + '</li>'; });
+    html += '</ul></div>';
+  }
+  if (caveats.length) {
+    html += '<details class="reimb-card-caveats"><summary>Things to know</summary><ul>';
+    caveats.forEach(function(c){ html += '<li>' + escHtml(c) + '</li>'; });
+    html += '</ul></details>';
+  }
+  if (p.link) {
+    html += '<a class="reimb-card-cta" href="' + escHtml(p.link) + '" target="_blank" rel="noopener" '
+      + 'onclick="try{if(typeof _wa!==\'undefined\'&&_wa.track)_wa.track(\'feature\',\'reimbursement_program_clicked\',{program_id:\'' + escHtml(p.id || '') + '\',confidence:\'' + escHtml(conf) + '\'});}catch(e){}">'
+      + escHtml(p.cta_label || 'Learn more') + '</a>';
+  }
+  html += '</div>';
+  return html;
+}
+
 async function toggleResourceBookmark(resourceId) {
   if (!currentUser) { showToast('Sign in to save resources'); return; }
 
@@ -25945,6 +26333,7 @@ function switchNavTo(view, skipPush) {
   document.getElementById('header-tab-bar').style.display = isHome ? 'flex' : 'none';
   if (view === 'signals') { renderSignalsView(); }
   if (view === 'resources') { renderResourcesView(); }
+  if (view === 'reimbursements') { try { renderReimbursementsView(); } catch(_e) {} }
   if (view === 'records') { try { renderRecordsView(); } catch(_e) {} }
   if (view === 'people' && !isDemoMode) { renderPeopleView(); }
   // 2026-06-01 (D5): call renderAskView in demo mode too so the demo branch

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
 <link rel="stylesheet" href="/assets/editorial-people-view.css?v=20260501-1610">
 <link rel="stylesheet" href="/assets/editorial-signals-view.css?v=20260514-1900">
 <link rel="stylesheet" href="/assets/editorial-resources-view.css?v=20260501-1505">
+<link rel="stylesheet" href="/assets/editorial-reimbursements.css?v=20260610-1200">
 <link rel="stylesheet" href="/assets/editorial-timeline.css?v=20260514-1620">
 <link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260531-dismiss">
 <link rel="stylesheet" href="/assets/editorial-upcoming.css">
@@ -691,6 +692,10 @@
         <button class="header-menu-item" onclick="closeHeaderMenu();switchNavTo('resources')">
           <span class="header-menu-icon"><i data-lucide="book-open" style="width:16px;height:16px;"></i></span>
           <span>Resources</span>
+        </button>
+        <button class="header-menu-item" onclick="closeHeaderMenu();switchNavTo('reimbursements')">
+          <span class="header-menu-icon"><i data-lucide="badge-dollar-sign" style="width:16px;height:16px;"></i></span>
+          <span>Reimbursements</span>
         </button>
         <button class="header-menu-item" onclick="closeHeaderMenu();showConnectScreen()">
           <span class="header-menu-icon"><i data-lucide="link" style="width:16px;height:16px;"></i></span>
@@ -1500,6 +1505,11 @@
     <!-- RESOURCES VIEW -->
     <div id="view-resources" class="app-view" data-editorial="resources">
       <!-- Content rendered by renderResourcesView() -->
+    </div>
+
+    <!-- REIMBURSEMENTS VIEW -->
+    <div id="view-reimbursements" class="app-view" data-editorial="reimbursements">
+      <!-- Content rendered by renderReimbursementsView() -->
     </div>
 
     <!-- ASK WELLET VIEW -->

--- a/supabase/functions/_shared/reimbursement-engine.ts
+++ b/supabase/functions/_shared/reimbursement-engine.ts
@@ -1,0 +1,485 @@
+// Reimbursement program-generation engine.
+//
+// Ported verbatim from getwellet's scorecard2-submit v2
+// (scorecard2_submit_v2.ts) so the in-app mywellet "reimbursements" edge
+// function and the public marketing scorecard produce the SAME program set
+// for the same merged input. The logic below is the single source of truth
+// within this repo; the public endpoint lives in the getwellet repo and
+// must be kept byte-for-byte identical to this engine when either changes.
+//
+// Decision (PR 1): we vendor the engine into mywellet rather than calling
+// getwellet's function with mode:"in_app", because the engine has no I/O —
+// it is pure functions over a ScorecardInput — and importing it locally
+// keeps the in-app path JWT-verified inside our own gateway without a
+// cross-origin server-to-server hop. See spec "Option A".
+
+// ---- Types ----
+
+export interface Program {
+  id: string;
+  name: string;
+  amount: string;
+  confidence: "high" | "medium" | "low";
+  why: string[];
+  caveats: string[];
+  link: string;
+  cta_label: string;
+}
+
+export interface Signal {
+  id: string;
+  title: string;
+  why: string;
+}
+
+export interface ScorecardInput {
+  loved_one_age_band: string;
+  conditions: string[];
+  current_tools: string[];
+  biggest_worry: string;
+  coverage: string[];
+  adl_level: string;
+  hospital_system: string | null;
+  caregiver_role: string;
+  state: string | null;
+}
+
+// ---- Validation sets (shared with the prefill resolver) ----
+
+export const VALID_AGE_BANDS = new Set([
+  "under_60", "60_69", "70_79", "80_89", "90_plus", "prefer_not_say",
+]);
+
+export const VALID_CONDITIONS = new Set([
+  "diabetes", "heart", "cancer", "dementia", "kidney", "lung",
+  "mental_health", "mobility", "multiple", "none_known", "prefer_not_say",
+]);
+
+export const VALID_TOOLS = new Set([
+  "mychart", "another_portal", "paper_notes", "spreadsheet", "memory", "shared_doc",
+]);
+
+export const VALID_WORRIES = new Set([
+  "missing_something", "medication_changes", "appointment_chaos",
+  "multiple_doctors", "declining_changes", "other",
+]);
+
+export const VALID_COVERAGE = new Set([
+  "medicare", "medicaid", "veteran", "private", "marketplace", "none", "unsure",
+]);
+
+export const VALID_ADL = new Set([
+  "none", "1_2", "3_plus", "supervision", "unsure",
+]);
+
+export const VALID_ROLES = new Set([
+  "primary", "shared", "distance", "professional", "other",
+]);
+
+// ---- Hospital -> state derivation ----
+//
+// Light-touch keyword match on the free-text hospital field. Used to gate
+// state-specific programs (currently just NC). Returns 2-letter state code
+// or null. Be conservative — false positives gate the user into wrong
+// programs, which is worse than no match.
+
+const HOSPITAL_STATE_HINTS: Array<[RegExp, string]> = [
+  // NC
+  [/\b(duke|unc|atrium|novant|wakemed|cone|cape\s*fear|carolinas?\s*health|cone\s*health|firsthealth|cherokee\s*indian|mountain\s*area|wilson\s*medical|vidant|cleveland\s*regional|charlotte\s*radiology|wake\s*forest\s*baptist)\b/i, "NC"],
+  // VA (state, not Veterans)
+  [/\b(inova|valley\s*health|sentara|carilion|virginia\s*hospital|chesapeake\s*regional)\b/i, "VA"],
+  // GA
+  [/\b(emory|piedmont|wellstar|northside\s*atlanta|grady|augusta\s*university)\b/i, "GA"],
+  // OH
+  [/\b(cleveland\s*clinic|metrohealth|ohiohealth|university\s*hospitals\s*cleveland|mount\s*carmel|nationwide\s*children)\b/i, "OH"],
+  // IN
+  [/\b(indiana\s*university\s*health|iu\s*health|community\s*health\s*indiana|franciscan\s*indiana|parkview)\b/i, "IN"],
+  // LA
+  [/\b(ochsner|tulane|baton\s*rouge\s*general|louisiana\s*state\s*university\s*health)\b/i, "LA"],
+  // MA
+  [/\b(mass\s*general|mgh|brigham|tufts\s*medical|boston\s*medical|baystate|umass\s*memorial|lahey)\b/i, "MA"],
+  // MO
+  [/\b(barnes\s*jewish|bjc|mercy\s*missouri|university\s*of\s*missouri\s*health|cox\s*health|st\s*luke'?s\s*kansas\s*city)\b/i, "MO"],
+  // NV
+  [/\b(university\s*medical\s*center\s*of\s*southern\s*nevada|sunrise\s*hospital|valley\s*hospital\s*las\s*vegas|renown)\b/i, "NV"],
+  // RI
+  [/\b(rhode\s*island\s*hospital|miriam\s*hospital|landmark\s*medical|kent\s*hospital)\b/i, "RI"],
+  // SD
+  [/\b(sanford\s*sioux\s*falls|avera\s*mckennan|monument\s*health)\b/i, "SD"],
+  // CT
+  [/\b(yale\s*new\s*haven|hartford\s*hospital|connecticut\s*children|stamford\s*hospital)\b/i, "CT"],
+];
+
+const SFC_STATES = new Set([
+  "CT", "GA", "IN", "LA", "MA", "MO", "NV", "NC", "OH", "RI", "SD",
+]);
+
+const SFC_SPOUSE_ELIGIBLE = new Set(["IN", "LA", "MO", "NV", "NC", "OH", "SD"]);
+
+const SFC_STATE_DETAILS: Record<string, { name: string; rate: string }> = {
+  CT: { name: "Connecticut Adult Family Living",       rate: "~$40–$60/day" },
+  GA: { name: "Georgia Structured Family Caregiving",  rate: "~$80/day" },
+  IN: { name: "Indiana Structured Family Caregiving",  rate: "~$40–$70/day" },
+  LA: { name: "Louisiana Monitored In-Home Caregiving",rate: "~$40–$65/day" },
+  MA: { name: "Massachusetts Adult Foster Care",       rate: "~$40–$70/day" },
+  MO: { name: "Missouri Structured Family Caregiving", rate: "~$67/day (caregiver share)" },
+  NV: { name: "Nevada Structured Family Caregiving",   rate: "~$40–$70/day" },
+  NC: { name: "North Carolina Coordinated Caregiving (CAP/DA)", rate: "~$55–$85/day" },
+  OH: { name: "Ohio Structured Family Caregiving",     rate: "~$40–$70/day" },
+  RI: { name: "Rhode Island RIte @ Home",              rate: "~$40–$65/day" },
+  SD: { name: "South Dakota Structured Family Caregiving", rate: "~$81–$113/day tiered" },
+};
+
+export function deriveState(hospital: string | null): string | null {
+  if (!hospital) return null;
+  for (const [re, st] of HOSPITAL_STATE_HINTS) {
+    if (re.test(hospital)) return st;
+  }
+  return null;
+}
+
+// ---- Program generation ----
+
+function isAge60Plus(band: string): boolean {
+  return band === "60_69" || band === "70_79" || band === "80_89" || band === "90_plus";
+}
+
+function isAge65Plus(band: string): boolean {
+  // age_band is the loved one — 65+ is reasonable proxy for 70_79+.
+  // 60_69 contains both <65 and 65+; we treat it as ambiguous and include
+  // them for GUIDE since most Medicare beneficiaries are 65+.
+  return band === "70_79" || band === "80_89" || band === "90_plus" || band === "60_69";
+}
+
+export function generatePrograms(input: ScorecardInput): Program[] {
+  const programs: Program[] = [];
+  const coverage = new Set(input.coverage || []);
+  const conditions = new Set(input.conditions || []);
+  const adl = input.adl_level || "unsure";
+  const heavyAdl = adl === "1_2" || adl === "3_plus" || adl === "supervision";
+  const veryHeavyAdl = adl === "3_plus" || adl === "supervision";
+  const state = input.state;
+  const role = input.caregiver_role;
+  const age = input.loved_one_age_band;
+
+  // ---------- VA PCAFC ----------
+  if (coverage.has("veteran") && heavyAdl) {
+    const tier = veryHeavyAdl ? 2 : 1;
+    const amount = tier === 2
+      ? "Up to ~$3,034–$3,500/mo (Level 2)"
+      : "Up to ~$1,896–$2,200/mo (Level 1)";
+    const why = [
+      "Your loved one is a veteran with VA-enrolled health care",
+      veryHeavyAdl
+        ? "They need supervision or help with 3+ activities of daily living — this typically triggers Level 2"
+        : "They need help with 1–2 activities of daily living — this typically triggers Level 1",
+    ];
+    if (role === "primary" || role === "shared") {
+      why.push("You're the primary or shared caregiver — PCAFC requires a designated Primary Family Caregiver");
+    }
+    programs.push({
+      id: "pcafc",
+      name: "VA PCAFC (Program of Comprehensive Assistance for Family Caregivers)",
+      amount,
+      confidence: veryHeavyAdl ? "high" : "medium",
+      why,
+      caveats: [
+        "Veteran must have a 70%+ service-connected disability rating",
+        "Stipend is tax-free; amount varies by tier and your zip's OPM GS-4 locality rate",
+        "Includes CHAMPVA health insurance and mental-health support for the caregiver",
+        "Application: 6–16 weeks to first payment (retroactive to eligibility date)",
+      ],
+      link: "https://www.va.gov/family-and-caregiver-benefits/health-and-disability/comprehensive-assistance-for-family-caregivers/",
+      cta_label: "See if you qualify for PCAFC",
+    });
+  } else if (coverage.has("veteran")) {
+    programs.push({
+      id: "pcafc_general",
+      name: "VA Caregiver Support (PGCSS)",
+      amount: "Training, respite, peer support — no stipend",
+      confidence: "medium",
+      why: [
+        "Your loved one has VA coverage",
+        "The VA's Program of General Caregiver Support Services covers caregivers who don't meet PCAFC's 70% threshold",
+      ],
+      caveats: [
+        "Less paperwork than PCAFC; no monthly stipend",
+        "Includes Building Better Caregivers online course and caregiver support coordinator",
+      ],
+      link: "https://www.caregiver.va.gov/",
+      cta_label: "Explore VA caregiver support",
+    });
+  }
+
+  // ---------- CMS GUIDE ----------
+  if (coverage.has("medicare") && conditions.has("dementia") && isAge65Plus(age)) {
+    programs.push({
+      id: "guide",
+      name: "CMS GUIDE (Guiding an Improved Dementia Experience)",
+      amount: "$2,500/yr respite + monthly care management for the practice",
+      confidence: "high",
+      why: [
+        "Your loved one has Medicare and a dementia diagnosis",
+        "GUIDE is built specifically for dementia families and their unpaid caregivers",
+        "320+ participating organizations across 47 states as of May 2026",
+      ],
+      caveats: [
+        "Requires Original Medicare (Parts A & B) — Medicare Advantage enrollees are NOT eligible",
+        "Must be enrolled with a GUIDE-participating practice — see the CMS map",
+        "Memory-care unit residents are excluded as of July 2026",
+        "Respite is paid to a respite provider, not to you directly",
+      ],
+      link: "https://www.cms.gov/priorities/innovation/innovation-models/guide",
+      cta_label: "Find a GUIDE-participating practice",
+    });
+  }
+
+  // ---------- Medicaid SFC ----------
+  if (coverage.has("medicaid") && veryHeavyAdl) {
+    if (state && SFC_STATES.has(state)) {
+      const det = SFC_STATE_DETAILS[state];
+      const spouseOk = SFC_SPOUSE_ELIGIBLE.has(state);
+      const why = [
+        "Your loved one has Medicaid coverage",
+        veryHeavyAdl ? "They need ≥3 ADLs or continuous supervision — SFC requires nursing-home-level need" : "They need significant ADL support",
+        `${state} is one of 11 states with a Structured Family Caregiving waiver`,
+      ];
+      programs.push({
+        id: "medicaid_sfc",
+        name: det.name,
+        amount: `${det.rate} (paid to caregiver in the home)`,
+        confidence: "high",
+        why,
+        caveats: [
+          "Caregiver and loved one typically must live in the same home",
+          spouseOk
+            ? `${state} permits a spouse to be the paid caregiver`
+            : `${state} does NOT permit a spouse to be the paid caregiver`,
+          "Daily rate is paid; first payment usually 30–60 days after enrollment",
+          "Administered by Careforth (formerly Seniorlink) in most states",
+        ],
+        link: "https://careforth.com/structured-family-caregiving/",
+        cta_label: "Apply for SFC in your state",
+      });
+    } else {
+      // Medicaid + heavy ADL but state is unknown / not in SFC-11
+      programs.push({
+        id: "medicaid_sfc_general",
+        name: "Medicaid Structured Family Caregiving (SFC)",
+        amount: "~$40–$113/day depending on state",
+        confidence: "medium",
+        why: [
+          "Your loved one has Medicaid coverage",
+          "They need ≥3 ADLs or continuous supervision",
+          "11 states currently run SFC: CT, GA, IN, LA, MA, MO, NV, NC, OH, RI, SD",
+        ],
+        caveats: [
+          "Available only in: CT, GA, IN, LA, MA, MO, NV, NC, OH, RI, SD",
+          "If you're not in one of those states, check your state's HCBS waivers — most have a self-directed option",
+          "Caregiver and loved one typically must live in the same home",
+        ],
+        link: "https://careforth.com/structured-family-caregiving/",
+        cta_label: "Check if your state has SFC",
+      });
+    }
+  } else if (coverage.has("medicaid")) {
+    programs.push({
+      id: "medicaid_general",
+      name: "Medicaid Self-Directed HCBS Waivers",
+      amount: "Varies — many states pay family caregivers directly",
+      confidence: "medium",
+      why: [
+        "Your loved one has Medicaid coverage",
+        "Most states run at least one Home and Community-Based Services waiver",
+        "Self-directed options often let family be paid as the caregiver",
+      ],
+      caveats: [
+        "Each state has different waivers, waitlists, and rules",
+        "Spouse eligibility varies — many states still exclude spouses",
+      ],
+      link: "https://www.medicaid.gov/medicaid/home-community-based-services/index.html",
+      cta_label: "Find your state's HCBS waivers",
+    });
+  }
+
+  // ---------- Medicare CTS (caregiver training) ----------
+  if (coverage.has("medicare")) {
+    const hasCareSignal = heavyAdl || conditions.size > 0;
+    if (hasCareSignal) {
+      programs.push({
+        id: "cts",
+        name: "Medicare Caregiver Training (G0541–G0543)",
+        amount: "~$52 first 30 min; ~20% coinsurance applies",
+        confidence: heavyAdl ? "high" : "medium",
+        why: [
+          "Your loved one has Medicare",
+          conditions.size > 0
+            ? "They have at least one chronic condition that benefits from structured caregiver training"
+            : "They need ongoing care support",
+          "G0541–G0543 codes activated January 2025 — any physician, NP, PT, OT or SLP can bill",
+        ],
+        caveats: [
+          "Family pays ~20% coinsurance per session (~$10) unless covered by a Medigap or Medicare Advantage plan",
+          "Must be ordered and documented in your loved one's care plan",
+          "No prior authorization required",
+        ],
+        link: "https://www.cms.gov/medicare/payment/fee-schedules/physician",
+        cta_label: "Ask your clinician to schedule CTS",
+      });
+    }
+  }
+
+  // ---------- NFCSP (first-class match for 60+) ----------
+  if (isAge60Plus(age)) {
+    programs.push({
+      id: "nfcsp",
+      name: "National Family Caregiver Support Program (NFCSP)",
+      amount: "Respite vouchers + supplies, typically $500–$2,500/yr",
+      confidence: heavyAdl ? "high" : "medium",
+      why: [
+        "Your loved one is 60 or older",
+        "NFCSP is the federal respite and support program for caregivers of older adults",
+        "FY2026 appropriation: $209M, delivered through ~650 local Area Agencies on Aging",
+      ],
+      caveats: [
+        "Not a cash payment — services, vouchers, supplies, and counseling",
+        "Funded first-come-first-served; some AAAs have waitlists",
+        "Apply through your local AAA — eldercare.acl.gov or 1-800-677-1116",
+      ],
+      link: "https://eldercare.acl.gov/Public/Index.aspx",
+      cta_label: "Find your local Area Agency on Aging",
+    });
+  }
+
+  // ---------- NC state-specific (if state derived to NC) ----------
+  if (state === "NC") {
+    // Project C.A.R.E. — dementia-only, non-Medicaid
+    if (conditions.has("dementia") && !coverage.has("medicaid")) {
+      programs.push({
+        id: "nc_project_care",
+        name: "NC Project C.A.R.E. (Caregiver Alternatives to Running on Empty)",
+        amount: "Up to $1,500/yr (3 × $500 respite vouchers)",
+        confidence: "high",
+        why: [
+          "Your loved one is in North Carolina and has a dementia diagnosis",
+          "Project C.A.R.E. is 100% NC-state-funded — built for the non-Medicaid gap population",
+        ],
+        caveats: [
+          "Dementia diagnosis required",
+          "Vouchers are reimbursement-based — you pay the respite provider first, then submit receipts",
+          "Apply through the NC Division of Aging and Adult Services",
+        ],
+        link: "https://www.ncdhhs.gov/divisions/aging/services-elderly-and-individuals-disabilities/project-care",
+        cta_label: "Apply for Project C.A.R.E.",
+      });
+    }
+
+    // NC Lifespan Respite — any age, any condition
+    programs.push({
+      id: "nc_lifespan_respite",
+      name: "NC Lifespan Respite Voucher Program",
+      amount: "Up to $750/yr reimbursement",
+      confidence: "medium",
+      why: [
+        "Your loved one is in North Carolina",
+        "Lifespan Respite covers any care need at any age (not limited to seniors or a specific diagnosis)",
+      ],
+      caveats: [
+        "Reimbursement-based — you pay for respite care first, then submit receipts",
+        "Funds run out each fiscal year — apply early in the cycle (July onward)",
+        "Administered through the NC Lifespan Respite Project at the ARC of NC",
+      ],
+      link: "https://www.arcnc.org/services/lifespan-respite",
+      cta_label: "Apply for Lifespan Respite vouchers",
+    });
+  }
+
+  // ---------- Private/marketplace caregiver benefits ----------
+  if ((coverage.has("private") || coverage.has("marketplace")) && heavyAdl) {
+    programs.push({
+      id: "private_caregiver_benefits",
+      name: "Private insurance + employer caregiver benefits",
+      amount: "Varies — respite hours, navigation, sometimes cash",
+      confidence: "low",
+      why: [
+        "Your loved one has private or marketplace coverage",
+        "Many employer plans now include eldercare benefits (Cariloop, Wellthy, Homethrive)",
+      ],
+      caveats: [
+        "Coverage varies widely — check the benefits handbook or HR portal",
+        "Often delivered as a third-party navigator, not a direct payment",
+      ],
+      link: "https://www.kff.org/medicare/issue-brief/private-insurance-caregiver-benefits/",
+      cta_label: "Check your plan's eldercare benefits",
+    });
+  }
+
+  // ---------- Fallback: if nothing matched, still give them NFCSP ----------
+  if (programs.length === 0) {
+    programs.push({
+      id: "aaa_respite",
+      name: "Local Area Agency on Aging (AAA) respite + family caregiver supports",
+      amount: "Varies — typically $500–$2,500 per family per year",
+      confidence: "medium",
+      why: [
+        "Every county in the US has an Area Agency on Aging",
+        "Most AAAs administer respite vouchers and caregiver supports for any age or condition",
+      ],
+      caveats: [
+        "Funding is limited and often awarded first-come-first-served",
+        "Grants are typically one-time, not ongoing monthly payments",
+      ],
+      link: "https://eldercare.acl.gov/Public/Index.aspx",
+      cta_label: "Find your local AAA",
+    });
+  }
+
+  // Order: highest dollar value first (PCAFC, SFC, GUIDE) — preserve
+  // insertion order which already matches that, then cap at 5.
+  return programs.slice(0, 5);
+}
+
+export function generateSignals(input: ScorecardInput): Signal[] {
+  const signals: Signal[] = [];
+  const conditions = new Set(input.conditions || []);
+
+  signals.push({
+    id: "witness",
+    title: "A second pair of eyes on every appointment",
+    why:
+      "While you handle the paperwork for reimbursement programs, Wellet " +
+      "reads the chart so you don't miss medication changes, follow-ups, or " +
+      "slow shifts between visits.",
+  });
+
+  if (conditions.has("dementia")) {
+    signals.push({
+      id: "dementia_witness",
+      title: "Notices the things you can't see day-to-day",
+      why:
+        "Cognitive change is small until it isn't. Wellet reads the visit " +
+        "notes for shifts in language, mood, and assessments — so a slow " +
+        "trend doesn't surprise you at the next appointment.",
+    });
+  } else if (conditions.has("heart") || conditions.has("diabetes") || conditions.has("kidney")) {
+    signals.push({
+      id: "labs_drift",
+      title: "Watches the labs that matter",
+      why:
+        "A1c, eGFR, BNP — Wellet shows you the trend over months, not just " +
+        "the last visit. Patterns surface before the next appointment.",
+    });
+  }
+
+  if (input.caregiver_role === "distance") {
+    signals.push({
+      id: "distance",
+      title: "Built for caring from far away",
+      why:
+        "When you can't be there in person, Wellet gives you the same " +
+        "visibility a local caregiver has — without depending on a phone call.",
+    });
+  }
+
+  return signals.slice(0, 3);
+}

--- a/supabase/functions/_shared/reimbursement-prefill.test.ts
+++ b/supabase/functions/_shared/reimbursement-prefill.test.ts
@@ -1,0 +1,106 @@
+// Unit tests for the reimbursement prefill resolver. Validates:
+// 1. Missing chart data is handled gracefully — every field falls through
+//    to "asked" with no throw.
+// 2. Provenance correctly flags ehr / inferred / user / asked.
+// 3. partial_input (the caregiver's answers) always wins over derivation.
+// 4. Helpers (age band, conditions text, coverage text, role mapping)
+//    behave at the boundaries.
+
+import { assertEquals } from 'https://deno.land/std@0.168.0/testing/asserts.ts';
+import {
+  ageBandFromDob,
+  conditionsFromText,
+  coverageFromText,
+  caregiverRoleFromCareCircle,
+  resolvePrefill,
+} from './reimbursement-prefill.ts';
+
+Deno.test('missing chart data: all derivable fields are asked, none throw', () => {
+  const r = resolvePrefill(
+    { person: { id: 'p1' }, ehrConnections: [], careCircleRole: null, soleCareCircleMember: false },
+    {},
+  );
+  // The 3 always-ask + role + the 5 derivable (all empty) = every field asked.
+  for (const f of ['loved_one_age_band', 'conditions', 'current_tools', 'biggest_worry', 'coverage', 'adl_level', 'hospital_system', 'caregiver_role', 'state']) {
+    assertEquals(r.asked_fields.includes(f), true, f + ' should be asked');
+  }
+  assertEquals(r.prefilled_fields.length, 0);
+});
+
+Deno.test('ehr + profile derivation sets provenance and prefilled_fields', () => {
+  const r = resolvePrefill(
+    {
+      person: { id: 'p1', date_of_birth: '1945-03-01', conditions: 'Type 2 diabetes, mild dementia', insurance_info: 'Medicare Part A+B, Medicaid' },
+      ehrConnections: [{ hospital_name: 'Duke University Hospital', status: 'connected' }],
+      careCircleRole: 'primary',
+      soleCareCircleMember: false,
+    },
+    {},
+  );
+  assertEquals(r.provenance.loved_one_age_band, 'ehr');
+  assertEquals(r.provenance.conditions, 'ehr');
+  assertEquals(r.provenance.coverage, 'inferred');
+  assertEquals(r.provenance.hospital_system, 'ehr');
+  assertEquals(r.provenance.caregiver_role, 'ehr');
+  // Duke -> NC via deriveState, off the prefilled hospital.
+  assertEquals(r.input.state, 'NC');
+  assertEquals(r.provenance.state, 'inferred');
+  // Always-ask fields remain asked.
+  assertEquals(r.asked_fields.includes('adl_level'), true);
+  assertEquals(r.asked_fields.includes('biggest_worry'), true);
+});
+
+Deno.test('partial_input wins over derivation, provenance = user', () => {
+  const r = resolvePrefill(
+    {
+      person: { id: 'p1', date_of_birth: '1945-03-01', conditions: 'dementia' },
+      ehrConnections: [],
+    },
+    { loved_one_age_band: '70_79', adl_level: '3_plus', coverage: ['veteran'] },
+  );
+  assertEquals(r.input.loved_one_age_band, '70_79');
+  assertEquals(r.provenance.loved_one_age_band, 'user');
+  assertEquals(r.input.adl_level, '3_plus');
+  assertEquals(r.provenance.adl_level, 'user');
+  assertEquals(r.provenance.coverage, 'user');
+  assertEquals(r.input.coverage[0], 'veteran');
+});
+
+Deno.test('sole care-circle member defaults role to primary (inferred)', () => {
+  const r = resolvePrefill(
+    { person: { id: 'p1' }, ehrConnections: [], careCircleRole: null, soleCareCircleMember: true },
+    {},
+  );
+  assertEquals(r.input.caregiver_role, 'primary');
+  assertEquals(r.provenance.caregiver_role, 'inferred');
+});
+
+Deno.test('ageBandFromDob boundaries', () => {
+  const yr = new Date().getFullYear();
+  assertEquals(ageBandFromDob((yr - 30) + '-01-01'), 'under_60');
+  assertEquals(ageBandFromDob((yr - 65) + '-01-01'), '60_69');
+  assertEquals(ageBandFromDob((yr - 75) + '-01-01'), '70_79');
+  assertEquals(ageBandFromDob((yr - 95) + '-01-01'), '90_plus');
+  assertEquals(ageBandFromDob(null), null);
+  assertEquals(ageBandFromDob('not-a-date'), null);
+});
+
+Deno.test('conditionsFromText collapses 3+ matches to multiple', () => {
+  assertEquals(conditionsFromText('diabetes'), ['diabetes']);
+  assertEquals(conditionsFromText(''), []);
+  assertEquals(conditionsFromText(null), []);
+  assertEquals(conditionsFromText('diabetes, heart failure, kidney disease'), ['multiple']);
+});
+
+Deno.test('coverageFromText recognizes veteran/medicare/medicaid', () => {
+  assertEquals(coverageFromText('VA disability').includes('veteran'), true);
+  assertEquals(coverageFromText('Medicare Advantage').includes('medicare'), true);
+  assertEquals(coverageFromText('').length, 0);
+});
+
+Deno.test('caregiverRoleFromCareCircle maps secondary -> shared', () => {
+  assertEquals(caregiverRoleFromCareCircle('secondary', false), 'shared');
+  assertEquals(caregiverRoleFromCareCircle('primary', false), 'primary');
+  assertEquals(caregiverRoleFromCareCircle('emergency', false), null);
+  assertEquals(caregiverRoleFromCareCircle(null, true), 'primary');
+});

--- a/supabase/functions/_shared/reimbursement-prefill.ts
+++ b/supabase/functions/_shared/reimbursement-prefill.ts
@@ -1,0 +1,269 @@
+// Reimbursement prefill resolver.
+//
+// Pure functions that derive ScorecardInput fields from the loved-one
+// record (people row), active EHR connections, and the caregiver's
+// care-circle role — then merge the caregiver's just-answered partial_input
+// on top. Records per-field provenance ("ehr" | "user" | "inferred" |
+// "asked") so the UI can show "we filled this from the chart" vs "you told
+// us", and so we know which fields still need to be asked.
+//
+// No I/O here — the edge function fetches the rows and passes them in. That
+// keeps this unit-testable against fixtures with no Supabase client.
+//
+// PR 1 scope (per spec): conditions come from people.conditions free text +
+// manual user confirmation. ICD-10 / chart problem-list mapping is PR 2.
+
+import {
+  deriveState,
+  ScorecardInput,
+  VALID_ADL,
+  VALID_AGE_BANDS,
+  VALID_CONDITIONS,
+  VALID_COVERAGE,
+  VALID_ROLES,
+  VALID_TOOLS,
+  VALID_WORRIES,
+} from "./reimbursement-engine.ts";
+
+export type Provenance = "ehr" | "user" | "inferred" | "asked";
+
+export interface PersonRow {
+  id: string;
+  date_of_birth?: string | null;
+  conditions?: string | null;      // free-text
+  insurance_info?: string | null;  // free-text
+}
+
+export interface EhrConnectionRow {
+  hospital_name?: string | null;
+  connected_provider?: string | null;
+  provider?: string | null;
+  status?: string | null;
+}
+
+export interface ResolverContext {
+  person: PersonRow;
+  ehrConnections: EhrConnectionRow[];
+  careCircleRole?: string | null;     // care_circle_members.role for this user
+  soleCareCircleMember?: boolean;     // user is the only care-circle member
+}
+
+export interface PartialInput {
+  loved_one_age_band?: string | null;
+  conditions?: string[] | null;
+  current_tools?: string[] | null;
+  biggest_worry?: string | null;
+  coverage?: string[] | null;
+  adl_level?: string | null;
+  hospital_system?: string | null;
+  caregiver_role?: string | null;
+  state?: string | null;
+}
+
+export interface ResolveResult {
+  input: ScorecardInput;
+  provenance: Record<string, Provenance>;
+  prefilled_fields: string[];  // fields we filled from chart/profile (not asked)
+  asked_fields: string[];      // fields we still need the caregiver to answer
+}
+
+// ---- Field-level derivation helpers ----
+
+// people.date_of_birth (YYYY-MM-DD) -> age band enum.
+export function ageBandFromDob(dob: string | null | undefined): string | null {
+  if (!dob) return null;
+  const birth = new Date(dob);
+  if (isNaN(birth.getTime())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const m = now.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--;
+  if (age < 60) return "under_60";
+  if (age <= 69) return "60_69";
+  if (age <= 79) return "70_79";
+  if (age <= 89) return "80_89";
+  return "90_plus";
+}
+
+// people.conditions free text -> subset of the 11-value condition enum.
+// Conservative keyword match; the UI always lets the caregiver add/remove.
+const CONDITION_KEYWORDS: Array<[RegExp, string]> = [
+  [/\b(diabet|a1c|insulin)\b/i, "diabetes"],
+  [/\b(heart|cardiac|chf|afib|coronary|hypertension|high blood pressure)\b/i, "heart"],
+  [/\b(cancer|oncolog|tumor|chemo|carcinoma|lymphoma|leukemia)\b/i, "cancer"],
+  [/\b(dementia|alzheimer|cognitive|memory loss)\b/i, "dementia"],
+  [/\b(kidney|renal|ckd|dialysis|egfr)\b/i, "kidney"],
+  [/\b(lung|copd|pulmonary|asthma|emphysema)\b/i, "lung"],
+  [/\b(depress|anxiety|mental health|bipolar|psych)\b/i, "mental_health"],
+  [/\b(mobility|fall|walker|wheelchair|gait|fracture)\b/i, "mobility"],
+];
+
+export function conditionsFromText(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const found = new Set<string>();
+  for (const [re, slug] of CONDITION_KEYWORDS) {
+    if (re.test(text)) found.add(slug);
+  }
+  const arr = Array.from(found);
+  // If we matched 3+ distinct conditions, the v2 engine prefers "multiple".
+  if (arr.length >= 3) return ["multiple"];
+  return arr;
+}
+
+// people.insurance_info free text -> subset of the coverage enum.
+const COVERAGE_KEYWORDS: Array<[RegExp, string]> = [
+  [/\b(veteran|va\b|tricare|champva|military)\b/i, "veteran"],
+  [/\bmedicaid\b/i, "medicaid"],
+  [/\bmedicare\b/i, "medicare"],
+  [/\b(marketplace|aca|obamacare|healthcare\.gov)\b/i, "marketplace"],
+  [/\b(blue cross|aetna|cigna|united\s*health|humana|kaiser|private|employer)\b/i, "private"],
+];
+
+export function coverageFromText(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const found = new Set<string>();
+  for (const [re, slug] of COVERAGE_KEYWORDS) {
+    if (re.test(text)) found.add(slug);
+  }
+  return Array.from(found);
+}
+
+// Active EHR connections -> a single hospital_system label for state
+// derivation. Prefer an explicit hospital_name; fall back to the provider.
+export function hospitalFromConnections(conns: EhrConnectionRow[]): string | null {
+  const active = (conns || []).filter((c) => !c.status || c.status === "connected");
+  for (const c of active) {
+    const label = c.hospital_name || c.connected_provider || c.provider;
+    if (label && label.trim()) return label.trim();
+  }
+  return null;
+}
+
+// care_circle_members.role (primary|secondary|emergency) -> scorecard role
+// enum (primary|shared|distance|professional|other). "secondary" maps to
+// "shared"; "emergency" has no scorecard analogue so we still ask.
+export function caregiverRoleFromCareCircle(
+  role: string | null | undefined,
+  soleMember: boolean | undefined,
+): string | null {
+  if (soleMember) return "primary";
+  if (!role) return null;
+  if (role === "primary") return "primary";
+  if (role === "secondary") return "shared";
+  return null;
+}
+
+// ---- Top-level resolver ----
+
+function pickArray(partial: string[] | null | undefined, valid: Set<string>): string[] | null {
+  if (!Array.isArray(partial)) return null;
+  const cleaned = partial
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter((v) => v && valid.has(v));
+  return cleaned.length ? cleaned : (partial.length ? [] : null);
+}
+
+function pickScalar(partial: string | null | undefined, valid: Set<string>): string | null {
+  if (typeof partial !== "string") return null;
+  const t = partial.trim();
+  return t && valid.has(t) ? t : null;
+}
+
+// Resolve all 9 fields. The caregiver's partial_input always wins (provenance
+// "user"); otherwise we derive from chart/profile (provenance "ehr"/"inferred")
+// or leave the field empty and mark it "asked".
+export function resolvePrefill(
+  ctx: ResolverContext,
+  partial: PartialInput,
+): ResolveResult {
+  const provenance: Record<string, Provenance> = {};
+  const prefilled: string[] = [];
+  const asked: string[] = [];
+
+  // age band: dob -> ask
+  let ageBand = pickScalar(partial.loved_one_age_band, VALID_AGE_BANDS);
+  if (ageBand) { provenance.loved_one_age_band = "user"; }
+  else {
+    ageBand = ageBandFromDob(ctx.person.date_of_birth);
+    if (ageBand) { provenance.loved_one_age_band = "ehr"; prefilled.push("loved_one_age_band"); }
+    else { asked.push("loved_one_age_band"); }
+  }
+
+  // conditions: user -> people.conditions text -> ask
+  let conditions = pickArray(partial.conditions, VALID_CONDITIONS);
+  if (conditions) { provenance.conditions = "user"; }
+  else {
+    conditions = conditionsFromText(ctx.person.conditions);
+    if (conditions.length) { provenance.conditions = "ehr"; prefilled.push("conditions"); }
+    else { conditions = []; asked.push("conditions"); }
+  }
+
+  // current_tools: always ask
+  let tools = pickArray(partial.current_tools, VALID_TOOLS);
+  if (tools) { provenance.current_tools = "user"; }
+  else { tools = []; asked.push("current_tools"); }
+
+  // biggest_worry: always ask
+  let worry = pickScalar(partial.biggest_worry, VALID_WORRIES);
+  if (worry) { provenance.biggest_worry = "user"; }
+  else { asked.push("biggest_worry"); }
+
+  // coverage: user -> insurance_info text (inferred, confirm) -> ask
+  let coverage = pickArray(partial.coverage, VALID_COVERAGE);
+  if (coverage) { provenance.coverage = "user"; }
+  else {
+    coverage = coverageFromText(ctx.person.insurance_info);
+    if (coverage.length) { provenance.coverage = "inferred"; prefilled.push("coverage"); }
+    else { coverage = []; asked.push("coverage"); }
+  }
+
+  // adl_level: always ask
+  let adl = pickScalar(partial.adl_level, VALID_ADL);
+  if (adl) { provenance.adl_level = "user"; }
+  else { asked.push("adl_level"); }
+
+  // hospital_system: user -> ehr_connections -> ask
+  let hospital: string | null = (typeof partial.hospital_system === "string" && partial.hospital_system.trim())
+    ? partial.hospital_system.trim().substring(0, 100)
+    : null;
+  if (hospital) { provenance.hospital_system = "user"; }
+  else {
+    hospital = hospitalFromConnections(ctx.ehrConnections);
+    if (hospital) { provenance.hospital_system = "ehr"; prefilled.push("hospital_system"); }
+    else { asked.push("hospital_system"); }
+  }
+
+  // caregiver_role: user -> care_circle_members.role -> ask
+  let role = pickScalar(partial.caregiver_role, VALID_ROLES);
+  if (role) { provenance.caregiver_role = "user"; }
+  else {
+    role = caregiverRoleFromCareCircle(ctx.careCircleRole, ctx.soleCareCircleMember);
+    if (role) { provenance.caregiver_role = ctx.soleCareCircleMember ? "inferred" : "ehr"; prefilled.push("caregiver_role"); }
+    else { asked.push("caregiver_role"); }
+  }
+
+  // state: user -> derived from hospital_system -> ask
+  let state: string | null = (typeof partial.state === "string" && partial.state.trim())
+    ? partial.state.trim().toUpperCase().substring(0, 2)
+    : null;
+  if (state) { provenance.state = "user"; }
+  else {
+    state = deriveState(hospital);
+    if (state) { provenance.state = "inferred"; prefilled.push("state"); }
+    else { asked.push("state"); }
+  }
+
+  const input: ScorecardInput = {
+    loved_one_age_band: ageBand || "prefer_not_say",
+    conditions: conditions || [],
+    current_tools: tools || [],
+    biggest_worry: worry || "other",
+    coverage: coverage || [],
+    adl_level: adl || "unsure",
+    hospital_system: hospital,
+    caregiver_role: role || "other",
+    state,
+  };
+
+  return { input, provenance, prefilled_fields: prefilled, asked_fields: asked };
+}

--- a/supabase/functions/reimbursements/index.ts
+++ b/supabase/functions/reimbursements/index.ts
@@ -1,0 +1,226 @@
+// reimbursements (mywellet) — in-app Reimbursements surface
+//
+// JWT-verified endpoint that powers the in-app Reimbursements view. For a
+// given loved one (person_id) it:
+//   1. Verifies the caller via their JWT and confirms they own the person.
+//   2. Loads people + active ehr_connections + the caller's care-circle
+//      role, and runs the prefill resolver to derive what we can from the
+//      chart/profile.
+//   3. Merges the caregiver's partial_input over the derived values and
+//      records per-field provenance.
+//   4. Runs the SAME generatePrograms() / generateSignals() engine the
+//      public scorecard uses (vendored in _shared/reimbursement-engine.ts).
+//   5. Upserts reimbursement_assessments for that person_id (one row each).
+//   6. Returns { programs, signals, prefilled_fields, asked_fields,
+//      assessment_id }.
+//
+// Two request shapes:
+//   - "prefill" (partial_input absent/empty, or mode:"prefill"): resolve
+//     what we can, DO NOT persist results, return prefilled_fields +
+//     asked_fields so the client can show the question flow. Programs are
+//     returned too (best-effort against the prefill) but not saved.
+//   - "submit" (full merged input): resolve + generate + upsert + return.
+//
+// Gateway config: verify_jwt = true. There is no public/anon path here —
+// the public marketing scorecard stays in the getwellet repo's
+// scorecard2-submit (verify_jwt = false). See spec "Option A".
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getCorsHeaders } from "../_shared/cors.ts";
+import {
+  generatePrograms,
+  generateSignals,
+} from "../_shared/reimbursement-engine.ts";
+import {
+  EhrConnectionRow,
+  PartialInput,
+  PersonRow,
+  resolvePrefill,
+} from "../_shared/reimbursement-prefill.ts";
+
+// Decode the JWT "sub" claim without verifying the signature. The gateway
+// has already verified the JWT (verify_jwt = true); we only need the sub to
+// cross-check ownership on the service-role fallback path.
+function decodeJwtSub(hdr: string): string | null {
+  try {
+    const tok = hdr.replace(/^bearer\s+/i, "").trim();
+    const parts = tok.split(".");
+    if (parts.length < 2) return null;
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const pad = b64.length % 4 ? "=".repeat(4 - (b64.length % 4)) : "";
+    const claims = JSON.parse(atob(b64 + pad));
+    return claims.sub || null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+function json(body: unknown, status: number, cors: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...cors, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  const cors = getCorsHeaders(req);
+
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  if (req.method !== "POST") return json({ error: "Method not allowed" }, 405, cors);
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON" }, 400, cors);
+  }
+
+  const personId = typeof body.person_id === "string" ? body.person_id : null;
+  if (!personId) return json({ error: "person_id is required" }, 400, cors);
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+    return json({ error: "Missing Authorization header" }, 401, cors);
+  }
+  const jwtSub = decodeJwtSub(authHeader);
+
+  const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+  const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    return json({ error: "Server configuration error" }, 500, cors);
+  }
+
+  // RLS-scoped client (the caller) for ownership-respecting reads, plus a
+  // service-role client for the upsert and cross-table reads.
+  const userClient = createClient(SUPABASE_URL, ANON_KEY, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false },
+  });
+  const admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false },
+  });
+
+  // Confirm the caller owns this person. RLS read first; service-role
+  // fallback only when the JWT sub matches the row's user_id.
+  let { data: person } = await userClient
+    .from("people")
+    .select("id, user_id, date_of_birth, conditions, insurance_info")
+    .eq("id", personId)
+    .maybeSingle();
+  if (!person && jwtSub) {
+    const { data: adminPerson } = await admin
+      .from("people")
+      .select("id, user_id, date_of_birth, conditions, insurance_info")
+      .eq("id", personId)
+      .maybeSingle();
+    if (adminPerson && adminPerson.user_id === jwtSub) person = adminPerson;
+  }
+  if (!person) return json({ error: "Person not found" }, 404, cors);
+
+  const userId = person.user_id as string;
+
+  // Load active EHR connections + the caller's care-circle role in parallel.
+  const [ehrRes, ccRes, ccCountRes] = await Promise.all([
+    admin
+      .from("ehr_connections")
+      .select("hospital_name, connected_provider, provider, status")
+      .eq("person_id", personId),
+    admin
+      .from("care_circle_members")
+      .select("role")
+      .eq("person_id", personId)
+      .eq("user_id", userId)
+      .maybeSingle(),
+    admin
+      .from("care_circle_members")
+      .select("id", { count: "exact", head: true })
+      .eq("person_id", personId),
+  ]);
+
+  const ehrConnections = (ehrRes.data || []) as EhrConnectionRow[];
+  const careCircleRole = (ccRes.data?.role as string | undefined) ?? null;
+  const soleCareCircleMember = (ccCountRes.count ?? 0) <= 1;
+
+  const rawPartial = (body.partial_input && typeof body.partial_input === "object")
+    ? (body.partial_input as PartialInput)
+    : {};
+
+  const resolved = resolvePrefill(
+    {
+      person: person as PersonRow,
+      ehrConnections,
+      careCircleRole,
+      soleCareCircleMember,
+    },
+    rawPartial,
+  );
+
+  const programs = generatePrograms(resolved.input);
+  const signals = generateSignals(resolved.input);
+
+  // A "prefill" request — no answers yet — returns the resolved fields and
+  // what we still need to ask, WITHOUT persisting. Treat an explicit
+  // mode:"prefill" or an empty partial_input as prefill.
+  const explicitMode = typeof body.mode === "string" ? body.mode : null;
+  const hasAnswers = Object.keys(rawPartial || {}).some((k) => {
+    const v = (rawPartial as Record<string, unknown>)[k];
+    return Array.isArray(v) ? v.length > 0 : v != null && v !== "";
+  });
+  const isPrefill = explicitMode === "prefill" || (!explicitMode && !hasAnswers);
+
+  if (isPrefill) {
+    return json({
+      mode: "prefill",
+      programs,
+      signals,
+      prefilled_fields: resolved.prefilled_fields,
+      asked_fields: resolved.asked_fields,
+      input_provenance: resolved.provenance,
+      assessment_id: null,
+    }, 200, cors);
+  }
+
+  // Submit path: upsert the assessment. assessed_at is bumped so the
+  // stale_at trigger re-arms the 90-day window and needs_refresh resets.
+  const now = new Date().toISOString();
+  const row = {
+    person_id: personId,
+    user_id: userId,
+    loved_one_age_band: resolved.input.loved_one_age_band,
+    conditions: resolved.input.conditions,
+    current_tools: resolved.input.current_tools,
+    biggest_worry: resolved.input.biggest_worry,
+    coverage: resolved.input.coverage,
+    adl_level: resolved.input.adl_level,
+    hospital_system: resolved.input.hospital_system,
+    caregiver_role: resolved.input.caregiver_role,
+    state: resolved.input.state,
+    result_programs: programs,
+    result_signals: signals,
+    input_provenance: resolved.provenance,
+    assessed_at: now,
+    needs_refresh: false,
+  };
+
+  const { data: upserted, error: upsertErr } = await admin
+    .from("reimbursement_assessments")
+    .upsert(row, { onConflict: "person_id" })
+    .select("id")
+    .single();
+
+  if (upsertErr) {
+    console.error("reimbursements upsert error", upsertErr);
+    return json({ error: "Could not save your assessment" }, 500, cors);
+  }
+
+  return json({
+    mode: "submit",
+    programs,
+    signals,
+    prefilled_fields: resolved.prefilled_fields,
+    asked_fields: resolved.asked_fields,
+    input_provenance: resolved.provenance,
+    assessment_id: upserted.id,
+  }, 200, cors);
+});

--- a/supabase/migrations/20260610120000_create_reimbursement_assessments.sql
+++ b/supabase/migrations/20260610120000_create_reimbursement_assessments.sql
@@ -1,0 +1,80 @@
+-- Reimbursements (mywellet) PR 1
+--
+-- One row per loved one (person_id). Holds the 9 ScorecardInput fields,
+-- the generated programs/signals, per-field provenance, and freshness
+-- metadata. We do NOT denormalize program details onto people — programs
+-- and federal rules change, and we want to re-run generation against a
+-- saved input set.
+--
+-- See: wellet_reimbursements_mywellet_spec.md (Data model).
+
+CREATE TABLE IF NOT EXISTS public.reimbursement_assessments (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  person_id       UUID        NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  user_id         UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- The 9 ScorecardInput fields (same shape as scorecard2-submit v2).
+  loved_one_age_band   TEXT,   -- derived from people.date_of_birth when possible
+  conditions           TEXT[]  NOT NULL DEFAULT '{}',  -- from people.conditions / chart
+  current_tools        TEXT[]  NOT NULL DEFAULT '{}',  -- always asked
+  biggest_worry        TEXT,   -- always asked
+  coverage             TEXT[]  NOT NULL DEFAULT '{}',  -- partially derivable from people.insurance_info
+  adl_level            TEXT,   -- always asked (not in chart)
+  hospital_system      TEXT,   -- derived from ehr_connections
+  caregiver_role       TEXT,   -- derived from care_circle_members.role, else asked
+  state                TEXT,   -- derived from hospital / profile, else asked
+
+  -- Results from scorecard2-submit v2's generatePrograms() / generateSignals().
+  result_programs      JSONB   NOT NULL DEFAULT '[]'::jsonb,
+  result_signals       JSONB   NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Per-input-field provenance, e.g. { "conditions": "ehr", "coverage": "user" }.
+  -- Lets the UI show "we filled this from the chart" vs "you told us".
+  input_provenance     JSONB   NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Freshness.
+  assessed_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  stale_at             TIMESTAMPTZ,  -- assessed_at + 90 days; set by trigger
+  needs_refresh        BOOLEAN     NOT NULL DEFAULT FALSE,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One assessment per loved one. The edge function upserts on this.
+CREATE UNIQUE INDEX IF NOT EXISTS reimbursement_assessments_person_unique
+  ON public.reimbursement_assessments(person_id);
+
+-- The freshness triggers (next migration) flip needs_refresh by user_id +
+-- person_id; index both for the lookups they do.
+CREATE INDEX IF NOT EXISTS reimbursement_assessments_user_idx
+  ON public.reimbursement_assessments(user_id);
+
+ALTER TABLE public.reimbursement_assessments ENABLE ROW LEVEL SECURITY;
+
+-- Caregivers see and manage only their own assessments. The edge function
+-- writes with the service role, so it is unaffected by this policy.
+CREATE POLICY "Users see own reimbursements" ON public.reimbursement_assessments
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- ── Freshness trigger: set stale_at = assessed_at + 90 days ──────────
+-- Runs on INSERT and whenever assessed_at changes on UPDATE, so a refresh
+-- (which bumps assessed_at) re-arms the 90-day window. Also keeps
+-- updated_at current.
+CREATE OR REPLACE FUNCTION public.set_reimbursement_freshness()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.stale_at := NEW.assessed_at + INTERVAL '90 days';
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER reimbursement_assessments_set_freshness
+  BEFORE INSERT OR UPDATE OF assessed_at
+  ON public.reimbursement_assessments
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_reimbursement_freshness();
+
+COMMENT ON TABLE public.reimbursement_assessments IS
+  'One per loved one (person_id). Saved scorecard input + generated programs/signals + freshness for the in-app Reimbursements surface. See wellet_reimbursements_mywellet_spec.md.';

--- a/supabase/migrations/20260610120100_reimbursement_freshness_triggers.sql
+++ b/supabase/migrations/20260610120100_reimbursement_freshness_triggers.sql
@@ -1,0 +1,59 @@
+-- Reimbursements (mywellet) PR 1 — freshness triggers
+--
+-- Flip reimbursement_assessments.needs_refresh = TRUE for a loved one when
+-- their situation changes in a way that could change which programs apply:
+--   - a new EHR connection is added (new hospital_system / chart)
+--   - their chart conditions or insurance change (people.conditions /
+--     people.insurance_info)
+--
+-- The on-render UI also treats stale_at < now() as needs_refresh, so the
+-- 90-day case is handled client-side and does not need a trigger.
+--
+-- See: wellet_reimbursements_mywellet_spec.md (Freshness rules).
+
+-- Mark every assessment for a loved one stale. SECURITY DEFINER so the
+-- trigger can update the row regardless of the acting user's RLS context;
+-- it only ever flips a boolean, never reads PHI.
+CREATE OR REPLACE FUNCTION public.mark_reimbursements_stale(p_person_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE public.reimbursement_assessments
+     SET needs_refresh = TRUE,
+         updated_at    = NOW()
+   WHERE person_id = p_person_id
+     AND needs_refresh = FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- ── ehr_connections INSERT ──────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.reimbursements_on_ehr_connection()
+RETURNS TRIGGER AS $$
+BEGIN
+  PERFORM public.mark_reimbursements_stale(NEW.person_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS reimbursements_ehr_connection_added ON public.ehr_connections;
+CREATE TRIGGER reimbursements_ehr_connection_added
+  AFTER INSERT ON public.ehr_connections
+  FOR EACH ROW
+  EXECUTE FUNCTION public.reimbursements_on_ehr_connection();
+
+-- ── people UPDATE (conditions or insurance_info changed) ────────────
+CREATE OR REPLACE FUNCTION public.reimbursements_on_person_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.conditions IS DISTINCT FROM OLD.conditions
+     OR NEW.insurance_info IS DISTINCT FROM OLD.insurance_info THEN
+    PERFORM public.mark_reimbursements_stale(NEW.id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+DROP TRIGGER IF EXISTS reimbursements_person_situation_changed ON public.people;
+CREATE TRIGGER reimbursements_person_situation_changed
+  AFTER UPDATE OF conditions, insurance_info ON public.people
+  FOR EACH ROW
+  EXECUTE FUNCTION public.reimbursements_on_person_update();

--- a/tests/security/reimbursements-rls.test.js
+++ b/tests/security/reimbursements-rls.test.js
@@ -1,0 +1,139 @@
+// @ts-check
+// RLS regression for public.reimbursement_assessments (Reimbursements PR 1).
+//
+// The policy "Users see own reimbursements" is FOR ALL USING
+// (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id). We verify:
+//   1. Anonymous clients cannot read the table.
+//   2. The authed QA user can insert + read their OWN row.
+//   3. WITH CHECK blocks inserting a row for a different user_id
+//      (write isolation — user A cannot plant a row as user B).
+//   4. A SELECT by the authed user only ever returns rows they own
+//      (read isolation — user A cannot read user B's rows).
+//
+// The edge function writes with the service role, which bypasses RLS, so
+// these client-side policies do not interfere with normal app writes.
+
+var { test, expect } = require('@playwright/test');
+var { createClient } = require('@supabase/supabase-js');
+
+var SUPABASE_URL = 'https://nrpdhxygzyfmyljzfexv.supabase.co';
+var SUPABASE_ANON_KEY = '[REDACTED-JWT]';
+var QA_EMAIL = 'qa-test-1776217285478@getwellet.com';
+var QA_PASSWORD = 'TestPass123!';
+var QA_USER_ID = '8c7e632f-1743-479d-9c27-da018837e60d';
+
+// A well-formed UUID that is NOT the QA user — used to attempt a cross-user
+// insert that RLS WITH CHECK must reject.
+var OTHER_USER_ID = '00000000-0000-4000-8000-000000000abc';
+
+test.describe('Reimbursements RLS (reimbursement_assessments)', function () {
+  /** @type {import('@supabase/supabase-js').SupabaseClient} */
+  var anonClient;
+  /** @type {import('@supabase/supabase-js').SupabaseClient} */
+  var authedClient;
+  /** @type {string} */
+  var testPersonId;
+  /** @type {string[]} */
+  var createdAssessmentIds = [];
+
+  test.beforeAll(async function () {
+    anonClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+    authedClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    var { error } = await authedClient.auth.signInWithPassword({
+      email: QA_EMAIL,
+      password: QA_PASSWORD,
+    });
+    if (error) throw new Error('Auth failed: ' + error.message);
+
+    // Need a person owned by the QA user (FK target for person_id).
+    var { data: people, error: peopleErr } = await authedClient
+      .from('people')
+      .select('id')
+      .eq('user_id', QA_USER_ID)
+      .limit(1);
+    if (peopleErr) throw new Error('Failed to query people: ' + peopleErr.message);
+    if (!people || people.length === 0) {
+      var { data: newPerson, error: createErr } = await authedClient
+        .from('people')
+        .insert({ user_id: QA_USER_ID, name: 'QA Reimbursements Person' })
+        .select('id')
+        .single();
+      if (createErr) throw new Error('Failed to create test person: ' + createErr.message);
+      testPersonId = newPerson.id;
+    } else {
+      testPersonId = people[0].id;
+    }
+  });
+
+  test.afterAll(async function () {
+    for (var i = 0; i < createdAssessmentIds.length; i++) {
+      await authedClient
+        .from('reimbursement_assessments')
+        .delete()
+        .eq('id', createdAssessmentIds[i]);
+    }
+  });
+
+  test('anon cannot SELECT from reimbursement_assessments', async function () {
+    var { data, error } = await anonClient
+      .from('reimbursement_assessments')
+      .select('*');
+    var blocked = !!error || (data && data.length === 0);
+    expect(blocked).toBe(true);
+  });
+
+  test('authed user can insert and read their own assessment', async function () {
+    var { data, error } = await authedClient
+      .from('reimbursement_assessments')
+      .insert({
+        person_id: testPersonId,
+        user_id: QA_USER_ID,
+        adl_level: '1_2',
+        caregiver_role: 'primary',
+      })
+      .select('id, user_id, stale_at, assessed_at')
+      .single();
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    expect(data.user_id).toBe(QA_USER_ID);
+    // The freshness trigger must have populated stale_at = assessed_at + 90d.
+    expect(data.stale_at).not.toBeNull();
+    var delta = new Date(data.stale_at).getTime() - new Date(data.assessed_at).getTime();
+    var ninetyDays = 90 * 24 * 60 * 60 * 1000;
+    expect(Math.abs(delta - ninetyDays)).toBeLessThan(60 * 1000);
+    createdAssessmentIds.push(data.id);
+
+    var { data: readBack, error: readErr } = await authedClient
+      .from('reimbursement_assessments')
+      .select('id')
+      .eq('id', data.id)
+      .maybeSingle();
+    expect(readErr).toBeNull();
+    expect(readBack).not.toBeNull();
+  });
+
+  test('WITH CHECK blocks inserting a row owned by a different user', async function () {
+    var { data, error } = await authedClient
+      .from('reimbursement_assessments')
+      .insert({
+        person_id: testPersonId,
+        user_id: OTHER_USER_ID, // not auth.uid() — must be rejected
+        adl_level: 'none',
+      })
+      .select('id');
+    // RLS WITH CHECK rejects the row: error, or no row returned.
+    var blocked = !!error || !data || data.length === 0;
+    expect(blocked).toBe(true);
+  });
+
+  test('authed SELECT only returns rows owned by the current user', async function () {
+    var { data, error } = await authedClient
+      .from('reimbursement_assessments')
+      .select('user_id');
+    expect(error).toBeNull();
+    (data || []).forEach(function (row) {
+      expect(row.user_id).toBe(QA_USER_ID);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of the Reimbursements feature. Adds an in-app **Reimbursements** view that surfaces programs that may pay for the care a caregiver is already giving for a loved one — reusing the same program-matching engine as the public scorecard.

- **Migration** `reimbursement_assessments`: one row per `person_id`, RLS `FOR ALL USING (auth.uid() = user_id) WITH CHECK (...)`, freshness trigger sets `stale_at = assessed_at + 90 days`.
- **Migration** freshness triggers: flip `needs_refresh = true` on `ehr_connections` insert and on `people.conditions` / `people.insurance_info` change.
- **Edge function** `supabase/functions/reimbursements` (JWT-verified): ownership check, loads `people` + active `ehr_connections` + care-circle role, runs the prefill resolver, runs the vendored `generatePrograms`/`generateSignals` engine, upserts the assessment. Returns `{ programs, signals, prefilled_fields, asked_fields, input_provenance, assessment_id }`.
- **Frontend**: header-menu item (badge-dollar-sign) + `#view-reimbursements`, single-page question flow with prefill chips + provenance, program cards, stale ribbon, "Update my situation".
- **Tests**: RLS regression + prefill resolver unit tests.

## Decisions diverging from spec
- **Repo**: applied to `wellet-app/wellet` — `wellet-app/mywellet` does not exist on the connector; `wellet-app/wellet` is the same codebase (identical index.html / wellet.js / supabase tree).
- **Engine vendored** into `_shared/reimbursement-engine.ts` (recommendation option a) so mywellet has a single in-repo source rather than a cross-repo import.
- **Brand colors** use existing design tokens (`--moss`, `--cream`, `--ink-*`); TERRA `#c07028` reserved for the stale ribbon only. Spec hexes differ slightly; tokens keep the surface consistent with the rest of the app.
- **Schema reality**: `people.conditions` / `insurance_info` are TEXT (no array, no address column) — conditions parsed from text, state derived from hospital only.
- **90-day staleness** evaluated client-side (no cron); triggers cover chart/connection changes.

## Out of scope (PR 2)
CareSignals embed in `_paintSignals` (untouched); per-program "Mark as applied"; ICD-10 mapping.

## Test plan
- [ ] Run migrations via `supabase/apply-migrations.sh`
- [ ] Deploy `supabase functions deploy reimbursements`
- [ ] `tests/security/reimbursements-rls.test.js` passes (anon blocked, own insert+read, WITH CHECK blocks foreign user_id, stale_at ~90d)
- [ ] `deno test supabase/functions/_shared/reimbursement-prefill.test.ts`
- [ ] Open Reimbursements from header menu → question flow → see program cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)