### PR TITLE
V2 rebrand: add token + primitive layer (additive, no visible changes)

### DIFF
--- a/V2_REBRAND_NOTES.md
+++ b/V2_REBRAND_NOTES.md
@@ -1,0 +1,52 @@
+# V2 Rebrand Token Layer
+
+## What this PR adds
+
+A single additive stylesheet (`assets/wellet-v2-tokens.css`) loaded **after the entire editorial-\* stack** on `index.html`, and on every standalone page (`how-it-works`, `privacy`, `support`, `terms`, `your-data`, `share`, `family-record`, `care_signals_preview`, `dsinvite`, `smoketest-wishes`).
+
+Also adds Gambetta + Public Sans `<link>` tags alongside the existing Fraunces / DM Sans loads. Both font sets remain loaded — no replacement until each surface migrates.
+
+**Nothing visible changes** until a surface opts in by using the new classes.
+
+## Discipline (same as editorial-foundation.css)
+
+This PR is plumbing only. It respects the editorial rollout pattern already in flight (`editorial-auth`, `editorial-updates`, `editorial-records`, etc.) — each surface migrates in its own PR, one at a time.
+
+## Typography
+
+- **Display**: Gambetta (Fontshare) — weights 300/400/500/400i
+- **Body**: Public Sans (Google Fonts) — weights 400/500/600/700
+
+Tokens expose `--font-v2-serif` and `--font-v2-sans` aliases.
+
+## Color tokens (`--c-*`)
+
+The V2 semantic palette:
+
+- **Forest** (`--c-forest`, `--c-forest-deep`, `--c-forest-leaf`, `--c-forest-pine`) — primary brand
+- **Mint** (`--c-mint`, `--c-mint-soft`, `--c-mint-deep`) — "fresh" status
+- **Clay / Walnut / Clay-soft** — change states + self-reported provenance
+- **Mist / Stone / Blue** — cool neutrals
+- **Midnight** — depth accent, used sparingly
+- **Alert** — ER red, used only in the ER surface
+
+These coexist with the existing `--moss`, `--mint`, `--cream`, `--amber` tokens in `wellet.css`. No existing tokens are overridden.
+
+## rcard primitives
+
+- `.rcard` — Forest 3px left border + Clay eyebrow + Mint pill (V2 grammar)
+- `.rcard.is-change` — Clay border (dose changed, etc.)
+- `.rcard.is-unavailable` — Stone bg, dimmed
+- `.rcard.with-icon` — 34px Mint-soft icon tile
+- `.rc-eyebrow.self-reported` — Walnut + "flag for next visit"
+- `.timeline-rail` — vertical rail with filled Forest dots
+- `.btn-forest-outline` — demoted-CTA variant
+- `.menu-tile`, `.menu-tile.is-emergency` — side-menu icon tiles
+
+## Reference
+
+V2 mockups: see the v2 reference site preview in the chief-of-staff thread for live examples of every primitive.
+
+## Migration plan
+
+Surfaces migrate **one at a time** in subsequent PRs, same discipline as the existing editorial rollout. This PR is plumbing only.

