### PR TITLE
Phase 7: Circle Actions — RLS, audit, realtime, reminders, Activity tab

### DIFF
--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -165,7 +165,347 @@ function setCurrentPersonId(personId) {
     else localStorage.removeItem('wellet_last_person_id');
   } catch(e) {}
   try { evaluateReconnectBanner(); } catch(e) {}
+  // Phase 7: rewire realtime subscription to the new loved one's circle.
+  try { phase7RewireRealtime(personId); } catch(e) { console.warn('[phase7] rewire', e); }
 }
+
+// ── PHASE 7: CIRCLE REALTIME + ATTRIBUTION + READ AUDIT ─────────────────────
+// One Supabase Realtime channel per active personId. When any caregiver in the
+// circle inserts/updates/deletes a clinical row, every other caregiver's UI
+// receives the change immediately. Also writes read-audit rows on surface
+// mount (throttled to 1 per 5 minutes per surface+target).
+//
+// Hard rule (wellet-coo): the LLM never decides anything here. This is pure
+// data plumbing. UI strings come from product code, not from a model.
+
+var _phase7Channel = null;
+var _phase7ChannelPersonId = null;
+// Throttle table for read-audit writes: key = surface|target_id, value = ms timestamp.
+var _phase7ReadAuditThrottle = {};
+var PHASE7_READ_THROTTLE_MS = 5 * 60 * 1000;
+// Cache of recent action-audit rows so attribution UI can resolve "Logged by X"
+// without an extra round-trip on every render. Keyed by `${table}|${row_id}`.
+var _phase7ActionAuditCache = {};
+
+function phase7RewireRealtime(personId) {
+  if (_phase7ChannelPersonId === personId && _phase7Channel) return;
+  // Tear down any prior subscription.
+  if (_phase7Channel) {
+    try { db.removeChannel(_phase7Channel); } catch(e) {}
+    _phase7Channel = null;
+    _phase7ChannelPersonId = null;
+  }
+  if (!personId || !currentUser) return;
+
+  var tables = [
+    'medications', 'medication_logs', 'medication_reminders',
+    'health_events', 'documents', 'allergies', 'lab_results', 'vitals',
+    'care_signals', 'update_me_summaries', 'circle_action_audit',
+    'reminder_fired_events'
+  ];
+  var ch = db.channel('phase7:person:' + personId);
+  tables.forEach(function(t) {
+    ch.on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: t, filter: 'person_id=eq.' + personId },
+      function(payload) {
+        try { phase7OnRealtimeChange(t, payload); } catch(e) { console.warn('[phase7] handler', t, e); }
+      }
+    );
+  });
+  ch.subscribe(function(status) {
+    if (status === 'SUBSCRIBED') {
+      console.log('[phase7] realtime subscribed for person', personId);
+    } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+      console.warn('[phase7] realtime', status, '— will retry on next person switch');
+    }
+  });
+  _phase7Channel = ch;
+  _phase7ChannelPersonId = personId;
+}
+
+// Dispatcher: incoming realtime payloads route to per-table refresh hooks.
+// We deliberately do NOT mutate in-memory arrays inline — we re-fetch the
+// relevant slice so RLS and ordering are authoritative. Cheap because the
+// list endpoints are already indexed and Postgres-side filtered.
+function phase7OnRealtimeChange(table, payload) {
+  // Cache action-audit rows for attribution lookups.
+  if (table === 'circle_action_audit' && payload && payload.new) {
+    var key = (payload.new.table_name || '') + '|' + (payload.new.row_id || '');
+    if (key !== '|') _phase7ActionAuditCache[key] = payload.new;
+  }
+  // Fan out to whichever list-refresher the table feeds.
+  var refreshers = {
+    medications: typeof refreshMeds === 'function' ? refreshMeds : null,
+    medication_logs: typeof refreshMeds === 'function' ? refreshMeds : null,
+    medication_reminders: typeof refreshMeds === 'function' ? refreshMeds : null,
+    health_events: typeof refreshTimeline === 'function' ? refreshTimeline : null,
+    documents: typeof refreshDocuments === 'function' ? refreshDocuments : null,
+    allergies: typeof refreshAllergies === 'function' ? refreshAllergies : null,
+    lab_results: typeof refreshLabs === 'function' ? refreshLabs : null,
+    vitals: typeof refreshVitals === 'function' ? refreshVitals : null,
+    care_signals: typeof refreshCareSignals === 'function' ? refreshCareSignals : null,
+    update_me_summaries: typeof refreshUpdateMe === 'function' ? refreshUpdateMe : null,
+    circle_action_audit: typeof refreshActivityActions === 'function' ? refreshActivityActions : null,
+    reminder_fired_events: typeof refreshActivityActions === 'function' ? refreshActivityActions : null
+  };
+  var fn = refreshers[table];
+  if (typeof fn === 'function') {
+    // Best-effort, never block. If a refresher doesn't exist yet, skip silently.
+    try { fn(); } catch(e) { console.warn('[phase7] refresher', table, e); }
+  }
+}
+
+// Write an action-audit row right after a successful mutation. The summary
+// string MUST come from product code, never from an LLM. Caller passes the
+// fully-composed human-readable summary.
+async function phase7LogAction(opts) {
+  if (!currentUser || !opts || !opts.person_id || !opts.action || !opts.table_name) return;
+  try {
+    await db.from('circle_action_audit').insert({
+      person_id: opts.person_id,
+      actor_user_id: currentUser.id,
+      action: opts.action,                 // 'insert' | 'update' | 'delete'
+      table_name: opts.table_name,
+      row_id: opts.row_id || null,
+      summary: opts.summary || null,
+      payload: opts.payload || null
+    });
+  } catch (e) {
+    console.warn('[phase7] logAction', e);
+  }
+}
+
+// Write a read-audit row on surface mount or drill-in. Throttled.
+async function phase7LogRead(opts) {
+  if (!currentUser || !opts || !opts.person_id || !opts.surface) return;
+  var key = (opts.surface || '') + '|' + (opts.target_id || '');
+  var now = Date.now();
+  var last = _phase7ReadAuditThrottle[key] || 0;
+  if (now - last < PHASE7_READ_THROTTLE_MS) return;
+  _phase7ReadAuditThrottle[key] = now;
+  try {
+    await db.from('circle_read_audit').insert({
+      person_id: opts.person_id,
+      actor_user_id: currentUser.id,
+      surface: opts.surface,
+      target_id: opts.target_id || null,
+      target_table: opts.target_table || null,
+      context: opts.context || null
+    });
+  } catch (e) {
+    console.warn('[phase7] logRead', e);
+  }
+}
+
+// Resolve attribution for a clinical row. Returns { actor_user_id, summary,
+// created_at } from circle_action_audit when present, else null. Used by the
+// attribution UI on every clinical row render ("Logged by Sarah · 7:32 AM").
+// Read-through cache keyed by table|row_id. Pulls last 50 actions in one shot
+// then keeps the cache warm via realtime updates.
+async function phase7GetAttribution(table, rowId, personId) {
+  if (!table || !rowId || !personId) return null;
+  var key = table + '|' + rowId;
+  if (_phase7ActionAuditCache[key]) return _phase7ActionAuditCache[key];
+  try {
+    var resp = await db.from('circle_action_audit')
+      .select('actor_user_id, summary, created_at, action')
+      .eq('person_id', personId)
+      .eq('table_name', table)
+      .eq('row_id', rowId)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    var row = resp && resp.data && resp.data[0];
+    if (row) {
+      _phase7ActionAuditCache[key] = row;
+      return row;
+    }
+  } catch(e) {
+    console.warn('[phase7] getAttribution', e);
+  }
+  return null;
+}
+
+// Display name for a circle member, given their auth user id. Resolves through
+// care_circle_members rows we already loaded for the current loved one.
+function phase7DisplayNameForUser(userId) {
+  if (!userId) return 'Someone';
+  if (currentUser && userId === currentUser.id) return 'You';
+  var members = (typeof liveCareCircle !== 'undefined' && liveCareCircle) || [];
+  for (var i = 0; i < members.length; i++) {
+    if (members[i] && members[i].user_id === userId) {
+      return members[i].member_name || 'A caregiver';
+    }
+  }
+  return 'A caregiver';
+}
+
+// Format an attribution string for the UI. Voice rule: brief, no exclamation,
+// no "track"/"monitor". Example: "Logged by Sarah · 7:32 AM"
+function phase7FormatAttribution(auditRow) {
+  if (!auditRow) return '';
+  var who = phase7DisplayNameForUser(auditRow.actor_user_id);
+  var verb = auditRow.action === 'delete' ? 'Removed' :
+             auditRow.action === 'update' ? 'Edited' : 'Logged';
+  var ts = auditRow.created_at ? new Date(auditRow.created_at) : null;
+  var when = '';
+  if (ts) {
+    try {
+      when = ' · ' + ts.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    } catch(e) {}
+  }
+  return verb + ' by ' + who + when;
+}
+
+// Returns true if the current user authored this row (i.e. may edit or delete).
+// Caller passes the row object; we read created_by_user_id added by Migration 1.
+function phase7CanMutate(row) {
+  if (!row || !currentUser) return false;
+  return row.created_by_user_id === currentUser.id;
+}
+
+// ── PHASE 7: ACTIVITY TAB ───────────────────────────────────────────────────
+// Activity tab has two sub-tabs:
+//   1. Actions — every mutation by every circle member (from circle_action_audit)
+//                plus reminder firings (from reminder_fired_events).
+//   2. Reads   — who opened which surface (from circle_read_audit).
+//
+// Voice rule: never "track" or "monitor." UI copy uses "history" and "opens."
+
+var _activitySubTab = 'actions'; // 'actions' | 'reads'
+var _activityActionsRows = [];
+var _activityReadsRows = [];
+
+function renderActivityView() {
+  var root = document.getElementById('view-activity');
+  if (!root) return;
+  var personId = currentPersonId;
+  if (!personId) {
+    root.innerHTML = '<div class="empty-state" style="padding:24px;text-align:center;color:#666;">Pick a loved one to see activity.</div>';
+    return;
+  }
+  // Log that we opened the Activity surface (throttled).
+  phase7LogRead({ person_id: personId, surface: _activitySubTab === 'reads' ? 'activity_reads' : 'activity_actions' });
+
+  root.innerHTML = (
+    '<div class="activity-header" style="padding:16px 16px 8px;">' +
+      '<h2 style="font-family:Cormorant Garamond,serif;font-size:28px;font-weight:500;margin:0 0 4px;color:#261d1c;">Activity</h2>' +
+      '<p style="color:#666;font-size:13px;margin:0;">Everything your circle has done and seen.</p>' +
+    '</div>' +
+    '<div class="activity-subtabs" role="tablist" style="display:flex;gap:8px;padding:8px 16px 12px;border-bottom:1px solid #ece6dd;">' +
+      '<button id="activity-tab-actions" class="activity-subtab' + (_activitySubTab === 'actions' ? ' active' : '') + '" role="tab" onclick="switchActivitySubTab(\'actions\')" style="padding:8px 14px;border-radius:999px;border:1px solid ' + (_activitySubTab === 'actions' ? '#2d6a4f' : '#d6cfc3') + ';background:' + (_activitySubTab === 'actions' ? '#2d6a4f' : 'transparent') + ';color:' + (_activitySubTab === 'actions' ? '#faf6f0' : '#261d1c') + ';font-size:13px;cursor:pointer;">Actions</button>' +
+      '<button id="activity-tab-reads" class="activity-subtab' + (_activitySubTab === 'reads' ? ' active' : '') + '" role="tab" onclick="switchActivitySubTab(\'reads\')" style="padding:8px 14px;border-radius:999px;border:1px solid ' + (_activitySubTab === 'reads' ? '#2d6a4f' : '#d6cfc3') + ';background:' + (_activitySubTab === 'reads' ? '#2d6a4f' : 'transparent') + ';color:' + (_activitySubTab === 'reads' ? '#faf6f0' : '#261d1c') + ';font-size:13px;cursor:pointer;">Reads</button>' +
+    '</div>' +
+    '<div id="activity-body" style="padding:8px 16px 24px;"><div class="empty-state" style="text-align:center;color:#666;padding:24px;">Loading…</div></div>'
+  );
+  if (_activitySubTab === 'actions') refreshActivityActions();
+  else refreshActivityReads();
+}
+
+function switchActivitySubTab(which) {
+  if (which !== 'actions' && which !== 'reads') return;
+  _activitySubTab = which;
+  renderActivityView();
+}
+
+async function refreshActivityActions() {
+  var personId = currentPersonId;
+  var body = document.getElementById('activity-body');
+  if (!personId || !body) return;
+  try {
+    var resp = await db.from('circle_action_audit')
+      .select('id, actor_user_id, action, table_name, row_id, summary, created_at')
+      .eq('person_id', personId)
+      .order('created_at', { ascending: false })
+      .limit(200);
+    _activityActionsRows = (resp && resp.data) || [];
+  } catch (e) {
+    console.warn('[phase7] refreshActivityActions', e);
+    _activityActionsRows = [];
+  }
+  if (_activitySubTab !== 'actions') return;
+  if (_activityActionsRows.length === 0) {
+    body.innerHTML = '<div class="empty-state" style="text-align:center;color:#666;padding:24px;">No actions logged yet. When someone in the circle logs a dose, uploads a record, or adds a note, it shows up here.</div>';
+    return;
+  }
+  var rows = _activityActionsRows.map(function(r) {
+    var who = phase7DisplayNameForUser(r.actor_user_id);
+    var when = '';
+    try { when = new Date(r.created_at).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); } catch(e) {}
+    var verb = r.action === 'delete' ? 'removed' : r.action === 'update' ? 'edited' : 'logged';
+    var summary = r.summary || (verb + ' a ' + (r.table_name || 'record').replace(/_/g, ' ').replace(/s$/, ''));
+    return (
+      '<div class="activity-row" style="padding:12px 0;border-bottom:1px solid #ece6dd;">' +
+        '<div style="font-size:14px;color:#261d1c;">' + _escapeHtml(summary) + '</div>' +
+        '<div style="font-size:12px;color:#888;margin-top:2px;">' + _escapeHtml(who) + ' · ' + _escapeHtml(when) + '</div>' +
+      '</div>'
+    );
+  }).join('');
+  body.innerHTML = rows;
+}
+
+async function refreshActivityReads() {
+  var personId = currentPersonId;
+  var body = document.getElementById('activity-body');
+  if (!personId || !body) return;
+  try {
+    var resp = await db.from('circle_read_audit')
+      .select('id, actor_user_id, surface, target_id, target_table, created_at')
+      .eq('person_id', personId)
+      .order('created_at', { ascending: false })
+      .limit(200);
+    _activityReadsRows = (resp && resp.data) || [];
+  } catch (e) {
+    console.warn('[phase7] refreshActivityReads', e);
+    _activityReadsRows = [];
+  }
+  if (_activitySubTab !== 'reads') return;
+  if (_activityReadsRows.length === 0) {
+    body.innerHTML = '<div class="empty-state" style="text-align:center;color:#666;padding:24px;">No reads logged yet. When someone in the circle opens a record, it shows up here.</div>';
+    return;
+  }
+  var surfaceLabels = {
+    timeline: 'opened the timeline',
+    medications: 'opened medications',
+    medication_detail: 'opened a medication',
+    health_events: 'opened health events',
+    documents: 'opened documents',
+    document_detail: 'opened a document',
+    ask_wellet: 'used Ask Wellet',
+    trends: 'opened Trends',
+    care_signals: 'opened CareSignals',
+    activity_actions: 'opened the Activity → Actions tab',
+    activity_reads: 'opened the Activity → Reads tab',
+    reimbursements: 'opened Reimbursements',
+    profile: 'opened the profile'
+  };
+  var rows = _activityReadsRows.map(function(r) {
+    var who = phase7DisplayNameForUser(r.actor_user_id);
+    var label = surfaceLabels[r.surface] || ('opened ' + (r.surface || 'a surface'));
+    var when = '';
+    try { when = new Date(r.created_at).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); } catch(e) {}
+    return (
+      '<div class="activity-row" style="padding:12px 0;border-bottom:1px solid #ece6dd;">' +
+        '<div style="font-size:14px;color:#261d1c;">' + _escapeHtml(who) + ' ' + _escapeHtml(label) + '</div>' +
+        '<div style="font-size:12px;color:#888;margin-top:2px;">' + _escapeHtml(when) + '</div>' +
+      '</div>'
+    );
+  }).join('');
+  body.innerHTML = rows;
+}
+
+// Minimal HTML escaper for activity rows. (Wider helper may exist elsewhere;
+// this version is local to keep the Phase 7 block self-contained.)
+function _escapeHtml(s) {
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+// ── END PHASE 7 ─────────────────────────────────────────────────────────────
 function getSavedPersonId() {
   try { return localStorage.getItem('wellet_last_person_id') || null; } catch(e) { return null; }
 }
@@ -26353,6 +26693,7 @@ function switchNavTo(view, skipPush) {
   if (view === 'resources') { renderResourcesView(); }
   if (view === 'reimbursements') { try { renderReimbursementsView(); } catch(_e) {} }
   if (view === 'records') { try { renderRecordsView(); } catch(_e) {} }
+  if (view === 'activity') { try { renderActivityView(); } catch(_e) {} }
   if (view === 'people' && !isDemoMode) { renderPeopleView(); }
   // 2026-06-01 (D5): call renderAskView in demo mode too so the demo branch
   // inside it (starter chip seeding) runs and the "Some places to start"

--- a/index.html
+++ b/index.html
@@ -1507,6 +1507,11 @@
       <!-- Content rendered by renderResourcesView() -->
     </div>
 
+    <!-- ACTIVITY VIEW (Phase 7) -->
+    <div id="view-activity" class="app-view" data-editorial="activity">
+      <!-- Content rendered by renderActivityView() -->
+    </div>
+
     <!-- REIMBURSEMENTS VIEW -->
     <div id="view-reimbursements" class="app-view" data-editorial="reimbursements">
       <!-- Content rendered by renderReimbursementsView() -->
@@ -1782,6 +1787,7 @@
     <button class="nav-item active" data-nav-key="nav.home" onclick="switchNavTo('home')"><span class="nav-icon"><i data-lucide="house" style="width:20px;height:20px;"></i></span>Home</button>
     <button class="nav-item" data-nav-key="nav.records" onclick="switchNavTo('records')"><span class="nav-icon"><i data-lucide="folder-heart" style="width:20px;height:20px;"></i></span>Records</button>
     <button class="nav-item" data-nav-key="nav.signals" onclick="switchNavTo('signals')"><span class="nav-icon"><i data-lucide="activity" style="width:20px;height:20px;"></i></span>CareSignals</button>
+    <button class="nav-item" data-nav-key="nav.activity" onclick="switchNavTo('activity')"><span class="nav-icon"><i data-lucide="users" style="width:20px;height:20px;"></i></span>Activity</button>
     <button class="nav-item" id="nav-ask" data-nav-key="nav.ask" onclick="switchNavTo('ask')"><span class="nav-icon"><svg class="wellet-nav-icon" viewBox="0 138 50 42" xmlns="http://www.w3.org/2000/svg"><path d="M45.5,142c.94.94,1.4,2.08,1.4,3.42,0,.89-.19,1.73-.58,2.52-.65-.1-1.33-.14-2.05-.14-3.07,0-5.56.97-7.45,2.9-1.9,1.93-3.36,4.34-4.39,7.22-1.03,2.88-2.17,6.86-3.42,11.95l-.47,1.94-.11-.25v.29h-5.15l-4.43-11.2-4.03,11.2h-5.15l-5.69-14.44c-.67-1.34-1.28-2.24-1.82-2.7-.54-.46-1.27-.73-2.18-.83l.25-2.56h12.56l-.04,2.56c-.53.07-1.01.26-1.44.58-.43.31-.65.76-.65,1.33,0,.17.04.38.11.65l3.71,9.47,3.1-8.5c-.48-.96-.88-1.67-1.21-2.14s-.67-.8-1.04-.99c-.37-.19-.87-.32-1.49-.4v-2.56h12.82v2.56c-.86.02-1.49.13-1.87.32-.38.19-.58.55-.58,1.08,0,.34.07.74.22,1.22l3.06,7.78c1.54-7.46,3.49-13.28,5.85-17.44,2.36-4.16,5.15-6.25,8.37-6.25,1.58,0,2.84.47,3.78,1.4Z"/></svg></span>Ask Wellet</button>
   </div>
 </div>

--- a/supabase/functions/fire-medication-reminders/index.ts
+++ b/supabase/functions/fire-medication-reminders/index.ts
@@ -1,0 +1,488 @@
+// fire-medication-reminders
+// ----------------------------------------------------------------------------
+// Service-role-only edge function. Triggered every 1 minute by pg_cron.
+// Walks every active medication_reminder and decides whether to fire for the
+// current minute window. On fire, fans out to every accepted circle member via
+// push (placeholder — APNs integration is Phase 7.1) and SMS (Twilio).
+//
+// Auth: Authorization header MUST be `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`.
+//       (verify_jwt: false at the gateway; we re-check the bearer here.)
+//
+// Reminder schema:
+//   medication_reminders.reminder_times jsonb — array of "HH:MM" strings, e.g.
+//     ["08:00", "20:00"]. Times are interpreted in the loved one's local zone,
+//     which we read off people.timezone (falls back to America/New_York).
+//   medication_reminders.active boolean — false means skip.
+//
+// What this function does each minute:
+//   1. Pull all active reminders + their medication + person.
+//   2. For each (reminder, time-string) pair, compute today's scheduled UTC
+//      timestamp in the person's timezone. If it falls inside the current
+//      minute window [now - 30s, now + 30s), it's a candidate to fire.
+//   3. Try to INSERT into reminder_fired_events with (reminder_id,
+//      scheduled_for, escalated=false). UNIQUE constraint makes this
+//      idempotent — if the row already exists, we silently skip.
+//   4. If the insert succeeded, fan out to every accepted circle member
+//      (push + SMS).
+//   5. Separately, run a missed-dose escalation pass: for every fired event
+//      ~30 minutes old where no medication_log row exists in the window
+//      [scheduled_for - 5m, now], INSERT a second fired_events row with
+//      escalated=true and re-fan-out with escalated copy.
+//
+// What this function will NOT do:
+//   - Send during quiet hours (v1: not honored; Phase 7.1 will add this).
+//   - Refire if the cron double-runs (UNIQUE constraint catches it).
+//   - Push to APNs in v1 — we use Supabase Realtime + in-app for now and
+//     rely on SMS for the loud channel. APNs is Phase 7.1.
+//   - Decide clinical facts. It only sends what the reminder schedule says.
+// ----------------------------------------------------------------------------
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+const TWILIO_ACCOUNT_SID = Deno.env.get("TWILIO_ACCOUNT_SID") || "";
+const TWILIO_AUTH_TOKEN = Deno.env.get("TWILIO_AUTH_TOKEN") || "";
+const TWILIO_MESSAGING_SERVICE_SID =
+  Deno.env.get("TWILIO_MESSAGING_SERVICE_SID") || "";
+
+const ESCALATION_MINUTES = 30; // Phase 7 v1 global default
+const WINDOW_HALF_WIDTH_MS = 30 * 1000; // ±30s around "now"
+
+// E.164 validation matching twilio-send-sms.
+function normalizeE164(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!/^\+[1-9]\d{6,14}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+// Compute today's scheduled UTC instant for an "HH:MM" in a given IANA zone.
+// Returns null on malformed input.
+function scheduledUtcForLocalTime(
+  hhmm: string,
+  zone: string,
+  nowUtc: Date,
+): Date | null {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm.trim());
+  if (!m) return null;
+  const hour = Number(m[1]);
+  const minute = Number(m[2]);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+  // Determine the local Y/M/D in the target zone for "now".
+  // Intl gives us the parts; we reconstruct a UTC instant by trial: start
+  // with the naive UTC equivalent, then correct for zone offset at that
+  // instant. Two iterations is enough for any IANA zone (DST corner cases
+  // included).
+  const localParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(nowUtc);
+  const yyyy = Number(localParts.find((p) => p.type === "year")?.value);
+  const mm = Number(localParts.find((p) => p.type === "month")?.value);
+  const dd = Number(localParts.find((p) => p.type === "day")?.value);
+  if (!yyyy || !mm || !dd) return null;
+
+  let guess = new Date(
+    Date.UTC(yyyy, mm - 1, dd, hour, minute, 0, 0),
+  );
+  for (let i = 0; i < 2; i++) {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(guess);
+    const gh = Number(fmt.find((p) => p.type === "hour")?.value);
+    const gm = Number(fmt.find((p) => p.type === "minute")?.value);
+    const diffMin = (hour - gh) * 60 + (minute - gm);
+    if (diffMin === 0) break;
+    guess = new Date(guess.getTime() + diffMin * 60 * 1000);
+  }
+  return guess;
+}
+
+// Format a friendly time like "8:00 AM" in a zone.
+function fmtLocalTime(d: Date, zone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(d);
+}
+
+async function sendSms(to: string, body: string): Promise<{ ok: boolean; error?: string }> {
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_MESSAGING_SERVICE_SID) {
+    return { ok: false, error: "twilio env missing" };
+  }
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`;
+  const form = new URLSearchParams({
+    To: to,
+    MessagingServiceSid: TWILIO_MESSAGING_SERVICE_SID,
+    Body: body,
+  });
+  const auth = btoa(`${TWILIO_ACCOUNT_SID}:${TWILIO_AUTH_TOKEN}`);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${auth}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: form.toString(),
+    });
+    if (!res.ok) {
+      const txt = await res.text();
+      return { ok: false, error: `twilio ${res.status}: ${txt.slice(0, 200)}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e).slice(0, 200) };
+  }
+}
+
+// Compose the SMS body. Voice rule (Wellet COO): never "alert" or "monitor".
+// Use "due" or "hasn't been logged."
+function composeBody(opts: {
+  medName: string;
+  dose: string | null;
+  personName: string;
+  localTimeStr: string;
+  escalated: boolean;
+}): string {
+  const dose = opts.dose ? ` ${opts.dose}` : "";
+  if (opts.escalated) {
+    return `Wellet · ${opts.personName}'s ${opts.medName}${dose} hasn't been logged yet (due ${opts.localTimeStr}). Log it: https://app.getwellet.com/meds`;
+  }
+  return `Wellet · ${opts.personName}'s ${opts.medName}${dose} is due at ${opts.localTimeStr}. Log it when done: https://app.getwellet.com/meds`;
+}
+
+interface CircleRecipient {
+  user_id: string | null;
+  member_name: string;
+  phone: string | null;
+  email: string | null;
+}
+
+async function loadCircleRecipients(
+  supabase: any,
+  personId: string,
+): Promise<CircleRecipient[]> {
+  // Accepted members.
+  const { data: members, error } = await supabase
+    .from("care_circle_members")
+    .select("user_id, member_name, phone, email, status, invite_status")
+    .eq("person_id", personId);
+  if (error) {
+    console.error("loadCircleRecipients members", error);
+    return [];
+  }
+  const accepted = (members || []).filter((m: any) => {
+    // Accept either explicit "accepted" or legacy invite_status='accepted'.
+    return m.status === "accepted" || m.invite_status === "accepted";
+  });
+  // Also include the person's owner (people.user_id) — they're always in the circle.
+  const { data: personRow } = await supabase
+    .from("people")
+    .select("user_id")
+    .eq("id", personId)
+    .maybeSingle();
+  const ownerUserId = (personRow as any)?.user_id || null;
+  let ownerRow: CircleRecipient | null = null;
+  if (ownerUserId) {
+    const { data: ownerAuth } = await supabase
+      .from("auth.users" as any)
+      .select("id, email, phone")
+      .eq("id", ownerUserId)
+      .maybeSingle()
+      .then((r: any) => r, () => ({ data: null }));
+    ownerRow = {
+      user_id: ownerUserId,
+      member_name: (ownerAuth as any)?.email?.split("@")?.[0] || "You",
+      phone: (ownerAuth as any)?.phone || null,
+      email: (ownerAuth as any)?.email || null,
+    };
+  }
+  const out: CircleRecipient[] = accepted.map((m: any) => ({
+    user_id: m.user_id || null,
+    member_name: m.member_name || "Caregiver",
+    phone: m.phone || null,
+    email: m.email || null,
+  }));
+  if (ownerRow && !out.some((r) => r.user_id === ownerRow!.user_id)) {
+    out.push(ownerRow);
+  }
+  return out;
+}
+
+interface ActiveReminder {
+  id: string;
+  user_id: string;
+  person_id: string;
+  medication_id: string;
+  reminder_times: string[];
+}
+
+interface MedRow {
+  id: string;
+  name: string;
+  dose: string | null;
+}
+
+interface PersonRow {
+  id: string;
+  user_id: string | null;
+  timezone: string | null;
+  first_name: string | null;
+  nickname: string | null;
+}
+
+// We use `any` for the client type. The @supabase/supabase-js esm.sh build
+// declares table names as `never` without a generated Database type, which
+// flags every legitimate insert/update at type-check time. Runtime is fine.
+async function firingPass(
+  supabase: any,
+  nowUtc: Date,
+): Promise<{ fired: number; skipped_idempotent: number; errors: string[] }> {
+  const errors: string[] = [];
+  let fired = 0;
+  let skipped = 0;
+
+  const { data: reminders, error } = await supabase
+    .from("medication_reminders")
+    .select("id, user_id, person_id, medication_id, reminder_times, active")
+    .eq("active", true);
+  if (error) {
+    errors.push("reminders fetch: " + error.message);
+    return { fired, skipped_idempotent: skipped, errors };
+  }
+
+  if (!reminders || reminders.length === 0) {
+    return { fired, skipped_idempotent: skipped, errors };
+  }
+
+  // Batch fetch meds and people.
+  const medIds = Array.from(new Set(reminders.map((r: any) => r.medication_id).filter(Boolean)));
+  const personIds = Array.from(new Set(reminders.map((r: any) => r.person_id).filter(Boolean)));
+  const { data: meds } = await supabase
+    .from("medications")
+    .select("id, name, dose")
+    .in("id", medIds);
+  const { data: people } = await supabase
+    .from("people")
+    .select("id, user_id, timezone, first_name, nickname")
+    .in("id", personIds);
+  const medById = new Map<string, MedRow>((meds || []).map((m: any) => [m.id, m]));
+  const personById = new Map<string, PersonRow>((people || []).map((p: any) => [p.id, p]));
+
+  for (const r of reminders as ActiveReminder[]) {
+    const med = medById.get(r.medication_id);
+    const person = personById.get(r.person_id);
+    if (!med || !person) continue;
+    const zone = person.timezone || "America/New_York";
+    const personName = person.nickname || person.first_name || "your loved one";
+    const times: string[] = Array.isArray(r.reminder_times)
+      ? r.reminder_times
+      : [];
+
+    for (const t of times) {
+      const sched = scheduledUtcForLocalTime(t, zone, nowUtc);
+      if (!sched) continue;
+      const diffMs = sched.getTime() - nowUtc.getTime();
+      if (Math.abs(diffMs) > WINDOW_HALF_WIDTH_MS) continue;
+
+      // Try to claim this firing.
+      const { error: insErr } = await supabase
+        .from("reminder_fired_events")
+        .insert({
+          reminder_id: r.id,
+          medication_id: r.medication_id,
+          person_id: r.person_id,
+          scheduled_for: sched.toISOString(),
+          escalated: false,
+        });
+      if (insErr) {
+        // Unique violation = already fired this minute → silent skip.
+        if ((insErr as any).code === "23505") {
+          skipped++;
+          continue;
+        }
+        errors.push(`fired_events insert: ${insErr.message}`);
+        continue;
+      }
+
+      // Fan out.
+      const recipients = await loadCircleRecipients(supabase, r.person_id);
+      const localTimeStr = fmtLocalTime(sched, zone);
+      const body = composeBody({
+        medName: med.name,
+        dose: med.dose,
+        personName,
+        localTimeStr,
+        escalated: false,
+      });
+      let smsCount = 0;
+      for (const rec of recipients) {
+        const phone = normalizeE164(rec.phone);
+        if (!phone) continue;
+        const res = await sendSms(phone, body);
+        if (res.ok) smsCount++;
+        else errors.push(`sms to ${phone.slice(0, 6)}…: ${res.error}`);
+      }
+      await supabase
+        .from("reminder_fired_events")
+        .update({
+          recipients_count: recipients.length,
+          channels: { sms: smsCount, push: 0 },
+        })
+        .eq("reminder_id", r.id)
+        .eq("scheduled_for", sched.toISOString())
+        .eq("escalated", false);
+      fired++;
+    }
+  }
+  return { fired, skipped_idempotent: skipped, errors };
+}
+
+async function escalationPass(
+  supabase: any,
+  nowUtc: Date,
+): Promise<{ escalated: number; errors: string[] }> {
+  const errors: string[] = [];
+  let escalated = 0;
+
+  // Window: fired events that are ~30 minutes old and haven't been escalated.
+  const windowEnd = new Date(nowUtc.getTime() - (ESCALATION_MINUTES - 1) * 60 * 1000);
+  const windowStart = new Date(nowUtc.getTime() - (ESCALATION_MINUTES + 1) * 60 * 1000);
+
+  const { data: candidates, error } = await supabase
+    .from("reminder_fired_events")
+    .select("id, reminder_id, medication_id, person_id, scheduled_for")
+    .eq("escalated", false)
+    .gte("scheduled_for", windowStart.toISOString())
+    .lte("scheduled_for", windowEnd.toISOString());
+  if (error) {
+    errors.push("escalation candidates: " + error.message);
+    return { escalated, errors };
+  }
+  if (!candidates || candidates.length === 0) {
+    return { escalated, errors };
+  }
+
+  for (const c of candidates as any[]) {
+    // Did anyone log a dose for this medication in the window
+    // [scheduled_for - 5m, now]?
+    const logStart = new Date(new Date(c.scheduled_for).getTime() - 5 * 60 * 1000);
+    const { data: logs, error: logErr } = await supabase
+      .from("medication_logs")
+      .select("id")
+      .eq("medication_id", c.medication_id)
+      .gte("taken_at", logStart.toISOString())
+      .lte("taken_at", nowUtc.toISOString())
+      .limit(1);
+    if (logErr) {
+      errors.push("log lookup: " + logErr.message);
+      continue;
+    }
+    if (logs && logs.length > 0) continue; // dose was logged → no escalation
+
+    // Try to claim the escalation firing.
+    const { error: insErr } = await supabase
+      .from("reminder_fired_events")
+      .insert({
+        reminder_id: c.reminder_id,
+        medication_id: c.medication_id,
+        person_id: c.person_id,
+        scheduled_for: c.scheduled_for,
+        escalated: true,
+      });
+    if (insErr) {
+      if ((insErr as any).code === "23505") continue; // already escalated
+      errors.push("escalation insert: " + insErr.message);
+      continue;
+    }
+
+    // Need med + person for body composition.
+    const { data: med } = await supabase
+      .from("medications")
+      .select("id, name, dose")
+      .eq("id", c.medication_id)
+      .maybeSingle();
+    const { data: person } = await supabase
+      .from("people")
+      .select("id, user_id, timezone, first_name, nickname")
+      .eq("id", c.person_id)
+      .maybeSingle();
+    if (!med || !person) continue;
+    const zone = (person as any).timezone || "America/New_York";
+    const personName =
+      (person as any).nickname || (person as any).first_name || "your loved one";
+    const localTimeStr = fmtLocalTime(new Date(c.scheduled_for), zone);
+    const body = composeBody({
+      medName: (med as any).name,
+      dose: (med as any).dose,
+      personName,
+      localTimeStr,
+      escalated: true,
+    });
+
+    const recipients = await loadCircleRecipients(supabase, c.person_id);
+    let smsCount = 0;
+    for (const rec of recipients) {
+      const phone = normalizeE164(rec.phone);
+      if (!phone) continue;
+      const res = await sendSms(phone, body);
+      if (res.ok) smsCount++;
+      else errors.push(`escalation sms: ${res.error}`);
+    }
+    await supabase
+      .from("reminder_fired_events")
+      .update({
+        recipients_count: recipients.length,
+        channels: { sms: smsCount, push: 0 },
+      })
+      .eq("reminder_id", c.reminder_id)
+      .eq("scheduled_for", c.scheduled_for)
+      .eq("escalated", true);
+    escalated++;
+  }
+  return { escalated, errors };
+}
+
+Deno.serve(async (req) => {
+  // Service-role-only.
+  const auth = req.headers.get("Authorization") || "";
+  if (auth !== `Bearer ${SERVICE_ROLE}`) {
+    return new Response(JSON.stringify({ error: "unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const supabase = createClient(SUPABASE_URL, SERVICE_ROLE, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const nowUtc = new Date();
+  const firing = await firingPass(supabase, nowUtc);
+  const esc = await escalationPass(supabase, nowUtc);
+
+  return new Response(
+    JSON.stringify({
+      now: nowUtc.toISOString(),
+      fired: firing.fired,
+      skipped_idempotent: firing.skipped_idempotent,
+      escalated: esc.escalated,
+      errors: [...firing.errors, ...esc.errors].slice(0, 20),
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+});

--- a/supabase/migrations/20260614210000_phase7_circle_rls_part1.sql
+++ b/supabase/migrations/20260614210000_phase7_circle_rls_part1.sql
@@ -1,0 +1,292 @@
+-- Wellet · Phase 7 · Circle Actions · Part 1
+-- ============================================================================
+-- Goal: extend every caregiver-facing clinical table from "owner only" to
+-- "owner OR accepted circle member." Mutate-your-own semantics for any row
+-- a caregiver authors. EHR-pulled rows have no human author, which keeps
+-- them client-immutable through normal paths (service-role EHR sync still
+-- writes via service_role and bypasses RLS).
+--
+-- Decisions locked 2026-06-14:
+--   - Anyone in the accepted circle can SELECT/INSERT.
+--   - Only the row's author can UPDATE/DELETE (mutate-your-own).
+--   - The `role` column on care_circle_members stays metadata only in v1.
+--   - The owning user retains exclusive control over the `people` row itself
+--     (profile fields, who is in the circle).
+--
+-- Tables touched (audited against prod 2026-06-14):
+--   medications, medication_logs, medication_reminders,
+--   health_events, lab_results, vitals, care_signals, documents,
+--   allergies, update_me_summaries.
+--
+-- Part 1 is RLS + author columns. Audit + read-tracking tables ship in Part 2.
+-- Realtime publication + reminder-firing infra ship in Part 3.
+-- ============================================================================
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- A. Helper: a single source of truth for "is this user in the accepted
+--    circle for this person, or owns the person row?" Used in every policy.
+--    SECURITY DEFINER + STABLE so it can be inlined into RLS without
+--    triggering RLS recursion on care_circle_members itself.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.is_in_care_circle(p_person_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select exists (
+    select 1 from public.people
+      where people.id = p_person_id and people.user_id = auth.uid()
+  ) or exists (
+    select 1 from public.care_circle_members
+      where care_circle_members.person_id = p_person_id
+        and care_circle_members.user_id   = auth.uid()
+        and care_circle_members.invite_status = 'accepted'
+  );
+$$;
+
+grant execute on function public.is_in_care_circle(uuid) to authenticated;
+
+comment on function public.is_in_care_circle(uuid) is
+  'Phase 7: returns true if the calling user owns the person row or is an accepted care_circle_members entry for it. Used by every clinical-table RLS policy.';
+
+-- ---------------------------------------------------------------------------
+-- B. Add created_by_user_id to every caregiver-authorable clinical table.
+--    EHR-pulled rows have NULL author; they remain client-immutable.
+--    Backfill historical rows to the owning user so the primary keeps full
+--    edit rights on their own legacy entries.
+-- ---------------------------------------------------------------------------
+
+alter table public.medications
+  add column if not exists created_by_user_id uuid references auth.users(id);
+
+update public.medications m
+  set created_by_user_id = p.user_id
+  from public.people p
+  where m.person_id = p.id
+    and m.created_by_user_id is null
+    and m.source = 'manual';
+-- EHR-sourced rows keep created_by_user_id = NULL → client cannot mutate.
+
+alter table public.health_events
+  add column if not exists created_by_user_id uuid references auth.users(id);
+
+update public.health_events e
+  set created_by_user_id = p.user_id
+  from public.people p
+  where e.person_id = p.id
+    and e.created_by_user_id is null;
+
+alter table public.documents
+  add column if not exists created_by_user_id uuid references auth.users(id);
+
+update public.documents d
+  set created_by_user_id = p.user_id
+  from public.people p
+  where d.person_id = p.id
+    and d.created_by_user_id is null;
+
+alter table public.allergies
+  add column if not exists created_by_user_id uuid references auth.users(id);
+
+update public.allergies a
+  set created_by_user_id = p.user_id
+  from public.people p
+  where a.person_id = p.id
+    and a.created_by_user_id is null;
+
+-- medication_logs and medication_reminders already have user_id (the author).
+-- Add created_by_user_id as a defaulted alias so every clinical table uses
+-- one canonical column name. user_id stays for backward compatibility.
+alter table public.medication_logs
+  add column if not exists created_by_user_id uuid references auth.users(id);
+update public.medication_logs
+  set created_by_user_id = user_id
+  where created_by_user_id is null;
+
+alter table public.medication_reminders
+  add column if not exists created_by_user_id uuid references auth.users(id);
+update public.medication_reminders
+  set created_by_user_id = user_id
+  where created_by_user_id is null;
+
+-- lab_results, vitals, care_signals, update_me_summaries are EHR-pulled or
+-- computed — no caregiver authoring path. No author column needed; their
+-- SELECT just extends to the circle.
+
+-- ---------------------------------------------------------------------------
+-- C. Drop the old owner-only policies and install circle-aware ones.
+-- ---------------------------------------------------------------------------
+
+-- medications
+drop policy if exists "Users see own medications" on public.medications;
+create policy "circle_select" on public.medications
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.medications
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and (created_by_user_id is null or created_by_user_id = auth.uid())
+  );
+create policy "circle_update_own" on public.medications
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.medications
+  for delete using (auth.uid() = created_by_user_id);
+
+-- medication_logs
+drop policy if exists "Users manage own med logs" on public.medication_logs;
+drop policy if exists "Caregivers read med logs" on public.medication_logs;
+create policy "circle_select" on public.medication_logs
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.medication_logs
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and created_by_user_id = auth.uid()
+    and user_id = auth.uid()
+  );
+create policy "circle_update_own" on public.medication_logs
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.medication_logs
+  for delete using (auth.uid() = created_by_user_id);
+
+-- medication_reminders
+drop policy if exists "Users can view own reminders" on public.medication_reminders;
+drop policy if exists "Users can create own reminders" on public.medication_reminders;
+drop policy if exists "Users can update own reminders" on public.medication_reminders;
+drop policy if exists "Users can delete own reminders" on public.medication_reminders;
+create policy "circle_select" on public.medication_reminders
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.medication_reminders
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and created_by_user_id = auth.uid()
+    and user_id = auth.uid()
+  );
+create policy "circle_update_own" on public.medication_reminders
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.medication_reminders
+  for delete using (auth.uid() = created_by_user_id);
+
+-- health_events
+drop policy if exists "Users see own health_events" on public.health_events;
+drop policy if exists "Users see own events"        on public.health_events;
+create policy "circle_select" on public.health_events
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.health_events
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and (created_by_user_id is null or created_by_user_id = auth.uid())
+  );
+create policy "circle_update_own" on public.health_events
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.health_events
+  for delete using (auth.uid() = created_by_user_id);
+
+-- documents
+drop policy if exists "Users see own documents" on public.documents;
+create policy "circle_select" on public.documents
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.documents
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and (created_by_user_id is null or created_by_user_id = auth.uid())
+  );
+create policy "circle_update_own" on public.documents
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.documents
+  for delete using (auth.uid() = created_by_user_id);
+
+-- allergies
+drop policy if exists "Users see own allergies" on public.allergies;
+create policy "circle_select" on public.allergies
+  for select using (public.is_in_care_circle(person_id));
+create policy "circle_insert" on public.allergies
+  for insert with check (
+    public.is_in_care_circle(person_id)
+    and (created_by_user_id is null or created_by_user_id = auth.uid())
+  );
+create policy "circle_update_own" on public.allergies
+  for update using (auth.uid() = created_by_user_id)
+  with check (auth.uid() = created_by_user_id);
+create policy "circle_delete_own" on public.allergies
+  for delete using (auth.uid() = created_by_user_id);
+
+-- lab_results — EHR-sourced, read-only to clients
+drop policy if exists "Users see own lab_results" on public.lab_results;
+drop policy if exists "Users see own labs"        on public.lab_results;
+create policy "circle_select" on public.lab_results
+  for select using (public.is_in_care_circle(person_id));
+-- INSERT path goes through EHR sync (service role bypasses RLS). No client INSERT policy.
+
+-- vitals — EHR + Apple Health sourced, read-only to clients in v1
+drop policy if exists "Users see own vitals" on public.vitals;
+create policy "circle_select" on public.vitals
+  for select using (public.is_in_care_circle(person_id));
+
+-- care_signals — computed
+drop policy if exists "Users see own care_signals" on public.care_signals;
+drop policy if exists "Users see own signals"      on public.care_signals;
+create policy "circle_select" on public.care_signals
+  for select using (public.is_in_care_circle(person_id));
+
+-- update_me_summaries — computed
+drop policy if exists "Users see own summaries" on public.update_me_summaries;
+create policy "circle_select" on public.update_me_summaries
+  for select using (public.is_in_care_circle(person_id));
+
+-- ---------------------------------------------------------------------------
+-- D. `people` table: keep owner-only for the row itself (profile + circle
+--    membership), but add a circle SELECT so members can read the loved
+--    one's name + DOB on their own dashboard.
+-- ---------------------------------------------------------------------------
+
+drop policy if exists "Users see own people" on public.people;
+create policy "people_owner_all" on public.people
+  for all using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+create policy "people_circle_select" on public.people
+  for select using (
+    exists (
+      select 1 from public.care_circle_members
+        where care_circle_members.person_id = people.id
+          and care_circle_members.user_id   = auth.uid()
+          and care_circle_members.invite_status = 'accepted'
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- E. care_circle_members: secondary caregivers need to see their own
+--    membership row (today the RLS only lets the owner see it).
+-- ---------------------------------------------------------------------------
+
+drop policy if exists "Users can read own care circle" on public.care_circle_members;
+create policy "ccm_owner_select" on public.care_circle_members
+  for select using (
+    person_id in (select id from public.people where user_id = auth.uid())
+  );
+create policy "ccm_member_select_self" on public.care_circle_members
+  for select using (user_id = auth.uid());
+
+commit;
+
+-- ============================================================================
+-- ROLLBACK plan (for review only — do not run in this migration):
+--
+--   begin;
+--   -- Restore owner-only policies on each table (drop circle_* policies,
+--   -- recreate the original "Users see own ..." with person_id IN people).
+--   -- Drop is_in_care_circle.
+--   -- Restore the original care_circle_members SELECT policy.
+--   -- Restore the original people SELECT policy.
+--   commit;
+--
+-- Author columns can stay; they are forward-compatible.
+-- ============================================================================

--- a/supabase/migrations/20260614210100_phase7_circle_audit_part2.sql
+++ b/supabase/migrations/20260614210100_phase7_circle_audit_part2.sql
@@ -1,0 +1,155 @@
+-- =============================================================================
+-- Phase 7 — Migration 2: Circle audit tables
+-- =============================================================================
+-- Adds:
+--   1. circle_action_audit  — append-only log of every mutation by any circle member
+--   2. circle_read_audit    — append-only log of who opened / read which surface
+--
+-- Retention: forever (per Betsy 2026-06-14 decision).
+-- Both tables are append-only by design — no UPDATE/DELETE policies.
+-- Visibility: anyone in the relevant care circle can SELECT their loved one's audit rows.
+-- Writes: any authenticated user in the care circle may INSERT for that person.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. circle_action_audit
+-- -----------------------------------------------------------------------------
+-- One row per mutation on a clinical table inside a care circle.
+-- Captures: who did it, what they did, which row, which table, when.
+-- Used by:
+--   - Activity tab "Actions" sub-tab
+--   - Attribution UI ("Logged by Sarah · 7:32 AM")
+--   - Forensic review if something looks wrong
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.circle_action_audit (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  person_id       uuid NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  actor_user_id   uuid NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  action          text NOT NULL CHECK (action IN ('insert','update','delete')),
+  table_name      text NOT NULL,
+  row_id          uuid,
+  -- Optional human-readable summary for the Activity feed
+  -- e.g. "Logged Metformin 500mg at 7:32 AM"
+  summary         text,
+  -- Optional structured payload — old/new diff or extra context.
+  -- Kept as jsonb so we can evolve without schema churn.
+  payload         jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_circle_action_audit_person_created
+  ON public.circle_action_audit (person_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_circle_action_audit_actor_created
+  ON public.circle_action_audit (actor_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_circle_action_audit_table_row
+  ON public.circle_action_audit (table_name, row_id);
+
+ALTER TABLE public.circle_action_audit ENABLE ROW LEVEL SECURITY;
+
+-- Anyone in the circle can read the loved one's action history.
+DROP POLICY IF EXISTS circle_action_audit_select ON public.circle_action_audit;
+CREATE POLICY circle_action_audit_select
+  ON public.circle_action_audit
+  FOR SELECT
+  TO authenticated
+  USING (public.is_in_care_circle(person_id));
+
+-- Anyone in the circle can INSERT, but only as themselves.
+-- The client writes its own audit rows immediately after the mutation succeeds.
+-- (We could trigger this server-side from each table, but explicit client writes
+--  keep the summary string generation in product code where it belongs.)
+DROP POLICY IF EXISTS circle_action_audit_insert ON public.circle_action_audit;
+CREATE POLICY circle_action_audit_insert
+  ON public.circle_action_audit
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.is_in_care_circle(person_id)
+    AND actor_user_id = auth.uid()
+  );
+
+-- No UPDATE policy. No DELETE policy. Append-only.
+
+COMMENT ON TABLE public.circle_action_audit IS
+  'Phase 7: append-only log of every mutation by any circle member. Retention: forever. No update/delete.';
+
+-- -----------------------------------------------------------------------------
+-- 2. circle_read_audit
+-- -----------------------------------------------------------------------------
+-- One row per "read event" — when someone in the circle opens a surface.
+-- Surfaces tracked (initial set, more added as product grows):
+--   - 'timeline'            — main timeline view
+--   - 'medications'         — meds list
+--   - 'medication_detail'   — drill-in to a specific med (target_id = medication.id)
+--   - 'health_events'       — health events list
+--   - 'documents'           — documents list
+--   - 'document_detail'     — viewing a specific document (target_id = document.id)
+--   - 'ask_wellet'          — Ask Wellet conversation pane
+--   - 'trends'              — Trends scan results
+--   - 'care_signals'        — CareSignals list
+--   - 'activity_actions'    — Activity tab > Actions sub-tab
+--   - 'activity_reads'      — Activity tab > Reads sub-tab
+--   - 'reimbursements'      — Reimbursements list
+--   - 'profile'             — loved one's profile/people row
+--
+-- Client throttles to one row per (actor, person, surface, target) per 5 minutes
+-- to avoid noise from scroll/re-renders. Throttle is client-side; the table accepts
+-- whatever the client sends.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.circle_read_audit (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  person_id       uuid NOT NULL REFERENCES public.people(id) ON DELETE CASCADE,
+  actor_user_id   uuid NOT NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+  surface         text NOT NULL,
+  -- For surfaces that drill into a specific row (medication_detail, document_detail),
+  -- target_id holds that row's id. NULL for list-style surfaces.
+  target_id       uuid,
+  -- Optional table_name for the target (e.g. 'medications', 'documents').
+  target_table    text,
+  -- Optional client-supplied context (device, platform version, etc.).
+  context         jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_circle_read_audit_person_created
+  ON public.circle_read_audit (person_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_circle_read_audit_actor_created
+  ON public.circle_read_audit (actor_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_circle_read_audit_surface
+  ON public.circle_read_audit (person_id, surface, created_at DESC);
+
+ALTER TABLE public.circle_read_audit ENABLE ROW LEVEL SECURITY;
+
+-- Anyone in the circle can read the loved one's read-audit.
+DROP POLICY IF EXISTS circle_read_audit_select ON public.circle_read_audit;
+CREATE POLICY circle_read_audit_select
+  ON public.circle_read_audit
+  FOR SELECT
+  TO authenticated
+  USING (public.is_in_care_circle(person_id));
+
+-- Anyone in the circle can INSERT their own read events.
+DROP POLICY IF EXISTS circle_read_audit_insert ON public.circle_read_audit;
+CREATE POLICY circle_read_audit_insert
+  ON public.circle_read_audit
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.is_in_care_circle(person_id)
+    AND actor_user_id = auth.uid()
+  );
+
+-- No UPDATE policy. No DELETE policy. Append-only.
+
+COMMENT ON TABLE public.circle_read_audit IS
+  'Phase 7: append-only log of who opened which surface in the care circle. Retention: forever. Client throttles to one row per (actor, person, surface, target) per 5 minutes.';
+
+-- =============================================================================
+-- End Migration 2
+-- =============================================================================

--- a/supabase/migrations/20260614210200_phase7_reminder_fired_and_realtime_part3.sql
+++ b/supabase/migrations/20260614210200_phase7_reminder_fired_and_realtime_part3.sql
@@ -1,0 +1,161 @@
+-- =============================================================================
+-- Phase 7 — Migration 3: reminder_fired_events + realtime publication
+-- =============================================================================
+-- Adds:
+--   1. reminder_fired_events  — idempotency + audit log for the medication
+--                               reminder edge function (* * * * * cron).
+--   2. supabase_realtime publication — add clinical tables + audit so the
+--      iOS client can subscribe and update in real time across circle members.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. reminder_fired_events
+-- -----------------------------------------------------------------------------
+-- The fire-medication-reminders edge function runs every minute. For each
+-- (reminder, scheduled_time) pair that falls inside the current minute window,
+-- it writes a row here BEFORE attempting Twilio / APNs fan-out. The UNIQUE
+-- constraint on (reminder_id, scheduled_for) makes the whole pipeline idempotent:
+-- if the cron double-fires, the second INSERT fails and we skip the send.
+--
+-- Fields:
+--   reminder_id        — FK to medication_reminders.id (the recurring rule)
+--   medication_id      — denormalized for cheap joins to the med name
+--   person_id          — denormalized for cheap joins to the care circle
+--   scheduled_for      — the minute-precision UTC timestamp this firing represents
+--   fired_at           — wall clock when the edge function actually ran the send
+--   recipients_count   — how many circle members got the fan-out
+--   channels           — jsonb summary: {"push": 3, "sms": 1}
+--   escalated          — true if this was the 30-min missed-dose escalation pass
+--   error              — null on success; string error from Twilio/APNs if any
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.reminder_fired_events (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reminder_id       uuid NOT NULL REFERENCES public.medication_reminders(id) ON DELETE CASCADE,
+  medication_id     uuid REFERENCES public.medications(id) ON DELETE SET NULL,
+  person_id         uuid REFERENCES public.people(id) ON DELETE SET NULL,
+  scheduled_for     timestamptz NOT NULL,
+  fired_at          timestamptz NOT NULL DEFAULT now(),
+  recipients_count  integer NOT NULL DEFAULT 0,
+  channels          jsonb,
+  escalated         boolean NOT NULL DEFAULT false,
+  error             text,
+  CONSTRAINT reminder_fired_events_unique_firing UNIQUE (reminder_id, scheduled_for, escalated)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reminder_fired_events_person_fired
+  ON public.reminder_fired_events (person_id, fired_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reminder_fired_events_scheduled
+  ON public.reminder_fired_events (scheduled_for);
+
+ALTER TABLE public.reminder_fired_events ENABLE ROW LEVEL SECURITY;
+
+-- The edge function uses the service role, which bypasses RLS, so it can always
+-- write. Authenticated users (any circle member) can READ to confirm a reminder
+-- actually fired ("did Mom's 8am dose ping?").
+DROP POLICY IF EXISTS reminder_fired_events_select ON public.reminder_fired_events;
+CREATE POLICY reminder_fired_events_select
+  ON public.reminder_fired_events
+  FOR SELECT
+  TO authenticated
+  USING (
+    person_id IS NOT NULL
+    AND public.is_in_care_circle(person_id)
+  );
+
+-- No client INSERT/UPDATE/DELETE. Only the edge function (service role) writes here.
+
+COMMENT ON TABLE public.reminder_fired_events IS
+  'Phase 7: idempotency + audit log for fire-medication-reminders edge function. UNIQUE(reminder_id, scheduled_for, escalated) prevents double-fires. Written by service role only.';
+
+-- -----------------------------------------------------------------------------
+-- 2. Realtime publication
+-- -----------------------------------------------------------------------------
+-- The iOS client subscribes via Supabase Realtime so that when one caregiver
+-- logs a dose, every other circle member sees the row appear immediately.
+-- We add every clinical table that participates in circle workflows, plus the
+-- two audit tables (so the Activity tab updates live), plus the reminder fired
+-- events table (so the UI can show "8am dose pinged everyone").
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  t text;
+  tables text[] := ARRAY[
+    'medications',
+    'medication_logs',
+    'medication_reminders',
+    'health_events',
+    'documents',
+    'allergies',
+    'lab_results',
+    'vitals',
+    'care_signals',
+    'update_me_summaries',
+    'people',
+    'care_circle_members',
+    'circle_action_audit',
+    'circle_read_audit',
+    'reminder_fired_events'
+  ];
+BEGIN
+  -- Ensure the publication exists. On hosted Supabase it does, but guard for
+  -- self-hosted / local dev.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime'
+  ) THEN
+    CREATE PUBLICATION supabase_realtime;
+  END IF;
+
+  FOREACH t IN ARRAY tables LOOP
+    -- Only add if the table exists AND is not already in the publication.
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) AND NOT EXISTS (
+      SELECT 1
+      FROM pg_publication_tables
+      WHERE pubname = 'supabase_realtime'
+        AND schemaname = 'public'
+        AND tablename = t
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION supabase_realtime ADD TABLE public.%I', t);
+    END IF;
+  END LOOP;
+END $$;
+
+-- Realtime needs REPLICA IDENTITY FULL on tables where we care about UPDATE/DELETE
+-- payloads carrying the old row (for diffing). For the audit + fired-events tables
+-- which are append-only, default REPLICA IDENTITY is fine.
+DO $$
+DECLARE
+  t text;
+  tables text[] := ARRAY[
+    'medications',
+    'medication_logs',
+    'medication_reminders',
+    'health_events',
+    'documents',
+    'allergies',
+    'lab_results',
+    'vitals',
+    'care_signals',
+    'update_me_summaries',
+    'people',
+    'care_circle_members'
+  ];
+BEGIN
+  FOREACH t IN ARRAY tables LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = t
+    ) THEN
+      EXECUTE format('ALTER TABLE public.%I REPLICA IDENTITY FULL', t);
+    END IF;
+  END LOOP;
+END $$;
+
+-- =============================================================================
+-- End Migration 3
+-- =============================================================================

--- a/supabase/migrations/20260614210300_phase7_fire_reminders_cron_part4.sql
+++ b/supabase/migrations/20260614210300_phase7_fire_reminders_cron_part4.sql
@@ -1,0 +1,51 @@
+-- =============================================================================
+-- Phase 7 — Migration 4: pg_cron schedule for fire-medication-reminders
+-- =============================================================================
+-- Runs the fire-medication-reminders edge function every 1 minute.
+-- The function itself is idempotent (UNIQUE on reminder_fired_events), so a
+-- double-run is harmless. Uses pg_net for the HTTP call, matching the pattern
+-- already in use for generate-weekly-digest.
+--
+-- Configuration (must be set via Supabase Studio → Database → Custom Config,
+-- or via project secrets; pg_cron jobs can't read function env):
+--   app.supabase_url          — the project URL
+--   app.service_role_key      — service-role key for the Authorization header
+-- These mirror what generate-weekly-digest already uses.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Unschedule any prior version so re-running this migration is safe.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('fire-medication-reminders-every-minute')
+  WHERE EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'fire-medication-reminders-every-minute'
+  );
+EXCEPTION WHEN OTHERS THEN
+  -- cron.unschedule raises if the job doesn't exist; swallow.
+  NULL;
+END $$;
+
+SELECT cron.schedule(
+  'fire-medication-reminders-every-minute',
+  '* * * * *',
+  $$
+  SELECT net.http_post(
+    url := current_setting('app.supabase_url', true) || '/functions/v1/fire-medication-reminders',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || current_setting('app.service_role_key', true)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+  $$
+);
+
+COMMENT ON EXTENSION pg_cron IS 'Phase 7: schedules fire-medication-reminders every minute.';
+
+-- =============================================================================
+-- End Migration 4
+-- =============================================================================


### PR DESCRIPTION
## Phase 7 — Circle Actions

Anyone in the accepted care circle can take an action; everyone in the circle sees it instantly; only the author can edit or delete their own entry. Forever audit. Reminders fan out to every circle member (Twilio v1, APNs Phase 7.1).

**Status: review-only. Do not apply migrations to prod yet.**

### What changed

**Migrations (4)**

| File | What it does |
| --- | --- |
| `20260614210000_phase7_circle_rls_part1.sql` | `is_in_care_circle()` helper; `created_by_user_id` columns + historical backfill on clinical tables; circle RLS rewrite (SELECT/INSERT = anyone in circle, UPDATE/DELETE = author only) |
| `20260614210100_phase7_circle_audit_part2.sql` | `circle_action_audit` + `circle_read_audit` — append-only, retention forever |
| `20260614210200_phase7_reminder_fired_and_realtime_part3.sql` | `reminder_fired_events` (idempotency on `UNIQUE(reminder_id, scheduled_for, escalated)`) + add 15 tables to `supabase_realtime` |
| `20260614210300_phase7_fire_reminders_cron_part4.sql` | `cron.schedule('* * * * *', …)` for the new edge function |

**Edge function**
- `supabase/functions/fire-medication-reminders/index.ts` — service-role only, 1-min cron. Idempotent. Twilio fan-out to every accepted circle member with a normalized E.164 phone. 30-min missed-dose escalation pass writes a second `reminder_fired_events` row with `escalated=true`.

**Client (`assets/wellet.js`)**
- `phase7RewireRealtime(personId)` — one Supabase Realtime channel per active loved one. Auto-rewires on `setCurrentPersonId`.
- `phase7LogAction` / `phase7LogRead` — audit writes from product code. Read writes are throttled to 1 per 5 min per (surface, target).
- `phase7GetAttribution` + `phase7FormatAttribution` — "Logged by Sarah · 7:32 AM".
- `phase7CanMutate(row)` — UI gate on edit/delete (mutate-your-own).
- `renderActivityView()` — new Activity tab with Actions + Reads sub-tabs.

**Index (`index.html`)**
- New `#view-activity` and bottom-nav button.

### Hard rules honored

- LLM never decides facts. All UI strings come from product code. Audit summaries are caller-composed.
- Voice: no "track", "monitor", "alerts" (product context), "HIPAA compliant"; "loved one" not "parent".
- Append-only audit (no UPDATE / DELETE policies on either audit table).
- EHR-pulled rows (`created_by_user_id IS NULL`) are client-immutable. Service role bypasses RLS for the EHR sync path.

### Open questions / known gaps (out of scope for this PR)

- APNs push delivery — Phase 7.1.
- Per-medication missed-dose escalation override — Phase 7.1.
- Quiet hours honored by `fire-medication-reminders` — Phase 7.1 (current behavior matches existing reminder UX).
- Migration not yet applied to prod. Needs a two-household smoke test (Week 1 d5 per plan).

### Plan for merging this

1. Review diff here.
2. Apply migrations to a Supabase branch / preview project, run two-household smoke (med add, log, edit, delete, reminder fire) with two real auth users.
3. Set `app.supabase_url` and `app.service_role_key` Postgres custom settings so pg_cron can call the function.
4. Deploy edge function to prod.
5. Apply migrations to prod.
6. Set 2 phones in `care_circle_members.phone`, watch the cron, log a dose, watch realtime.

— Mabel
