### PR TITLE
compliance: Path A — align code claims to published 'no BAA, not covered entity' posture

### DIFF
--- a/guided-demo.js
+++ b/guided-demo.js
@@ -276,7 +276,7 @@ if (new URLSearchParams(window.location.search).get('demo') === 'guided') {
       + '  <span style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.15);border-radius:20px;padding:6px 14px;font-size:12px;color:rgba(255,255,255,0.7);">EHR integration</span>'
       + '  <span style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.15);border-radius:20px;padding:6px 14px;font-size:12px;color:rgba(255,255,255,0.7);">Wearable rhythm</span>'
       + '  <span style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.15);border-radius:20px;padding:6px 14px;font-size:12px;color:rgba(255,255,255,0.7);">CareSignals</span>'
-      + '  <span style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.15);border-radius:20px;padding:6px 14px;font-size:12px;color:rgba(255,255,255,0.7);">HIPAA compliant</span>'
+      + '  <span style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.15);border-radius:20px;padding:6px 14px;font-size:12px;color:rgba(255,255,255,0.7);">Personal Health Record</span>'
       + '</div>';
     document.body.appendChild(ec);
   }

--- a/supabase/functions/_shared/azureOpenAI.ts
+++ b/supabase/functions/_shared/azureOpenAI.ts
@@ -3,9 +3,16 @@
 // Wellet AI vendor adapter.
 //
 // Single choke point for every PHI-touching AI call in the project.
+//
+// Compliance posture (see wellet-privacy-policy.md §1 and §4): Wellet is not
+// a HIPAA covered entity, and we have not signed a BAA with any AI vendor.
+// We route PHI-marked calls only to vendors that offer a BAA we could sign
+// in the future, so this code stays compatible with a later compliance shift
+// without rewiring call sites. The guardrails below enforce that posture.
+//
 // Vendor is selected by the WELLET_AI_VENDOR env var:
-//   - "azure"         → Azure OpenAI Service (BAA-covered, default for PHI)
-//   - "openai_direct" → OpenAI direct API (legacy, no-BAA — emergency escape hatch only)
+//   - "azure"         → Azure OpenAI Service (BAA-eligible, default for PHI)
+//   - "openai_direct" → OpenAI direct API (legacy — emergency escape hatch only)
 //   - "sonar"         → Perplexity Sonar (NON-PHI ONLY — adapter will throw if called for PHI paths)
 //   - "bedrock"       → AWS Bedrock Claude (Phase 2, not yet implemented)
 //
@@ -87,13 +94,15 @@ function vendor(): Vendor {
   throw new Error(`[azureOpenAI] Unknown WELLET_AI_VENDOR: ${v}`);
 }
 