--- a/assets/wellet-v2-tokens.css
+++ b/assets/wellet-v2-tokens.css
@@ -1,76 +1,186 @@
 /* ============================================================================
-   wellet-v2-tokens.css — V2 brand token + UX primitive layer
+   wellet-v2-tokens.css — V2 brand tokens + rcard primitive layer
    ----------------------------------------------------------------------------
-   ADDITIVE ONLY. Nothing in this file overrides an existing variable or
-   touches a currently-rendered surface. Surfaces opt in by adding the new
-   classes (.rcard, .rc-eyebrow, .rc-pill, .rc-rail, etc.) — until then,
-   loading this file changes nothing visible.
+   ADDITIVE ONLY. Loaded LAST in the cascade. Nothing here overrides an
+   existing v1 token; surfaces opt in by adding new classes.
 
-   Aligned to the v2 reference at /wellet_rebrand/reference_site/mockups.html
-   (see asset_id 2e9b6a0d-1277-4e03-b8b0-e6f2ade0e5b6) and to the v2 brand
-   guidelines document.
+   Section 1: Canonical token export (from dist/wellet.css, generated
+              Fri, 19 Jun 2026 16:34:27 GMT — the source of truth shipped
+              in the V2 reference bundle).
+   Section 2: Legacy aliases — short --c-* / --rc-* names used by existing
+              v2 surfaces (m.html pillars, rcard grammar). These map to
+              canonical core tokens; do not introduce new aliases.
+   Section 3: rcard primitives — the V2 Resources card grammar.
 
-   Naming convention: --c-* for color, --rc-* for resources-card primitives.
-
-   FONTS: V2 uses Gambetta (display, italic noun emphasis) and Public Sans
-   (body). The primitives below reference --font-v2-serif and --font-v2-sans
-   with sensible fallbacks. To activate v2 typography, also add to <head>:
-
+   FONTS: add to <head>:
      <link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
      <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-
-   Fraunces / DM Sans remain loaded for v1 surfaces; no conflict.
+     <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
    ============================================================================ */
 
