### PR TITLE
feat(billing): PR 1 — claims + EOB ingestion schema (manual-entry only)

### DIFF
--- a/supabase/migrations/20260612160000_create_billing_ingestion.sql
+++ b/supabase/migrations/20260612160000_create_billing_ingestion.sql
@@ -1,0 +1,277 @@
+-- Billing-error detection PR 1 — claims + EOB ingestion (manual-entry only).
+--
+-- This migration creates the four ingestion tables that PR 2 (the manual-entry
+-- form) writes into and that the billing-rules engine (PR 3) reads from.
+-- OCR is explicitly deferred to v1.1: every row in v1 has source = 'manual'.
+--
+-- Mirrors the reimbursement_assessments pattern:
+--   - person_id + user_id FK, RLS on auth.uid() = user_id
+--   - per-field provenance via JSONB
+--   - freshness via updated_at trigger
+--
+-- Caregiver-facing language note: in UI copy we will say "bill" (claims_documents)
+-- and "Explanation of Benefits" (eob_documents). Internal column names use the
+-- standard insurance terms so the engine maps cleanly to CMS-source language.
+--
+-- See: wellet_billing_error_detection_build_plan_v2.md (v2.1 sequence: PR 1).
+--      wellet_accuracy_audit_followup_2026-06-12.md (governing accuracy rule).
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 1. claims_documents
+--   One row per uploaded/entered provider bill.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.claims_documents (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  person_id             UUID        NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Provider / facility identification. All optional at insert; engine rules
+  -- that depend on a missing field will not fire (see accuracy rule #6).
+  provider_name         TEXT,
+  provider_npi          TEXT,                         -- 10-digit NPI if known
+  facility_name         TEXT,
+  service_date_start    DATE,                         -- earliest date of service on the bill
+  service_date_end      DATE,                         -- latest date of service on the bill
+  statement_date        DATE,
+  total_billed_amount   NUMERIC(12,2),                -- cents-precision dollars
+  amount_due            NUMERIC(12,2),
+  payer_name            TEXT,                         -- Medicare / commercial insurer / Medicaid / self-pay
+  payer_type            TEXT CHECK (
+                          payer_type IS NULL OR
+                          payer_type IN (
+                            'medicare', 'medicare_advantage', 'medicaid',
+                            'commercial', 'self_pay', 'tricare', 'va', 'other'
+                          )
+                        ),
+  account_number        TEXT,
+
+  -- Source provenance. v1: 'manual' only. v1.1 may add 'ocr'.
+  source                TEXT NOT NULL CHECK (source IN ('manual', 'ocr', 'imported')),
+
+  -- Per-field provenance map, e.g. { "provider_npi": "manual", "service_date_start": "manual" }.
+  -- Mirrors reimbursement_assessments.input_provenance.
+  field_provenance      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Free-text notes the caregiver added on entry (no engine logic depends on this).
+  notes                 TEXT,
+
+  -- Storage hook for the original document if ever uploaded. Nullable in v1
+  -- since manual entry has no attachment. v1.1 will populate this when OCR ships.
+  original_storage_path TEXT,
+
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS claims_documents_user_idx
+  ON public.claims_documents(user_id);
+CREATE INDEX IF NOT EXISTS claims_documents_person_idx
+  ON public.claims_documents(person_id);
+CREATE INDEX IF NOT EXISTS claims_documents_service_date_idx
+  ON public.claims_documents(service_date_start);
+
+ALTER TABLE public.claims_documents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own claims_documents" ON public.claims_documents
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE public.claims_documents IS
+  'One row per provider bill the caregiver has entered for a loved one. v1 manual-entry only; OCR deferred to v1.1.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 2. claims_line_items
+--   One row per line on a bill. Engine rules fire at the line level.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.claims_line_items (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  claim_document_id     UUID        NOT NULL REFERENCES public.claims_documents(id) ON DELETE CASCADE,
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  -- Service identification.
+  service_date          DATE,                         -- specific line date (may differ from doc-level range)
+  cpt_code              TEXT,                         -- HCPCS Level I (CPT) code, 5 chars
+  hcpcs_code            TEXT,                         -- HCPCS Level II code (when not CPT)
+  modifier_1            TEXT,                         -- e.g. '76', '77', '25', 'LT', 'RT'
+  modifier_2            TEXT,
+  modifier_3            TEXT,
+  modifier_4            TEXT,
+  description           TEXT,                         -- caregiver's transcription of the line description
+  units                 INTEGER     NOT NULL DEFAULT 1,
+  billed_amount         NUMERIC(12,2),                -- what the provider charged for this line
+
+  -- Provider identification at the line level. Most bills only carry this at
+  -- the document level, but Rule 1 (duplicate_same_day_same_code) cares about
+  -- (npi, service_date, cpt_code) so we cache it here.
+  provider_npi          TEXT,
+
+  -- Source provenance.
+  source                TEXT NOT NULL CHECK (source IN ('manual', 'ocr', 'imported')),
+  field_provenance      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Caregiver-verified flag. In v1 (manual), this defaults to true on insert.
+  -- In v1.1 (OCR), it defaults to false until the caregiver reviews and confirms.
+  verified_by_user      BOOLEAN     NOT NULL DEFAULT TRUE,
+
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS claims_line_items_doc_idx
+  ON public.claims_line_items(claim_document_id);
+CREATE INDEX IF NOT EXISTS claims_line_items_user_idx
+  ON public.claims_line_items(user_id);
+
+-- Engine rule lookup index: Rule 1 queries (provider_npi, service_date, cpt_code).
+CREATE INDEX IF NOT EXISTS claims_line_items_npi_date_cpt_idx
+  ON public.claims_line_items(provider_npi, service_date, cpt_code);
+
+ALTER TABLE public.claims_line_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own claims_line_items" ON public.claims_line_items
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE public.claims_line_items IS
+  'One row per line on a provider bill. Engine rules fire at the line level. user_id is denormalized from the parent claims_document for RLS performance.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 3. eob_documents
+--   One row per Explanation of Benefits.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.eob_documents (
+  id                          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  person_id                   UUID        NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  user_id                     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  payer_name                  TEXT,
+  payer_type                  TEXT CHECK (
+                                payer_type IS NULL OR
+                                payer_type IN (
+                                  'medicare', 'medicare_advantage', 'medicaid',
+                                  'commercial', 'self_pay', 'tricare', 'va', 'other'
+                                )
+                              ),
+  provider_name               TEXT,
+  provider_npi                TEXT,
+  service_date_start          DATE,
+  service_date_end            DATE,
+  eob_date                    DATE,                   -- date the EOB was issued
+  claim_number                TEXT,                   -- payer-side claim ID
+
+  -- Document-level totals. These are CMS standard EOB fields per
+  -- https://www.cms.gov/medical-bill-rights/help/guides/explanation-of-benefits
+  total_provider_charges      NUMERIC(12,2),          -- "Provider Charges"
+  total_allowed_amount        NUMERIC(12,2),          -- "Allowed Charges"
+  total_paid_by_insurer       NUMERIC(12,2),          -- "Paid by Insurer"
+  patient_responsibility      NUMERIC(12,2),          -- "What You Owe" / "Patient Balance"
+
+  -- Provider participation status with this payer. Critical for Rule 3
+  -- (medicare_balance_billing_participating_provider). Nullable: if unknown,
+  -- the rule will not fire (accuracy rule #6).
+  provider_participation_status  TEXT CHECK (
+                                provider_participation_status IS NULL OR
+                                provider_participation_status IN (
+                                  'participating', 'non_participating', 'opt_out', 'unknown'
+                                )
+                              ),
+
+  source                      TEXT NOT NULL CHECK (source IN ('manual', 'ocr', 'imported')),
+  field_provenance            JSONB       NOT NULL DEFAULT '{}'::jsonb,
+  notes                       TEXT,
+  original_storage_path       TEXT,
+
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS eob_documents_user_idx
+  ON public.eob_documents(user_id);
+CREATE INDEX IF NOT EXISTS eob_documents_person_idx
+  ON public.eob_documents(person_id);
+CREATE INDEX IF NOT EXISTS eob_documents_service_date_idx
+  ON public.eob_documents(service_date_start);
+
+ALTER TABLE public.eob_documents ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own eob_documents" ON public.eob_documents
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE public.eob_documents IS
+  'One row per Explanation of Benefits the caregiver has entered. Column language follows CMS Medical Bill Rights EOB guide.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 4. eob_line_items
+--   One row per service line on an EOB.
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.eob_line_items (
+  id                          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  eob_document_id             UUID        NOT NULL REFERENCES public.eob_documents(id) ON DELETE CASCADE,
+  user_id                     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  service_date                DATE,
+  cpt_code                    TEXT,
+  hcpcs_code                  TEXT,
+  modifier_1                  TEXT,
+  modifier_2                  TEXT,
+  modifier_3                  TEXT,
+  modifier_4                  TEXT,
+  description                 TEXT,
+  units                       INTEGER     NOT NULL DEFAULT 1,
+
+  -- The CMS EOB four-number breakdown.
+  provider_charge             NUMERIC(12,2),          -- billed by provider
+  allowed_amount              NUMERIC(12,2),          -- payer's allowed amount
+  paid_by_insurer             NUMERIC(12,2),          -- insurer's payment
+  patient_responsibility      NUMERIC(12,2),          -- the line-level "what you owe"
+
+  source                      TEXT NOT NULL CHECK (source IN ('manual', 'ocr', 'imported')),
+  field_provenance            JSONB       NOT NULL DEFAULT '{}'::jsonb,
+  verified_by_user            BOOLEAN     NOT NULL DEFAULT TRUE,
+
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS eob_line_items_doc_idx
+  ON public.eob_line_items(eob_document_id);
+CREATE INDEX IF NOT EXISTS eob_line_items_user_idx
+  ON public.eob_line_items(user_id);
+
+ALTER TABLE public.eob_line_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own eob_line_items" ON public.eob_line_items
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE public.eob_line_items IS
+  'One row per service line on an EOB. Engine matches these to claims_line_items by (cpt_code, service_date, provider_npi) for Rule 2 comparisons.';
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 5. updated_at trigger (one function, reused for all 4 tables)
+-- ─────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.set_billing_ingestion_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER claims_documents_set_updated_at
+  BEFORE UPDATE ON public.claims_documents
+  FOR EACH ROW EXECUTE FUNCTION public.set_billing_ingestion_updated_at();
+
+CREATE TRIGGER claims_line_items_set_updated_at
+  BEFORE UPDATE ON public.claims_line_items
+  FOR EACH ROW EXECUTE FUNCTION public.set_billing_ingestion_updated_at();
+
+CREATE TRIGGER eob_documents_set_updated_at
+  BEFORE UPDATE ON public.eob_documents
+  FOR EACH ROW EXECUTE FUNCTION public.set_billing_ingestion_updated_at();
+
+CREATE TRIGGER eob_line_items_set_updated_at
+  BEFORE UPDATE ON public.eob_line_items
+  FOR EACH ROW EXECUTE FUNCTION public.set_billing_ingestion_updated_at();


### PR DESCRIPTION
## PR 1 — Billing-error detection: claims + EOB ingestion schema

**Build plan:** `wellet_billing_error_detection_build_plan_v2.md` (PR 1 of 5)
**Accuracy rule:** `wellet_accuracy_audit_followup_2026-06-12.md`
**Sibling pattern:** `20260610120000_create_reimbursement_assessments.sql`

### What this PR does

Creates the four tables that PR 2 (manual-entry form) writes into and the engine (PR 3) reads from. Pure schema + RLS. No edge functions, no engine code, no caregiver-facing surface.

| Table | Purpose | Engine rule that reads it |
|---|---|---|
| `claims_documents` | One row per provider bill | All 3 v1 rules |
| `claims_line_items` | One row per billed service line | Rule 1 (duplicate same day same code) |
| `eob_documents` | One row per Explanation of Benefits | Rule 2, Rule 3 |
| `eob_line_items` | One row per service line on an EOB | Rule 2 (bill exceeds patient responsibility) |

Plus one shared `set_billing_ingestion_updated_at()` trigger function applied to all four tables.

### What this PR explicitly does NOT do

- No OCR plumbing — deferred to v1.1 (see "v1.1 prerequisite" below).
- No Supabase Storage bucket — only added when OCR ships.
- No engine code — that's PR 3.
- No UI — PR 2 ships the manual-entry form, PR 4 ships the internal admin surface, PR 5 ships the caregiver-facing surface.

### v1.1 prerequisite (logged, not blocking this PR)

OCR ingestion (parsing uploaded bills/EOBs) is held until Microsoft BAA coverage for Azure Document Intelligence is confirmed for the Wellet subscription. The same BAA question applies to the existing Azure OpenAI endpoint that already handles PHI — Betsy is running that down as a separate workstream, not as part of this PR.

The schema already accommodates OCR without future migration changes:
- `source` enum on all 4 tables accepts `'ocr'`
- `original_storage_path` column is nullable on `claims_documents` and `eob_documents`
- `verified_by_user` column defaults to `TRUE` for v1 (manual) and will default to `FALSE` for OCR rows pending caregiver review

### Design decisions

**1. `user_id` denormalized on line-item tables.**
Both `claims_line_items` and `eob_line_items` carry a `user_id` FK alongside the parent-document FK. This is for RLS performance — every line-item query filters by `auth.uid() = user_id` directly rather than joining to the parent. Matches the pattern in `reimbursement_assessments`.

**2. Per-field provenance via JSONB, not normalized.**
`field_provenance` is a JSONB map like `{"provider_npi": "manual", "service_date_start": "manual"}`. Matches `reimbursement_assessments.input_provenance`. Lets the UI render "you entered this" vs "we read this from the document" without a separate audit table.

**3. Nullable everywhere the rule can fall back.**
Per accuracy rule #6 ("mark gaps as `NEEDS VERIFIED SOURCE`"), every column the engine reads is nullable. If a field is missing, the rule does not fire. We never infer missing values.

**4. `payer_type` CHECK constraint instead of an enum type.**
Postgres ENUM types are hard to migrate. A CHECK constraint with an allowed-values list gives us the same validation with simpler future ALTERs.

**5. `provider_participation_status` on `eob_documents`, not on `claims_documents`.**
Rule 3 needs to know if the provider has signed the Medicare participation agreement. That information lives on the EOB (the payer's record of the relationship), not on the provider's bill.

### Source citations in the schema itself

Inline comments in the migration cite:
- [CMS "How to read an Explanation of Benefits"](https://www.cms.gov/medical-bill-rights/help/guides/explanation-of-benefits) — drives the EOB document/line-item column names (Provider Charges, Allowed Amount, Paid by Insurer, Patient Responsibility)
- `wellet_billing_error_detection_build_plan_v2.md` — sequence and rule scope
- `wellet_accuracy_audit_followup_2026-06-12.md` — accuracy posture

### Testing notes

This PR is schema-only. Testing is:
1. `supabase db reset` against a local branch — migration applies clean
2. RLS smoke test: as user A, insert + select — works; as user A, select user B's row — returns nothing

Engine fixtures (positive + negative cases for each of the 3 rules) ship with PR 3.

### Gate reminder

Per `wellet_billing_error_detection_build_plan_v2.md`, no rule reaches a caregiver until:
1. The rule-PR description carries source URL, source section, last_verified date, plain-language claim, and one-sentence explanation
2. Written sign-off from an outside reviewer (Betsy is sourcing a SHIP counselor — see `wellet_ship_reviewer_onepager.md`)
3. Betsy's explicit `active=true` flip per rule

This PR does not seed any rules. The `billing_rules` table itself lands in PR 3.

— Mabel