-// Hard guardrail: if the caller marked the request phi:true, only BAA-covered
-// vendors are allowed. Sonar is always blocked. openai_direct is blocked unless
-// WELLET_ALLOW_OPENAI_DIRECT_PHI=true is set (emergency override only).
+// Hard guardrail: if the caller marked the request phi:true, only BAA-eligible
+// vendors are allowed (Azure OpenAI, Bedrock). Sonar is always blocked.
+// openai_direct is blocked unless WELLET_ALLOW_OPENAI_DIRECT_PHI=true is set
+// (emergency override only). Wellet does not currently hold a signed BAA with
+// any of these vendors — see file header for compliance posture.
 function assertVendorAllowedForPhi(v: Vendor, phi: boolean) {
   if (!phi) return;
   if (v === "sonar") {
-    throw new Error("[azureOpenAI] PHI call routed to Sonar — blocked. Sonar has no BAA.");
+    throw new Error("[azureOpenAI] PHI call routed to Sonar — blocked. Sonar is not a BAA-eligible vendor.");
   }
   if (v === "openai_direct" && Deno.env.get("WELLET_ALLOW_OPENAI_DIRECT_PHI") !== "true") {
     throw new Error(
@@ -101,7 +110,7 @@ function assertVendorAllowedForPhi(v: Vendor, phi: boolean) {
     );
   }
   if (v === "bedrock") {
-    // Bedrock is BAA-covered but the implementation isn't done.
+    // Bedrock is BAA-eligible but the implementation isn't done.
     throw new Error("[azureOpenAI] Bedrock vendor not yet implemented (Phase 2).");
   }
 }

--- a/supabase/functions/ask-wellet/index.ts
+++ b/supabase/functions/ask-wellet/index.ts
@@ -62,7 +62,7 @@ import { aiChat } from "../_shared/azureOpenAI.ts";
 // (../_shared/azureOpenAI.ts) instead of calling Perplexity directly. This
 // closes a real posture gap: the main "answer" path ships the loved one's
 // full clinical record into the prompt, which is PHI and must run on a
-// BAA-covered vendor (Azure OpenAI). The watch-mode path stays on Sonar by
+// BAA-eligible vendor (Azure OpenAI). The watch-mode path stays on Sonar by
 // setting phi:false — it only sees the loved one's first name, a UI chip,
 // and the caregiver's own free-text request. The adapter's phi guardrail
 // will throw if Sonar is ever attempted with phi:true.
@@ -1004,8 +1004,8 @@ ${context}${emptyContextGuard}`;
 
     // PHI path. The grounded systemPrompt above contains the loved one's full
     // clinical record. We mark phi:true so the adapter's assertVendorAllowedForPhi
-    // guardrail refuses to route this to Sonar or any non-BAA vendor — Azure
-    // OpenAI (BAA-covered) is the only allowed destination today.
+    // guardrail refuses to route this to Sonar or any non-BAA-eligible vendor —
+    // Azure OpenAI is the only allowed destination today.
     let answer = 'I could not generate an answer. Please try again.';
     let modelUsed: string | undefined = undefined;
     try {

--- a/supabase/functions/extract-wishes/index.ts
+++ b/supabase/functions/extract-wishes/index.ts
@@ -1,8 +1,8 @@
 // extract-wishes v1 — AI-surfaced directives & preferences from a loved one's record
 //
 // Reads everything available for one person (documents, visit notes, health_events,
-// Ask Wellet sessions, check_ins) and asks Azure OpenAI gpt-4o (PHI: true, BAA-covered)
-// to identify directives, preferences, and wishes that already live in the data.
+// Ask Wellet sessions, check_ins) and asks Azure OpenAI gpt-4o (PHI: true) to
+// identify directives, preferences, and wishes that already live in the data.
 // Writes each finding to public.wishes with status='suggested', a verbatim source
 // quote, and provenance. Caregiver confirms in the UI.
 //
@@ -295,7 +295,7 @@ Deno.serve(async (req: Request) => {
       ? contextBlock.slice(0, MAX_CONTEXT) + '\n[…truncated]'
       : contextBlock;
 
-    // Call Azure gpt-4o (BAA-covered).
+    // Call Azure gpt-4o.
     let raw = '';
     try {
       const result = await aiChat({


### PR DESCRIPTION
## Summary

Aligns code and demo claims with the **published privacy policy**, which states:

> "Wellet is not a 'covered entity' under HIPAA… Wellet does not currently have a Business Associate Agreement (BAA) with OpenAI."

The code was claiming the opposite (`BAA-covered`) in multiple places, and `guided-demo.js` had a `HIPAA compliant` chip. Both contradicted the policy and violated the wellet-coo skill's banned-words rule ("HIPAA compliant as a claim", banned).

This PR is **code-only**. It does not change behavior. It changes language to match what we have actually signed.

## Posture decision

Wellet is a consumer-direct Personal Health Record. The caregiver is the data subject (or their authorized agent). We are not a B2B vendor to a covered entity, so HIPAA does not directly apply to us. The published privacy policy was already correct. The code drifted ahead of legal reality.

Future-compatibility: kept `BAA-eligible` (not `BAA-covered`) in the Azure vendor comments. Azure OpenAI does offer a BAA — we just have not signed one. If/when we sign our first B2B/hospital deal (Path B trigger), we can flip language and execute the agreement without another code change.

## Changes

| File | Change |
|---|---|
| `supabase/functions/_shared/azureOpenAI.ts` | Header rewritten with explicit compliance-posture comment block. `BAA-covered` → `BAA-eligible` throughout. Guardrail and error messages updated. |
| `supabase/functions/ask-wellet/index.ts` | 2 spots: `BAA-covered` → `BAA-eligible` |
| `supabase/functions/extract-wishes/index.ts` | 2 spots: removed `BAA-covered` parenthetical from header + inline comment |
| `guided-demo.js` | Line 279: `HIPAA compliant` badge → `Personal Health Record` |

## Out of scope (tracked separately)

1. **Privacy policy diff** — `wellet-privacy-policy.md` still references "OpenAI" as the LLM vendor when we are actually on Azure OpenAI Service. Update is in `wellet_privacy_policy_path_a_diff.md` in the workspace and will land as a separate getwellet PR.
2. **Path B trigger** — when Wellet signs the first B2B/hospital deal, we kick off the full HIPAA program (BAAs with Azure + Supabase + any other PHI processors, vCISO, risk assessment, training, BAA inventory). Linear ticket forthcoming.
3. **Document Intelligence BAA** — provisioning is in PR #127 scope as a feature flag, OCR remains disabled until a BAA is signed.

## Verification

```
$ grep -rn "BAA-covered" supabase/ guided-demo.js
(no matches)

$ grep -rn "HIPAA compliant" supabase/ guided-demo.js
(no matches)
```

— Mabel
