### PR TITLE
fix(emergency-summary): remove drug-interaction flag, add clinical-judgment guardrails

### DIFF
--- a/supabase/functions/generate-emergency-summary/index.ts
+++ b/supabase/functions/generate-emergency-summary/index.ts
@@ -276,7 +276,14 @@ Format rules:
 - Keep it under 300 words
 - Use clear section headers like ALLERGIES:, MEDICATIONS:, CONDITIONS:, RECENT PROCEDURES:, CONTACTS:
 - List medications with dosages on separate lines
-- Flag any critical drug interactions or allergy concerns prominently at the top`,
+- If a documented allergy in the data is relevant to a medication that is also in the data, restate the allergy in the ALLERGIES section verbatim. Do not infer new allergy/medication conflicts from training knowledge.
+
+Clinical-judgment guardrails (STRICT):
+- Do NOT flag drug interactions. Wellet does not perform pharmacovigilance — leave clinical judgment to the care team.
+- Do NOT flag dosing errors, contraindications, or medication mistakes.
+- Do NOT introduce any medication, condition, allergy, dose, date, or contact that is not present verbatim in the data provided. If a field is missing, omit the section or write "Not on file."
+- Never invent ICD-10, CPT, HCPCS, or NDC codes. Only include codes that appear in the data.
+- You are not a doctor. Frame everything as a transcription of what is recorded, not as medical advice.`,
             },
             {
               role: "user",


### PR DESCRIPTION
## Why

From the 2026-06-12 Wellet accuracy audit (HIGH-1 finding).

The `generate-emergency-summary` system prompt told the LLM to **"Flag any critical drug interactions or allergy concerns prominently at the top."** This is pharmacovigilance — the model would have to use training-data knowledge, not a verified drug-interaction database. An ER document with a hallucinated interaction flag is a patient-safety event.

This contradicts the rule already enforced in `ask-wellet/index.ts:960` ("Do NOT flag dosing errors, drug interactions, or medication mistakes"). The two functions should follow the same architectural principle: **the LLM transcribes the record; clinical judgment stays with the care team.**

## What changed

- Removed the "Flag any critical drug interactions or allergy concerns" line
- Added explicit clinical-judgment guardrails (no interactions, no dosing errors, no contraindications, no inventing meds/conditions/allergies/codes)
- Allergy restatement only allowed when both the allergy AND the medication already appear verbatim in the record
- Pattern matches `ask-wellet`

## Test before merge

1. Generate an emergency summary for a synthetic patient with known meds + a documented allergy. Confirm the output does not invent any new flag.
2. Generate a summary for a patient with a med that is famously interaction-prone (e.g. warfarin + an NSAID). Confirm the model no longer adds an interaction warning.
3. Confirm format (headers, plain text, <300 words) still holds.

## Deploy

After merge: `supabase functions deploy generate-emergency-summary` against production.

— Mabel