### PR TITLE
V2 foundation on connect + dsinvite pages

### DIFF
--- a/connect/loved-one.html
+++ b/connect/loved-one.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+
+  <!-- V2 canonical tokens -->
+  <link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
+  <!-- V2 fonts -->
+  <link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Open Wellet Connect</title>
 <meta name="description" content="Finish connecting Apple Health to Wellet.">

--- a/connect/start.html
+++ b/connect/start.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+
+  <!-- V2 canonical tokens -->
+  <link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
+  <!-- V2 fonts -->
+  <link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Open in Wellet Connect</title>
 <meta name="description" content="Finish signing in to Wellet Connect.">

--- a/dsinvite.html
+++ b/dsinvite.html
@@ -2,6 +2,11 @@
 <html>
 <head>
 <meta charset="utf-8">
+
+  <!-- V2 fonts -->
+  <link href="https://api.fontshare.com/v2/css?f[]=gambetta@300,400,500,400i&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <title>A note from Betsy</title>
 <style>


### PR DESCRIPTION
## Wave 4 · wellet (mywellet.com) site-wide V2 foundation

Three pages were not yet on the V2 foundation:
- `connect/start.html` (magic-link landing)
- `connect/loved-one.html` (loved-one invite landing)
- `dsinvite.html` (downstream share invite — had tokens, missing Gambetta)

This PR adds `/assets/wellet-v2-tokens.css` + Gambetta + Public Sans to each.

### What did NOT change
- Auth/magic-link logic (Supabase redirect untouched)
- Any other HTML page (all 10 others already V2-clean)
- CSS files, scripts, copy

Net diff: +19 / 0 across 3 files.

— Mabel
