### PR TITLE
feat(onboarding): honor intended_mode from URL, skip self-vs-loved-one gate

### DIFF
--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -1464,9 +1464,14 @@ function _buildSignupAttribution() {
     else if (landing === '/' || landing === '/index.html') sig = 'caregiver_landing';
     else sig = 'unknown';
   }
+  // intended_mode: getwellet sets this explicitly from the /me vs / route so we
+  // can skip the self-vs-loved-one gate. Only persist a known value.
+  var intendedMode = (params.intended_mode === 'me' || params.intended_mode === 'caregiver')
+    ? params.intended_mode : null;
   return {
     signup_location: sig,
     landing_page: landing,
+    intended_mode: intendedMode,
     entry_path: landing + (window.location.search || ''),
     referrer: (document.referrer || '').slice(0, 500),
     utm_source: params.utm_source || null,
@@ -2247,11 +2252,24 @@ async function loadUserData() {
     appMode = profileMode;
 
     if (appMode === null) {
-      // First run. Before showing the mode question, check whether this user
-      // came from /me (or has signup_location starting with 'me_'). If so they
-      // already told us, so call chooseModeMe() directly. Otherwise show the
-      // mode question and let the user pick.
+      // First run. If getwellet told us which mode the user self-selected
+      // (intended_mode=me|caregiver), honor it and skip the gate. The URL param
+      // wins; if it was already consumed during signup we fall back to the value
+      // stored in user_metadata. An unknown/missing value falls through to the
+      // existing heuristic + gate, so old links see no regression.
       var _meta = (currentUser && currentUser.user_metadata) || {};
+      var _intended = null;
+      try { _intended = new URLSearchParams(window.location.search || '').get('intended_mode'); } catch (e) {}
+      if (_intended !== 'me' && _intended !== 'caregiver') { _intended = _meta.intended_mode || null; }
+      if (_intended === 'me') {
+        try { await chooseModeMe(); } catch (e) { console.warn('intended_mode=me bypass failed:', e); showModeQuestion(); }
+        return;
+      }
+      if (_intended === 'caregiver') {
+        try { await chooseModeCaregiver(); } catch (e) { console.warn('intended_mode=caregiver bypass failed:', e); showModeQuestion(); }
+        return;
+      }
+      // No explicit mode — fall back to the legacy /me signup heuristic.
       var _sig = _meta.signup_location || '';
       var _landing = _meta.landing_page || '';
       var _isMeSignup = (typeof _sig === 'string' && _sig.indexOf('me_') === 0) ||


### PR DESCRIPTION
## Bug

getwellet's /me route did not pass the user's self-selected mode to the app, so users in /me mode still saw the "managing yourself or a loved one?" first-run gate after already choosing "for me" upstream. This closes that UX gap, which matches the recent /me signup drop-off pattern (NYC self-managing signup that did not complete onboarding).

## Fix

`assets/wellet.js`:
- `_buildSignupAttribution()` captures a validated `intended_mode` (`me` | `caregiver` only) into `user_metadata`, so the intent survives even if the URL param is consumed during the signup round trip.
- The first-run gate in `loadUserData()` now reads `intended_mode` — URL param first, `user_metadata` fallback:
  - `me` -> `chooseModeMe()`: writes `profiles.app_mode = 'me'`, creates the user's own `people` row with `is_self = true`, routes into the for-me connect flow.
  - `caregiver` -> `chooseModeCaregiver()`: writes `profiles.app_mode = 'caregiver'`, routes into caregiver onboarding.
  - missing/invalid -> falls through to the existing `me_*` / landing-page heuristic and then the gate, so old links see no regression.

The mode handlers already performed the profile write, self-person creation, and routing; this change only makes them fire automatically when the mode is known.

Paired marketing-site change (sets the param): **wellet-app/getwellet#14** — `fix(signup): pass intended_mode through /me route to mywellet`.

## Manual test steps

1. Visit getwellet.com/me, enter an email, click the signup button.
2. Confirm the redirect to mywellet.com carries `intended_mode=me`.
3. Land in mywellet and confirm the self-vs-loved-one gate is skipped, `profiles.app_mode = 'me'` is set, and an `is_self = true` person row is created.
4. Repeat from getwellet.com/ and confirm `intended_mode=caregiver` skips the gate into caregiver onboarding.
5. Sign up via an old link with no `intended_mode` and confirm the gate still shows (no regression).

## Notes

- Diff is intentionally small (~22 insertions / 4 deletions, one file).
- Schema already supports this (`profiles.app_mode`, `people.is_self` from `20260505_me_branch_setup.sql`).
- Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)