### PR TITLE
fix(upload): raise .upload-overlay z-index above Connect screen

### DIFF
--- a/assets/wellet.css
+++ b/assets/wellet.css
@@ -444,7 +444,11 @@
   .add-person-btn:hover { border-color: var(--moss); color: var(--moss); background: var(--mint); }
 
   /* upload sheet */
-  .upload-overlay { display: none; position: fixed; inset: 0; background: rgba(44,42,38,0.45); z-index: 100; align-items: flex-end; justify-content: center; }
+  /* z-index 9500: must sit above .connect-data-screen (z-index: 9000) so the
+     Upload-a-record card on the Connect screen opens visibly. Confirmed bug
+     2026-06-13: the overlay was opening (display:flex applied) but rendering
+     beneath the Connect screen and looked like a dead tap. */
+  .upload-overlay { display: none; position: fixed; inset: 0; background: rgba(44,42,38,0.45); z-index: 9500; align-items: flex-end; justify-content: center; }
   .upload-overlay.show { display: flex; }
   .upload-sheet { background: white; border-radius: 20px 20px 0 0; padding: 0 0 40px; width: 100%; max-width: 768px; max-height: 90vh; overflow-y: auto; -webkit-overflow-scrolling: touch; }
   .upload-handle-row { padding: 16px 20px 0; display: flex; align-items: center; justify-content: space-between; position: sticky; top: 0; background: white; z-index: 2; border-radius: 20px 20px 0 0; }


### PR DESCRIPTION
## Bug

On a fresh /me signup, tapping the **Upload a record** card on the Connect screen does nothing visible. Reviewer-reported (Emma); reproduced today on production.

## Root cause

A z-index stacking conflict, not a JS bug:

```css
.connect-data-screen { z-index: 9000 }
.upload-overlay      { z-index: 100   }   /* below the Connect screen */
```

The overlay is actually opening on tap:

- `.show` class is added
- `getComputedStyle(...).display` becomes `flex`
- `role="dialog"` and `aria-modal="true"` are present in the accessibility tree
- The history state is pushed for back-button dismissal

It just renders beneath the Connect screen, so the tap looks dead.

## Fix

Raise `.upload-overlay` to `z-index: 9500` so it sits above the Connect screen.

## Verification

Repro:
1. Sign up fresh at https://mywellet.com/me as a self-mode user
2. Land on Connect screen
3. Tap **Upload a record**
4. With this fix: the upload sheet visibly slides up.

Pre-fix DOM evidence (today):
- `document.getElementById('upload-overlay').classList.toString()` → `"upload-overlay show"`
- `getComputedStyle(document.getElementById('upload-overlay')).display` → `"flex"`
- Visually: nothing.

## Notes

- Pre-existing JS path (`_goUploadFromVendorCard`, PR #115/#125) was correct. This is purely a stacking fix.
- No JS change. CSS-only diff.

— Mabel