+/* ============================================================================
+   SECTION 1 — Canonical tokens (verbatim from dist/wellet.css)
+   ============================================================================ */
 :root {
-  /* ---- Surface neutrals ---- */
-  --c-cream:        #e7e7df;
-  --c-cream-warm:   #dcdace;
+  --core-color-cream: #e7e7df;
+  --core-color-cream-warm: #dcdace;
+  --core-color-forest: #11443b;
+  --core-color-forest-deep: #0d3a32;
+  --core-color-forest-2: #114445;
+  --core-color-midnight: #183241;
+  --core-color-mint: #9ece90;
+  --core-color-mist: #b7c9cd;
+  --core-color-stone: #dcdace;
+  --core-color-forest-leaf: #2d4b40;
+  --core-color-forest-pine: #1b4d45;
+  --core-color-olive: #424833;
+  --core-color-clay: #a87251;
+  --core-color-walnut: #552d27;
+  --core-color-blue-soft: #81a3ee;
+  --core-color-blue-deep: #c2cce0;
+  --core-color-alert: #ec5747;
+  --core-color-alert-deep: #f46363;
+  --core-color-ink: #11443b;
+  --core-color-ink-2: #3a4a45;
+  --core-color-ink-3: #7a857f;
+  --core-color-white: #ffffff;
+  --core-color-black: #0a0a0a;
+  --core-font-family-display: Gambetta;
+  --core-font-family-body: Public Sans;
+  --core-font-family-mono: DM Mono;
+  --core-font-weight-light: 300;
+  --core-font-weight-regular: 400;
+  --core-font-weight-medium: 500;
+  --core-size-0: 0px;
+  --core-size-1: 4px;
+  --core-size-2: 8px;
+  --core-size-3: 12px;
+  --core-size-4: 16px;
+  --core-size-5: 24px;
+  --core-size-6: 32px;
+  --core-size-7: 48px;
+  --core-size-8: 64px;
+  --core-size-9: 96px;
+  --core-radius-xs: 6px;
+  --core-radius-sm: 10px;
+  --core-radius-md: 16px;
+  --core-radius-lg: 32px;
+  --core-radius-pill: 999px;
+  --core-shadow-card: 0 1px 2px 0 #11443b0f, 0 4px 12px 0 #11443b0a;
+  --core-shadow-raised: 0 4px 16px 0 #11443b14, 0 12px 36px 0 #11443b0f;
+  --core-shadow-modal: 0 8px 24px 0 #1832411a, 0 24px 64px 0 #1832411f;
+  --core-blur-glass: 33px;
+  --core-blur-glass-heavy: 52px;
+  --semantic-color-bg-default: #e7e7df;
+  --semantic-color-bg-raised: #dcdace;
+  --semantic-color-bg-inverse: #183241;
+  --semantic-color-fg-default: #11443b;
+  --semantic-color-fg-muted: #3a4a45;
+  --semantic-color-fg-subtle: #7a857f;
+  --semantic-color-fg-inverse: #ffffff;
+  --semantic-color-brand-primary: #11443b;
+  --semantic-color-brand-primary-hover: #0d3a32;
+  --semantic-color-brand-highlight: #9ece90;
+  --semantic-color-border-default: #dcdace;
+  --semantic-color-border-strong: #11443b;
+  --semantic-color-status-stable: #b7c9cd;
+  --semantic-color-status-watching: #9ece90;
+  --semantic-color-status-attention: #ec5747;
+  --type-display-font-family: Gambetta;
+  --type-display-font-weight: 500;
+  --type-display-font-size: 72px;
+  --type-display-line-height: 76px;
+  --type-display-letter-spacing: -2px;
+  --type-h1-font-family: Gambetta;
+  --type-h1-font-weight: 500;
+  --type-h1-font-size: 48px;
+  --type-h1-line-height: 54px;
+  --type-h1-letter-spacing: -1px;
+  --type-h2-font-family: Gambetta;
+  --type-h2-font-weight: 500;
+  --type-h2-font-size: 36px;
+  --type-h2-line-height: 42px;
+  --type-h2-letter-spacing: -0.5px;
+  --type-h3-font-family: Gambetta;
+  --type-h3-font-weight: 500;
+  --type-h3-font-size: 24px;
+  --type-h3-line-height: 30px;
+  --type-h3-letter-spacing: 0;
+  --type-lede-font-family: Public Sans;
+  --type-lede-font-weight: 300;
+  --type-lede-font-size: 22px;
+  --type-lede-line-height: 32px;
+  --type-lede-letter-spacing: 0;
+  --type-body-font-family: Public Sans;
+  --type-body-font-weight: 400;
+  --type-body-font-size: 17px;
+  --type-body-line-height: 27px;
+  --type-body-letter-spacing: 0;
+  --type-body-sm-font-family: Public Sans;
+  --type-body-sm-font-weight: 400;
+  --type-body-sm-font-size: 15px;
+  --type-body-sm-line-height: 24px;
+  --type-body-sm-letter-spacing: 0;
+  --type-caption-font-family: Public Sans;
+  --type-caption-font-weight: 500;
+  --type-caption-font-size: 13px;
+  --type-caption-line-height: 18px;
+  --type-caption-letter-spacing: 0.2px;
+  --type-micro-font-family: Public Sans;
+  --type-micro-font-weight: 500;
+  --type-micro-font-size: 12px;
+  --type-micro-line-height: 16px;
+  --type-micro-letter-spacing: 0.4px;
+}
+
+/* ============================================================================
+   SECTION 2 — Legacy aliases
+   ----------------------------------------------------------------------------
+   Short names referenced by v2 surfaces shipped before the canonical export
+   landed. All map to canonical core tokens; safe to remove once all call
+   sites use --core-* directly.
+   ============================================================================ */
+:root {
+  --c-cream:        var(--core-color-cream);
+  --c-cream-warm:   var(--core-color-cream-warm);
   --c-dad-bg:       #efece2;
   --c-mom-bg:       #e6ede7;
 
-  /* ---- Forest family (primary brand) ---- */
-  --c-forest:       #11443b;
-  --c-forest-deep:  #0d3a32;
-  --c-forest-2:     #114445;
-  --c-forest-leaf:  #2d4b40;
-  --c-forest-pine:  #1b4d45;
+  --c-forest:       var(--core-color-forest);
+  --c-forest-deep:  var(--core-color-forest-deep);
+  --c-forest-2:     var(--core-color-forest-2);
+  --c-forest-leaf:  var(--core-color-forest-leaf);
+  --c-forest-pine:  var(--core-color-forest-pine);
 
-  /* ---- Mint family (status / "fresh" signal) ---- */
-  --c-mint:         #9ece90;
+  --c-mint:         var(--core-color-mint);
   --c-mint-soft:    #d6e5cf;
   --c-mint-deep:    #7eb572;
 
-  /* ---- Mist / stone / blue (cool neutrals + plumbing) ---- */
-  --c-mist:         #b7c9cd;
+  --c-mist:         var(--core-color-mist);
   --c-mist-soft:    #d6dfe1;
-  --c-stone:        #dcdace;
-  --c-blue-soft:    #81a3ee;
-  --c-blue-deep:    #c2cce0;
+  --c-stone:        var(--core-color-stone);
+  --c-blue-soft:    var(--core-color-blue-soft);
+  --c-blue-deep:    var(--core-color-blue-deep);
 
-  /* ---- Clay / walnut (change + caregiver-provenance) ---- */
-  --c-clay:         #a87251;
+  --c-clay:         var(--core-color-clay);
   --c-clay-soft:    #e3d2c2;
-  --c-walnut:       #552d27;
+  --c-walnut:       var(--core-color-walnut);
 
-  /* ---- Depth / accent ---- */
-  --c-midnight:     #183241;
+  --c-midnight:     var(--core-color-midnight);
   --c-midnight-2:   #1f3d4e;
-  --c-olive:        #424833;
+  --c-olive:        var(--core-color-olive);
 
-  /* ---- Alarm (used sparingly, ER only) ---- */
-  --c-alert:        #ec5747;
+  --c-alert:        var(--core-color-alert);
+  --c-alert-deep:   var(--core-color-alert-deep);
 
-  /* ---- Ink ladder (text) ---- */
-  --c-v2-ink:       #1c2826;
-  --c-v2-ink-2:     #3a4a45;
-  --c-v2-ink-3:     #6b7773;
+  --c-v2-ink:       var(--core-color-ink);
+  --c-v2-ink-2:     var(--core-color-ink-2);
+  --c-v2-ink-3:     var(--core-color-ink-3);
 
-  /* ---- V2 typography family aliases ---- */
   --font-v2-serif:  "Gambetta", Georgia, serif;
   --font-v2-sans:   "Public Sans", system-ui, -apple-system, sans-serif;
+  --font-v2-mono:   "DM Mono", ui-monospace, monospace;
 
-  /* ---- rcard primitive sizing ---- */
   --rc-border-w:    3px;
   --rc-radius:      14px;
   --rc-pad-y:       14px;
@@ -82,9 +192,7 @@
 }
 
 /* ============================================================================
-   rcard — the v2 Resources card grammar.
-   Forest 3px left border, Clay uppercase eyebrow, optional Mint pill in the
-   top-right with a dot, italic Gambetta/Fraunces title.
+   SECTION 3 — rcard primitives (V2 Resources card grammar)
    ============================================================================ */
 .rcard {
   position: relative;
@@ -92,33 +200,30 @@
   border-left: var(--rc-border-w) solid var(--c-forest);
   border-radius: var(--rc-radius);
   padding: var(--rc-pad-y) var(--rc-pad-x);
-  box-shadow: 0 1px 2px rgba(28, 40, 38, 0.04);
+  box-shadow: var(--core-shadow-card);
 }
 
