### PR TITLE
fix(/me): four onboarding quick wins — Upload-first, gentler skip, mode-neutral welcome, safe name fallback

### DIFF
--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -4537,7 +4537,7 @@ function renderUpdateMe() {
   var pane = document.getElementById('tab-update');
   if (!pane) return;
   var person = currentPeople.find(function(p){ return p.id === currentPersonId; });
-  var name = person ? person.name.split(' ')[0] : 'your loved one';
+  var name = person ? person.name.split(' ')[0] : loRefSubjectLower();
   var isSelf = !!(person && person.relationship === 'self');
   var subjectName = isSelf ? 'you' : name;
   var ehrConnected = !!getEhrData(currentPersonId);

--- a/index.html
+++ b/index.html
@@ -471,6 +471,16 @@
     <h1 class="connect-data-headline" id="connect-data-headline">Bring in <em>your data</em>.</h1>
     <p class="connect-data-sub">Connect one thing now to see Wellet light up. The others can come later.</p>
 
+    <!-- 2026-06-01 (D3): Upload card so reviewers without an activated hospital still have a path forward. -->
+    <button type="button" class="connect-card" id="connect-card-upload" onclick="_goUploadFromVendorCard()">
+      <span class="connect-card-icon"><i data-lucide="upload"></i></span>
+      <span class="connect-card-body">
+        <span class="connect-card-title">Upload a record</span>
+        <span class="connect-card-sub">Have a PDF or photo of a visit summary, lab result, or after-visit summary? Drop it in and Wellet will read it for you.</span>
+      </span>
+      <span class="connect-card-chevron"><i data-lucide="chevron-right"></i></span>
+    </button>
+
     <button type="button" class="connect-card" id="connect-card-ehr" onclick="connectFromMeOnboarding('ehr')">
       <span class="connect-card-icon"><i data-lucide="hospital"></i></span>
       <span class="connect-card-body">
@@ -517,18 +527,8 @@
       <span class="connect-card-chevron"><i data-lucide="chevron-right"></i></span>
     </button>
 
-    <!-- 2026-06-01 (D3): Upload card so reviewers without an activated hospital still have a path forward. -->
-    <button type="button" class="connect-card" id="connect-card-upload" onclick="_goUploadFromVendorCard()">
-      <span class="connect-card-icon"><i data-lucide="upload"></i></span>
-      <span class="connect-card-body">
-        <span class="connect-card-title">Upload a record</span>
-        <span class="connect-card-sub">Have a PDF or photo of a visit summary, lab result, or after-visit summary? Drop it in and Wellet will read it for you.</span>
-      </span>
-      <span class="connect-card-chevron"><i data-lucide="chevron-right"></i></span>
-    </button>
-
     <button type="button" class="connect-skip-btn" onclick="skipConnectScreen()">
-      Skip for now — you can connect anything from Settings
+      Just show me around first
     </button>
   </div>
 </div>
@@ -2876,7 +2876,7 @@
       <div style="width:56px;height:56px;border-radius:50%;background:var(--mint);display:flex;align-items:center;justify-content:center;margin:0 auto 16px;"><i data-lucide="heart-handshake" style="width:28px;height:28px;color:var(--moss);"></i></div>
       <div style="font-family: var(--serif);font-size:var(--type-h1);margin-bottom:8px;">Welcome to Wellet</div>
       <p style="font-size:var(--type-body);line-height:1.65;color:var(--text-secondary);margin-bottom:16px;">You're one of the very first people to use this. Wellet has been in my head for years, but the app you're looking at is less than a month old.</p>
-      <p style="font-size:var(--type-body);line-height:1.65;color:var(--text-secondary);margin-bottom:20px;"><strong style="color:var(--text-primary);">That means there will be bugs.</strong> I'm asking, begging you: if something breaks or feels off, tap the menu (<strong>•••</strong>) and choose <strong>Report a bug</strong>. Every report makes Wellet better for every caregiver who comes next.</p>
+      <p style="font-size:var(--type-body);line-height:1.65;color:var(--text-secondary);margin-bottom:20px;"><strong style="color:var(--text-primary);">That means there will be bugs.</strong> I'm asking, begging you: if something breaks or feels off, tap the menu (<strong>•••</strong>) and choose <strong>Report a bug</strong>. Every report makes Wellet better for everyone who comes next.</p>
       <div style="background:var(--cream);border-radius:12px;padding:16px;text-align:left;margin-bottom:20px;">
         <div style="font-size:var(--type-meta);font-weight:500;color:var(--text-primary);margin-bottom:10px;">Here's how to get started:</div>
         <div id="welcome-getting-started" style="font-size:var(--type-meta);color:var(--text-secondary);line-height:1.7;">


### PR DESCRIPTION
## Why

The /me onboarding audit (`/home/user/workspace/me_onboarding_flow_audit.md`) found the real drop-off cause: the first screen a self-managing user sees after signup leads with a hospital connect that only works for about 31 health systems. A user whose hospital is not on that list reaches a "Request access" / "Tell us your hospital" contact form that returns no data and no value.

The data behind it: three /me signups since May 25 (richdea, byelverton5, pchalasani). All three got `app_mode='me'` set and an `is_self=true` people row created, then bounced in under three minutes. Zero EHR connections. Zero uploads. The mode-pass works; the first screen they saw did not give them a path that succeeds.

This ships the four low-risk quick wins Betsy approved (audit items 1, 2, 4, 5).

## Changes

1. **Upload card is now first on the connect screen** (`index.html`, `#connect-data-screen`). The "Upload a record" card moves above "Your health records." Upload works for every user and returns a result in seconds; the hospital connect works for only the ~31 activated health systems. The card markup, copy, and CTA are unchanged — only the order. Upload label kept as "Upload a record".
2. **Gentler skip link** (`index.html`, connect screen). "Skip for now — you can connect anything from Settings" becomes "Just show me around first." Same target (`skipConnectScreen()`).
3. **Mode-neutral welcome overlay** (`index.html:2879`). "Every report makes Wellet better for every caregiver who comes next" becomes "...for everyone who comes next" so the first overlay does not call a self-managing user a caregiver.
4. **Safe self-mode name fallback** (`assets/wellet.js:4540`, `renderUpdateMe()`). The fallback changes from a hardcoded `'your loved one'` to the existing mode-aware helper `loRefSubjectLower()` (returns "you" in /me mode, "your loved one" otherwise). Defensive — it does not fire for a correctly onboarded user today, but it prevents a "your loved one" leak if a person row is ever missing.

## Manual test steps

1. Sign up at getwellet.com/me as a new user.
2. Land in mywellet and confirm the self-vs-loved-one gate is skipped (behavior from #124).
3. Confirm the connect screen now shows "Upload a record" as the first card, above "Your health records."
4. Confirm the skip link reads "Just show me around first."
5. Dismiss the welcome overlay and confirm the copy reads "everyone who comes next."

## Notes

- Diff is intentionally small (+13 / -13 across two files); the Upload reorder shows as an add plus a remove because it is a DOM move.
- `node --check` passes on `assets/wellet.js`.
- Related: wellet-app/wellet#124 (honor intended_mode, skip the gate) and wellet-app/getwellet#14 (pass intended_mode through the /me route). This PR builds on the screen those land the user on.
- Draft for Betsy's morning review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
