### PR TITLE
brand v2.01: editorial-foundation token sweep

### DIFF
--- a/assets/editorial-caresignals.css
+++ b/assets/editorial-caresignals.css
@@ -52,7 +52,7 @@
   font-family: 'Public Sans', system-ui, sans-serif !important;
   font-size: var(--type-meta) !important;
   font-weight: 300 !important;
-  color: var(--ink-6, #57534C) !important;
+  color: var(--ink-6, #4A463F) !important;
   margin: 0 0 18px !important;
 }
 
@@ -105,7 +105,7 @@
   font-family: 'Public Sans', system-ui, sans-serif !important;
   font-size: var(--type-meta) !important;
   font-weight: 300 !important;
-  color: var(--ink-6, #57534C) !important;
+  color: var(--ink-6, #4A463F) !important;
   margin: 0 0 8px !important;
 }
 #view-signals .med-times {
@@ -384,7 +384,7 @@
   font-family: 'Public Sans', system-ui, sans-serif !important;
   font-size: var(--type-meta) !important;
   font-weight: 300 !important;
-  color: var(--ink-6, #57534C) !important;
+  color: var(--ink-6, #4A463F) !important;
 }
 #view-signals .sensor-status {
   width: 6px;
@@ -622,7 +622,7 @@
   font-family: 'Public Sans', system-ui, sans-serif !important;
   font-size: var(--type-body) !important;
   line-height: 1.55 !important;
-  color: var(--ink-6, #57534C) !important;
+  color: var(--ink-6, #4A463F) !important;
   font-weight: 300 !important;
   margin: 0 0 14px !important;
 }
@@ -874,7 +874,7 @@
   border-color: #C8DDD0 !important;
 }
 #view-signals .cs-attention__statusbadge--dismissed {
-  color: var(--ink-6, #57534C) !important;
+  color: var(--ink-6, #4A463F) !important;
   background: var(--ink-1, #F2EFE9) !important;
   border-color: var(--ink-2, #C9C2B5) !important;
 }

--- a/assets/editorial-foundation.css
+++ b/assets/editorial-foundation.css
@@ -30,28 +30,33 @@
    --------------------------------------------------------------------------- */
 :root {
   /* Eight-gray ladder — no black, no flat #000.
-     Used for editorial body copy, dividers, and quiet metadata.
-     Range goes from --ink-0 (lightest, near-cream) to --ink-9 (deepest ink). */
-  --ink-0: #ECE7DC;
-  --ink-1: #E2DDD3;
-  --ink-2: #C8C0B5;
-  --ink-3: #A8A097;
-  --ink-4: #8A8278;
-  --ink-5: #6E665C;
-  --ink-7: #3C362F;
-  --ink-9: #1F1B16;
+     v2.01: cool-neutral Stone family (NOT warm-tan). Aligned to Stone #E8E6E0
+     so ink ladder visually descends from Stone canvas, not from a warm cream.
+     Range goes from --ink-0 (lightest) to --ink-9 (deepest ink, neutral). */
+  --ink-0: #EEEDE8;
+  --ink-1: #DAD6CB;
+  --ink-2: #BFB9AC;
+  --ink-3: #9F9A8E;
+  --ink-4: #7E796F;
+  --ink-5: #5F5A52;
+  --ink-6: #4A463F;
+  --ink-7: #2D2A24;
+  --ink-9: #161312;
 
-  /* Quiet status tones — no red, ever.
-     Used for editorial signals. The signal palette deliberately stays
-     warm/neutral so the app never feels alarming. */
-  --signal-warm:    #B8835A;  /* the only "urgent" tone, used sparingly */
-  --signal-stale:   #B5A582;  /* unanswered / aging */
-  --signal-fresh:   #8AA89A;  /* recent / healthy */
-  --signal-missing: #C8C0B5;  /* absent data */
+  /* Quiet status tones — no terra, no orange, no italic color accent.
+     v2.01: routes urgent through Walnut (canonical soft-alert from timeline
+     tiles), fresh through Mint, missing through ink-2. Stale is a cool
+     desaturated stone, not amber. */
+  --signal-warm:    #B8392B;  /* Walnut — the only "urgent" tone, used sparingly */
+  --signal-stale:   #8A847A;  /* unanswered / aging — cool, not amber */
+  --signal-fresh:   #9ECF90;  /* Mint — recent / healthy */
+  --signal-missing: #BFB9AC;  /* absent data, harmonizes with --ink-2 */
 
-  /* Editorial moss palette — supplements the existing --moss. */
-  --moss-deep: #3F5F52;       /* deeper editorial accent */
-  --moss-quiet: #8AA89A;      /* quieter moss for serif marks */
+  /* Editorial moss palette — supplements the existing --moss.
+     v2.01: --moss-deep is now canonical Forest #11443B (was sage-leaning
+     #3F5F52). --moss-quiet sits between Mist and Forest. */
+  --moss-deep: #11443B;       /* canonical Forest */
+  --moss-quiet: #6B8A7E;      /* quieter moss for serif marks */
 
   /* Editorial frame & gutter — sits alongside the existing 768px page-wrap.
      These power the editorial reading column when surfaces opt in. */
@@ -186,7 +191,7 @@ em.fr {
   line-height: 1.5;
   padding: 10px 14px 12px;
   border-radius: 8px;
-  box-shadow: 0 6px 20px rgba(63, 95, 82, 0.22);
+  box-shadow: 0 6px 20px rgba(17, 68, 59, 0.22);
   z-index: 65;
   opacity: 0;
   transform: translateY(-6px);
@@ -213,11 +218,11 @@ em.fr {
   font-size: var(--type-micro);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(247, 245, 240, 0.8);
+  color: rgba(232, 230, 224, 0.8);
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 3px;
-  text-decoration-color: rgba(247, 245, 240, 0.4);
+  text-decoration-color: rgba(232, 230, 224, 0.4);
 }
 @media (min-width: 768px) {
   .lp-hint { top: 78px; }
@@ -229,7 +234,7 @@ em.fr {
    --------------------------------------------------------------------------- */
 .shell-scrim {
   position: fixed; inset: 0;
-  background: rgba(31, 27, 22, 0.18);
+  background: rgba(25, 50, 65, 0.18);
   opacity: 0; pointer-events: none;
   transition: opacity 0.22s ease;
   z-index: 60;
@@ -356,7 +361,7 @@ em.fr {
 .er-sheet .er-bar {
   position: sticky; top: 0;
   background: #FFFFFF;
-  border-bottom: 1px solid #E5E2DC;
+  border-bottom: 1px solid var(--ink-1);
   padding: 14px 22px;
   display: flex;
   align-items: center;
@@ -396,24 +401,24 @@ em.fr {
   line-height: 1.15;
   letter-spacing: -0.01em;
   margin: 8px 0 2px;
-  color: #0F0D0A;
+  color: var(--ink-9);
 }
 .er-sheet p.er-sub {
   font-family: var(--sans);
   font-size: var(--type-body);
-  color: #5C5650;
+  color: var(--ink-5);
   margin: 0 0 6px;
   line-height: 1.5;
 }
 .er-sheet p.er-stamp {
   font-family: var(--sans);
   font-size: var(--type-meta);
-  color: #8A847C;
+  color: var(--ink-4);
   margin: 0 0 24px;
   letter-spacing: 0.02em;
 }
 .er-sheet section.er-block {
-  border-top: 1px solid #E5E2DC;
+  border-top: 1px solid var(--ink-1);
   padding: 18px 0 6px;
 }
 .er-sheet section.er-block .er-label {
@@ -421,7 +426,7 @@ em.fr {
   font-size: var(--type-micro);
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #5C5650;
+  color: var(--ink-5);
   font-weight: 500;
   margin: 0 0 10px;
 }
@@ -438,16 +443,16 @@ em.fr {
   padding: 9px 0;
   font-family: var(--sans);
   font-size: var(--type-body);
-  color: #0F0D0A;
+  color: var(--ink-9);
   line-height: 1.4;
-  border-bottom: 1px solid #F0EDE7;
+  border-bottom: 1px solid var(--ink-1);
 }
 .er-sheet section.er-block li:last-child { border-bottom: 0; }
 .er-sheet section.er-block li .er-key {
   font-family: var(--serif);
   font-weight: 400;
   font-size: var(--type-h2);
-  color: #0F0D0A;
+  color: var(--ink-9);
   letter-spacing: -0.002em;
 }
 .er-sheet section.er-block li .er-val {
@@ -473,7 +478,7 @@ em.fr {
   font-weight: 500;
   letter-spacing: 0.01em;
   cursor: pointer;
-  box-shadow: 0 8px 28px rgba(15, 13, 10, 0.18);
+  box-shadow: 0 8px 28px rgba(22, 19, 18, 0.18);
   z-index: 2;
   text-align: center;
   display: flex; align-items: center; justify-content: center;
@@ -499,7 +504,7 @@ em.fr {
 .er-sheet.doctor .er-hand {
   background: var(--cream);
   color: var(--ink-9);
-  border: 1px solid #E5E2DC;
+  border: 1px solid var(--ink-1);
   box-shadow: none;
 }
 .er-sheet.doctor .er-doctor-strip {
@@ -523,7 +528,7 @@ em.fr {
   bottom: 0;
   left: 0;
   right: 0;
-  background: rgba(247, 245, 240, 0.96);
+  background: rgba(232, 230, 224, 0.96);
   backdrop-filter: saturate(180%) blur(14px);
   -webkit-backdrop-filter: saturate(180%) blur(14px);
   border-top: 1px solid var(--ink-1);


### PR DESCRIPTION
## Source-of-truth fix

`editorial-foundation.css` defines the editorial token ladder consumed by **17 downstream CSS files** (timeline, records, updates, signals-view, people, people-view, ER, ask, sheets, auth, reimbursements, upcoming, resources-view, try-flow, caresignals, plus the main `wellet.css`) and one HTML preview. Fixing the tokens here cascades canon to every editorial surface without per-file edits.

## Ink ladder — warm-tan → cool Stone family

| Token | Was | Now |
|---|---|---|
| `--ink-0` | `#ECE7DC` | `#EEEDE8` |
| `--ink-1` | `#E2DDD3` | `#DAD6CB` |
| `--ink-2` | `#C8C0B5` | `#BFB9AC` |
| `--ink-3` | `#A8A097` | `#9F9A8E` |
| `--ink-4` | `#8A8278` | `#7E796F` |
| `--ink-5` | `#6E665C` | `#5F5A52` |
| `--ink-6` | (inline-only) | `#4A463F` (now explicit) |
| `--ink-7` | `#3C362F` | `#2D2A24` |
| `--ink-9` | `#1F1B16` | `#161312` (kills warm brown-black) |

## Signals — kill terra, route through canon

| Token | Was | Now | Reason |
|---|---|---|---|
| `--signal-warm` | `#B8835A` (terra-tan, banned) | `#B8392B` Walnut | matches timeline `tl-icon-tile-alert` from PR #139 |
| `--signal-stale` | `#B5A582` (amber-tan) | `#8A847A` (cool stone) | removes amber |
| `--signal-fresh` | `#8AA89A` | `#9ECF90` Mint | canonical |
| `--signal-missing` | `#C8C0B5` | `#BFB9AC` | harmonizes with `--ink-2` |

## Moss

| Token | Was | Now |
|---|---|---|
| `--moss-deep` | `#3F5F52` (sage-lean) | `#11443B` Forest |
| `--moss-quiet` | `#8AA89A` | `#6B8A7E` |

## Hardcoded inline hexes routed to tokens (10 sites within foundation)

- `#0F0D0A` → `var(--ink-9)` (3 sites in .er-sheet)
- `#5C5650` → `var(--ink-5)` (2 sites)
- `#8A847C` → `var(--ink-4)`
- `#E5E2DC`, `#F0EDE7` → `var(--ink-1)` (4 sites)
- `rgba(31,27,22,*)` → `rgba(25,50,65,*)` Midnight scrim
- `rgba(63,95,82,0.22)` → `rgba(17,68,59,0.22)` Forest shadow
- `rgba(247,245,240,*)` → `rgba(232,230,224,*)` Stone (lp-hint dismiss + shell-nav bg)

## editorial-caresignals.css

`--ink-6` inline fallback `#57534C` → `#4A463F` to match canonical token (5 sites).

## ER summary sheet — intentional exception preserved

`.er-sheet` keeps `#FFFFFF` — documented in-file ("the only place Wellet uses pure white").

## Verification

Computed tokens on production `index.html` confirm canon flowed through:
- `--moss-deep: #11443B` ✓
- `--signal-warm: #B8392B` ✓
- `--ink-9: #161312` ✓
- `--ink-1: #DAD6CB` ✓
- `--cream: #E8E6E0` ✓ (Stone)

Visual smoke test on `index.html` (auth screen) and `care_signals_preview.html` (wearable cards, signal dots, Watching chip) — both render cleanly with improved contrast.

## Why this matters

The ink ladder is the spine of the editorial UI. With warm-tan tokens, every editorial surface read slightly amber against the cool Stone canvas — a subtle but pervasive mismatch. After this PR, ink descends from Stone neutrally and Walnut/Mint/Forest carry all the chromatic signal.