-/* Change state — clay border + clay pill */
 .rcard.is-change {
   border-left-color: var(--c-clay);
 }
 
-/* Stone / unavailable */
 .rcard.is-unavailable {
   background: var(--c-stone);
   border-left-color: var(--c-v2-ink-3);
   opacity: 0.65;
 }
 
-/* ---- Eyebrow: source / identity ---- */
 .rc-eyebrow {
   display: block;
+  font-family: var(--font-v2-sans);
   font-size: var(--rc-eyebrow-size);
   letter-spacing: var(--rc-eyebrow-tracking);
   text-transform: uppercase;
   color: var(--c-clay);
   font-weight: 600;
-  margin: 0 150px 4px 0;  /* right margin reserves space for pill */
+  margin: 0 150px 4px 0;
 }
 
-/* Self-reported provenance: walnut + "flag for next visit" reminder */
 .rc-eyebrow.self-reported {
   color: var(--c-walnut);
 }
@@ -129,7 +234,6 @@
   font-weight: 500;
 }
 
-/* ---- Pill: status / "how many" / "when" ---- */
 .rc-pill {
   position: absolute;
   top: 14px;
@@ -138,7 +242,8 @@
   align-items: center;
   gap: 6px;
   padding: 3px 9px 3px 8px;
-  border-radius: 999px;
+  border-radius: var(--core-radius-pill);
+  font-family: var(--font-v2-sans);
   font-size: var(--rc-pill-size);
   letter-spacing: var(--rc-pill-tracking);
   font-weight: 700;
@@ -150,7 +255,7 @@
   content: "";
   width: 5px;
   height: 5px;
-  border-radius: 999px;
+  border-radius: var(--core-radius-pill);
   background: var(--c-forest-deep);
   display: inline-block;
 }
@@ -162,7 +267,6 @@
   background: var(--c-walnut);
 }
 
-/* ---- Title: italic display face (Gambetta) ---- */
 .rc-title {
   font-family: var(--font-v2-serif);
   font-style: italic;
@@ -173,7 +277,6 @@
   margin: 0 0 4px;
 }
 
-/* ---- Icon tile variant ---- */
 .rcard.with-icon {
   display: grid;
   grid-template-columns: 34px 1fr;
@@ -190,11 +293,7 @@
   color: var(--c-forest-deep);
 }
 
-/* ============================================================================
-   rail — timeline vertical with filled forest dots.
-   Use .rcard inside .timeline-rail to suppress the left border; the rail dot
-   does the framing instead.
-   ============================================================================ */
+/* Timeline rail (used by mywellet timeline + pro labs) */
 .timeline-rail {
   position: relative;
   padding-left: 22px;
@@ -220,21 +319,18 @@
   top: 22px;
   width: 9px;
   height: 9px;
-  border-radius: 999px;
+  border-radius: var(--core-radius-pill);
   background: var(--c-forest);
 }
 
-/* ============================================================================
-   Outlined Forest button — demoted CTA variant.
-   Use on secondary actions (e.g. "Open prep") so the primary Wellet Summary
-   stays the visual hero.
-   ============================================================================ */
+/* Demoted CTA — outlined Forest */
 .btn-forest-outline {
   background: transparent;
   border: 1.5px solid var(--c-forest);
   color: var(--c-forest);
+  font-family: var(--font-v2-sans);
   font-weight: 600;
-  border-radius: 999px;
+  border-radius: var(--core-radius-pill);
   padding: 10px 18px;
   cursor: pointer;
 }
@@ -242,9 +338,7 @@
   background: rgba(17, 68, 59, 0.06);
 }
 
-/* ============================================================================
-   Side-menu emergency tile — Walnut filled (not pure red) for ER Summary.
-   ============================================================================ */
+/* Side-menu emergency tile (mywellet) */
 .menu-tile {
   width: 30px;
   height: 30px;

--- a/assets/wellet-v2-tokens.css
+++ b/assets/wellet-v2-tokens.css
@@ -1,0 +1,260 @@
+/* ============================================================================
+   wellet-v2-tokens.css — V2 brand token + UX primitive layer
+   ----------------------------------------------------------------------------
+   ADDITIVE ONLY. Nothing in this file overrides an existing variable or
+   touches a currently-rendered surface. Surfaces opt in by adding the new
+   classes (.rcard, .rc-eyebrow, .rc-pill, .rc-rail, etc.) — until then,
+   loading this file changes nothing visible.
+
+   Aligned to the v2 reference at /wellet_rebrand/reference_site/mockups.html
+   (see asset_id 2e9b6a0d-1277-4e03-b8b0-e6f2ade0e5b6) and to the v2 brand
+   guidelines document.
+
+   Naming convention: --c-* for color, --rc-* for resources-card primitives.
+
+   FONTS: V2 uses Gambetta (display, italic noun emphasis) and Public Sans
+   (body). The primitives below reference --font-v2-serif and --font-v2-sans
+   with sensible fallbacks. To activate v2 typography, also add to <head>:
+
+     <link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+   Fraunces / DM Sans remain loaded for v1 surfaces; no conflict.
+   ============================================================================ */
+
+:root {
+  /* ---- Surface neutrals ---- */
+  --c-cream:        #e7e7df;
+  --c-cream-warm:   #dcdace;
+  --c-dad-bg:       #efece2;
+  --c-mom-bg:       #e6ede7;
+
+  /* ---- Forest family (primary brand) ---- */
+  --c-forest:       #11443b;
+  --c-forest-deep:  #0d3a32;
+  --c-forest-2:     #114445;
+  --c-forest-leaf:  #2d4b40;
+  --c-forest-pine:  #1b4d45;
+
+  /* ---- Mint family (status / "fresh" signal) ---- */
+  --c-mint:         #9ece90;
+  --c-mint-soft:    #d6e5cf;
+  --c-mint-deep:    #7eb572;
+
+  /* ---- Mist / stone / blue (cool neutrals + plumbing) ---- */
+  --c-mist:         #b7c9cd;
+  --c-mist-soft:    #d6dfe1;
+  --c-stone:        #dcdace;
+  --c-blue-soft:    #81a3ee;
+  --c-blue-deep:    #c2cce0;
+
+  /* ---- Clay / walnut (change + caregiver-provenance) ---- */
+  --c-clay:         #a87251;
+  --c-clay-soft:    #e3d2c2;
+  --c-walnut:       #552d27;
+
+  /* ---- Depth / accent ---- */
+  --c-midnight:     #183241;
+  --c-midnight-2:   #1f3d4e;
+  --c-olive:        #424833;
+
+  /* ---- Alarm (used sparingly, ER only) ---- */
+  --c-alert:        #ec5747;
+
+  /* ---- Ink ladder (text) ---- */
+  --c-v2-ink:       #1c2826;
+  --c-v2-ink-2:     #3a4a45;
+  --c-v2-ink-3:     #6b7773;
+
+  /* ---- V2 typography family aliases ---- */
+  --font-v2-serif:  "Gambetta", Georgia, serif;
+  --font-v2-sans:   "Public Sans", system-ui, -apple-system, sans-serif;
+
+  /* ---- rcard primitive sizing ---- */
+  --rc-border-w:    3px;
+  --rc-radius:      14px;
+  --rc-pad-y:       14px;
+  --rc-pad-x:       16px;
+  --rc-eyebrow-size: 11px;
+  --rc-eyebrow-tracking: 0.08em;
+  --rc-pill-size:   10px;
+  --rc-pill-tracking: 0.03em;
+}
+
+/* ============================================================================
+   rcard — the v2 Resources card grammar.
+   Forest 3px left border, Clay uppercase eyebrow, optional Mint pill in the
+   top-right with a dot, italic Gambetta/Fraunces title.
+   ============================================================================ */
+.rcard {
+  position: relative;
+  background: #fff;
+  border-left: var(--rc-border-w) solid var(--c-forest);
+  border-radius: var(--rc-radius);
+  padding: var(--rc-pad-y) var(--rc-pad-x);
+  box-shadow: 0 1px 2px rgba(28, 40, 38, 0.04);
+}
+
+/* Change state — clay border + clay pill */
+.rcard.is-change {
+  border-left-color: var(--c-clay);
+}
+
+/* Stone / unavailable */
+.rcard.is-unavailable {
+  background: var(--c-stone);
+  border-left-color: var(--c-v2-ink-3);
+  opacity: 0.65;
+}
+
+/* ---- Eyebrow: source / identity ---- */
+.rc-eyebrow {
+  display: block;
+  font-size: var(--rc-eyebrow-size);
+  letter-spacing: var(--rc-eyebrow-tracking);
+  text-transform: uppercase;
+  color: var(--c-clay);
+  font-weight: 600;
+  margin: 0 150px 4px 0;  /* right margin reserves space for pill */
+}
+
+/* Self-reported provenance: walnut + "flag for next visit" reminder */
+.rc-eyebrow.self-reported {
+  color: var(--c-walnut);
+}
+.rc-eyebrow.self-reported::after {
+  content: " · flag for next visit";
+  color: var(--c-walnut);
+  opacity: 0.7;
+  font-weight: 500;
+}
+
+/* ---- Pill: status / "how many" / "when" ---- */
+.rc-pill {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px 3px 8px;
+  border-radius: 999px;
+  font-size: var(--rc-pill-size);
+  letter-spacing: var(--rc-pill-tracking);
+  font-weight: 700;
+  background: var(--c-mint);
+  color: var(--c-forest-deep);
+  box-shadow: inset 0 0 0 1px rgba(13, 58, 50, 0.10);
+}
+.rc-pill::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--c-forest-deep);
+  display: inline-block;
+}
+.rc-pill.is-change {
+  background: var(--c-clay-soft);
+  color: var(--c-walnut);
+}
+.rc-pill.is-change::before {
+  background: var(--c-walnut);
+}
+
+/* ---- Title: italic display face (Gambetta) ---- */
+.rc-title {
+  font-family: var(--font-v2-serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1.05rem;
+  line-height: 1.25;
+  color: var(--c-v2-ink);
+  margin: 0 0 4px;
+}
+
+/* ---- Icon tile variant ---- */
+.rcard.with-icon {
+  display: grid;
+  grid-template-columns: 34px 1fr;
+  gap: 12px;
+  align-items: start;
+}
+.rcard.with-icon .rc-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--c-mint-soft);
+  display: grid;
+  place-items: center;
+  color: var(--c-forest-deep);
+}
+
+/* ============================================================================
+   rail — timeline vertical with filled forest dots.
+   Use .rcard inside .timeline-rail to suppress the left border; the rail dot
+   does the framing instead.
+   ============================================================================ */
+.timeline-rail {
+  position: relative;
+  padding-left: 22px;
+}
+.timeline-rail::before {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--c-mist);
+}
+.timeline-rail .rcard {
+  border-left: 0;
+  margin-bottom: 14px;
+  position: relative;
+}
+.timeline-rail .rcard::before {
+  content: "";
+  position: absolute;
+  left: -22px;
+  top: 22px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--c-forest);
+}
+
+/* ============================================================================
+   Outlined Forest button — demoted CTA variant.
+   Use on secondary actions (e.g. "Open prep") so the primary Wellet Summary
+   stays the visual hero.
+   ============================================================================ */
+.btn-forest-outline {
+  background: transparent;
+  border: 1.5px solid var(--c-forest);
+  color: var(--c-forest);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 10px 18px;
+  cursor: pointer;
+}
+.btn-forest-outline:hover {
+  background: rgba(17, 68, 59, 0.06);
+}
+
+/* ============================================================================
+   Side-menu emergency tile — Walnut filled (not pure red) for ER Summary.
+   ============================================================================ */
+.menu-tile {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  background: var(--c-mint-soft);
+  display: grid;
+  place-items: center;
+  color: var(--c-forest-deep);
+}
+.menu-tile.is-emergency {
+  background: var(--c-walnut);
+  color: #fff;
+}

--- a/care_signals_preview.html
+++ b/care_signals_preview.html
@@ -31,6 +31,10 @@
 <title>Care Signals v1 — UI preview</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <script src="https://unpkg.com/lucide@0.460.0/dist/umd/lucide.min.js"></script>
 <style>
   :root {

--- a/dsinvite.html
+++ b/dsinvite.html
@@ -259,6 +259,7 @@
   .whisper b { color: var(--ink); font-weight: 600; letter-spacing: 0.2em; }
   @media (min-width: 700px) { .whisper { margin-top: 40px; padding-top: 24px; font-size: 13px; } }
 </style>
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 </head>
 <body>
   <div class="container">

--- a/family-record.html
+++ b/family-record.html
@@ -40,6 +40,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <script src="/lucide.min.js"></script>
 <style>
   :root {

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -32,6 +32,10 @@
 <title>How It Works — Wellet</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <style>
   :root {
     --moss: #608F7C;

--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;1,9..144,300;1,9..144,400&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="/lucide.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -63,6 +66,7 @@
 <link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260531-dismiss">
 <link rel="stylesheet" href="/assets/editorial-upcoming.css">
 <link rel="stylesheet" href="/assets/editorial-connect-progress.css?v=20260528-1418">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <link rel="stylesheet" href="/assets/try-flow.css">
 </head>
 <body>

--- a/privacy.html
+++ b/privacy.html
@@ -32,6 +32,10 @@
 <title>Privacy Policy — Wellet</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <style>
   :root {
     --moss: #608F7C;

--- a/share.html
+++ b/share.html
@@ -40,6 +40,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;1,9..40,300&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="/lucide.min.js"></script>
 <style>

--- a/smoketest-wishes.html
+++ b/smoketest-wishes.html
@@ -74,6 +74,7 @@
     .stat-num { font: 600 20px/1 ui-serif, serif; color: var(--ink); display: block; }
     .stat-label { font-size: 11px; color: var(--muted); letter-spacing: 0.06em; text-transform: uppercase; }
   </style>
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 </head>
 <body>
   <div class="wrap">

--- a/support.html
+++ b/support.html
@@ -34,6 +34,10 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <style>
   :root {
     --moss: #608F7C;

--- a/terms.html
+++ b/terms.html
@@ -32,6 +32,10 @@
 <title>Terms of Service — Wellet</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <style>
   :root {
     --moss: #608F7C;

--- a/your-data.html
+++ b/your-data.html
@@ -32,6 +32,10 @@
 <title>Your Data — Wellet</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=DM+Serif+Display&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://api.fontshare.com" crossorigin>
+<link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
 <style>
   :root {
     --moss: #608F7C;


### PR DESCRIPTION
## What this PR does

Adds a single additive stylesheet (`assets/wellet-v2-tokens.css`) loaded **after the entire editorial-* stack** on index.html, and on every standalone page. Also adds Gambetta + Public Sans `<link>` tags alongside the existing Fraunces / DM Sans loads.

**No visible surface changes in this PR.** Same discipline as `editorial-foundation.css`: plumbing only, surfaces opt in one at a time.

## Files

- **new**: `assets/wellet-v2-tokens.css` — V2 tokens + primitives
- **new**: `V2_REBRAND_NOTES.md` — what's inside + migration plan
- **modified**: `index.html` and 10 standalone HTML pages — each gets the two font `<link>` tags and the V2 tokens `<link>` tag

## Cascade discipline

On index.html the new file loads **last** in the cascade, after `editorial-foundation`, `editorial-auth`, `editorial-updates`, `editorial-records`, `editorial-ask`, `editorial-sheets`, `editorial-er`, `editorial-people`, etc. It cannot accidentally override any in-flight editorial surface work.

## What's in the token layer

### Typography aliases
- `--font-v2-serif` → Gambetta (Fontshare)
- `--font-v2-sans` → Public Sans

### Color tokens (--c-*)
forest / forest-deep / forest-leaf / forest-pine, mint / mint-soft / mint-deep, clay / clay-soft, walnut, mist / mist-soft, stone, blue-deep, midnight, alert

### rcard primitives
`.rcard` (Forest 3px left border + Clay eyebrow + Mint pill), `.rcard.is-change` (Clay variant), `.rcard.is-unavailable` (Stone variant), `.rcard.with-icon` (Mint-soft icon tile), `.rc-eyebrow.self-reported` (Walnut + 'flag for next visit'), `.timeline-rail` (filled Forest dots), `.btn-forest-outline`, `.menu-tile.is-emergency`

## Safety

- Additive only — no existing variables overridden, no existing selectors modified
- Loaded LAST so it can be reasoned about independently
- Two font sets coexist (Fraunces + Gambetta, DM Sans + Public Sans); no swap
- A surface inherits zero v2 styling unless it adds one of the new classes
- Trivially revertable: delete one CSS file + the link lines

## Reference

V2 mockups: live examples of every primitive in the v2 reference site preview shared in the chief-of-staff thread.