### PR TITLE
brand v2.01: cascade follow-up to PR #141 (cache-bust + stragglers)

### DIFF
--- a/assets/editorial-ask.css
+++ b/assets/editorial-ask.css
@@ -601,7 +601,7 @@
   height: 32px;
   border-radius: 10px;
   background: #EDF3EE;
-  color: #2F4A3A;
+  color: var(--moss-deep, #11443B);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -650,7 +650,7 @@
 }
 .watch-row-status.watch-row-status-active {
   background: #EDF3EE;
-  color: #2F4A3A;
+  color: var(--moss-deep, #11443B);
 }
 .watch-row-status.watch-row-status-paused {
   background: #F0EDE5;

--- a/assets/editorial-reimbursements.css
+++ b/assets/editorial-reimbursements.css
@@ -287,12 +287,12 @@
   background: var(--reimb-confidence-high, var(--moss));
 }
 #view-reimbursements[data-editorial="reimbursements"] .reimb-pip--medium {
-  color: var(--reimb-confidence-medium, #3C362F);
-  background: rgba(60, 54, 47, 0.10);
+  color: var(--reimb-confidence-medium, #2D2A24);
+  background: rgba(45, 42, 36, 0.10);
 }
 #view-reimbursements[data-editorial="reimbursements"] .reimb-pip--low {
-  color: var(--reimb-confidence-low, #8A8278);
-  background: rgba(138, 130, 120, 0.12);
+  color: var(--reimb-confidence-low, #7E796F);
+  background: rgba(126, 121, 111, 0.12);
 }
 #view-reimbursements[data-editorial="reimbursements"] .reimb-card-sub {
   font-family: var(--sans, "Public Sans", system-ui, sans-serif);

--- a/assets/editorial-signals-view.css
+++ b/assets/editorial-signals-view.css
@@ -183,7 +183,7 @@
   letter-spacing: 0.02em;
 }
 .watch-row-status-active {
-  color: #2F4A3A;
+  color: var(--moss-deep, #11443B);
   background: #EDF3EE;
   border: 1px solid #C9D5CD;
 }
@@ -376,7 +376,7 @@
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .cs-aw-card:has(input[type="radio"]:checked) {
-  border-color: #2F4A3A;
+  border-color: var(--moss-deep, #11443B);
   background: #F5FAF6;
 }
 .cs-aw-card-title {
@@ -423,7 +423,7 @@
 .cs-aw-params input[type="text"] { width: 180px; }
 .cs-aw-params input:focus {
   outline: none;
-  border-color: #2F4A3A;
+  border-color: var(--moss-deep, #11443B);
   background: #fff;
 }
 

--- a/assets/try-flow.css
+++ b/assets/try-flow.css
@@ -40,7 +40,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  border: 2px dashed var(--ink-2, #D8D3CA);
+  border: 2px dashed var(--ink-2, #BFB9AC);
   border-radius: 20px;
   padding: 48px 24px;
   margin: 16px 0;
@@ -61,7 +61,7 @@
   font-size: clamp(22px, 5vw, 32px);
   font-weight: 500;
   font-variation-settings: "opsz" 24, "SOFT" 60;
-  color: var(--ink-9, #1F1B16);
+  color: var(--ink-9, #161312);
   margin: 0 0 12px;
   line-height: 1.2;
 }
@@ -70,7 +70,7 @@
   font-size: 15px;
   font-weight: 300;
   line-height: 1.55;
-  color: var(--ink-6, #57534C);
+  color: var(--ink-6, #4A463F);
   max-width: 380px;
   margin: 0 0 16px;
 }
@@ -100,7 +100,7 @@
 .try-drop-footer {
   text-align: center;
   font-size: 12px;
-  color: var(--ink-5, #6E6962);
+  color: var(--ink-5, #5F5A52);
   line-height: 1.5;
   padding: 8px 0 24px;
 }
@@ -113,7 +113,7 @@
 .try-spinner {
   width: 40px;
   height: 40px;
-  border: 3px solid var(--ink-1, #E6E1D6);
+  border: 3px solid var(--ink-1, #DAD6CB);
   border-top-color: var(--moss, #11443B);
   border-radius: 50%;
   margin: 0 auto 20px;
@@ -126,12 +126,12 @@
   font-family: 'Gambetta', serif;
   font-size: 22px;
   font-weight: 500;
-  color: var(--ink-9, #1F1B16);
+  color: var(--ink-9, #161312);
   margin: 0 0 8px;
 }
 .try-file-label {
   font-size: 14px;
-  color: var(--ink-5, #6E6962);
+  color: var(--ink-5, #5F5A52);
   margin: 0;
 }
 
@@ -143,13 +143,13 @@
   font-size: 24px;
   font-weight: 500;
   font-variation-settings: "opsz" 24, "SOFT" 60;
-  color: var(--ink-9, #1F1B16);
+  color: var(--ink-9, #161312);
   margin: 0 0 16px;
   text-align: center;
 }
 .try-results-body {
   background: white;
-  border: 1px solid var(--ink-1, #E6E1D6);
+  border: 1px solid var(--ink-1, #DAD6CB);
   border-radius: 14px;
   padding: 20px;
   margin-bottom: 20px;
@@ -171,7 +171,7 @@
 .try-result-value {
   font-size: 15px;
   line-height: 1.5;
-  color: var(--ink-7, #443F38);
+  color: var(--ink-7, #2D2A24);
 }
 .try-result-list {
   list-style: none;
@@ -181,8 +181,8 @@
 .try-result-list li {
   padding: 4px 0;
   font-size: 14px;
-  color: var(--ink-7, #443F38);
-  border-bottom: 1px solid var(--ink-0, #F0ECE4);
+  color: var(--ink-7, #2D2A24);
+  border-bottom: 1px solid var(--ink-0, #EEEDE8);
 }
 .try-result-list li:last-child {
   border-bottom: 0;
@@ -205,7 +205,7 @@
 .try-result-signal-text {
   font-size: 14px;
   line-height: 1.5;
-  color: var(--ink-7, #443F38);
+  color: var(--ink-7, #2D2A24);
 }
 
 .try-results-actions {
@@ -250,7 +250,7 @@
 /* ── Email gate ── */
 .try-email-card {
   background: white;
-  border: 1px solid var(--ink-1, #E6E1D6);
+  border: 1px solid var(--ink-1, #DAD6CB);
   border-radius: 16px;
   padding: 32px 24px;
   text-align: center;
@@ -260,13 +260,13 @@
   font-family: 'Gambetta', serif;
   font-size: 22px;
   font-weight: 500;
-  color: var(--ink-9, #1F1B16);
+  color: var(--ink-9, #161312);
   margin: 0 0 10px;
 }
 .try-email-card p {
   font-size: 14px;
   line-height: 1.55;
-  color: var(--ink-6, #57534C);
+  color: var(--ink-6, #4A463F);
   margin: 0 0 20px;
 }
 #try-email-form {
@@ -278,7 +278,7 @@
 #try-otp-input {
   width: 100%;
   padding: 12px 16px;
-  border: 1.5px solid var(--ink-2, #D8D3CA);
+  border: 1.5px solid var(--ink-2, #BFB9AC);
   border-radius: 10px;
   font-family: 'Public Sans', sans-serif;
   font-size: 16px;
@@ -318,11 +318,11 @@
 }
 .try-otp-label {
   font-size: 14px;
-  color: var(--ink-6, #57534C);
+  color: var(--ink-6, #4A463F);
   margin: 0 0 12px;
 }
 .try-email-note {
   font-size: 12px;
-  color: var(--ink-5, #6E6962);
+  color: var(--ink-5, #5F5A52);
   margin: 16px 0 0;
 }

--- a/assets/wellet-v2-tokens.css
+++ b/assets/wellet-v2-tokens.css
@@ -35,7 +35,7 @@
   --core-color-forest-pine: #1b4d45;
   --core-color-olive: #424833;
   --core-color-clay: #a87251;
-  --core-color-walnut: #552d27;
+  --core-color-walnut: #B8392B;
   --core-color-blue-soft: #81a3ee;
   --core-color-blue-deep: #c2cce0;
   --core-color-alert: #ec5747;

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -15817,7 +15817,7 @@ async function openAddWatchModal() {
 
   sheet.innerHTML = ''
     + '<div style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;">'
-    +   '<div style="width:38px;height:38px;border-radius:12px;background:#EDF3EE;color:#2F4A3A;display:flex;align-items:center;justify-content:center;flex-shrink:0;">'
+    +   '<div style="width:38px;height:38px;border-radius:12px;background:#EDF3EE;color:#11443B;display:flex;align-items:center;justify-content:center;flex-shrink:0;">'
     +     '<i data-lucide="bell" style="width:18px;height:18px;"></i>'
     +   '</div>'
     +   '<div style="flex:1;min-width:0;">'
@@ -15827,8 +15827,8 @@ async function openAddWatchModal() {
     + '</div>'
     + '<div class="cs-aw-cards">' + cardsHtml + '</div>'
     + '<div style="display:flex;gap:10px;margin-top:14px;">'
-    +   '<button type="button" id="cs-aw-cancel" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #C9D5CD;background:transparent;color:#2F4A3A;font-size:14px;font-weight:500;cursor:pointer;">Cancel</button>'
-    +   '<button type="button" id="cs-aw-save" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #2F4A3A;background:#2F4A3A;color:#fff;font-size:14px;font-weight:500;cursor:pointer;">Start watching</button>'
+    +   '<button type="button" id="cs-aw-cancel" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #C9D5CD;background:transparent;color:#11443B;font-size:14px;font-weight:500;cursor:pointer;">Cancel</button>'
+    +   '<button type="button" id="cs-aw-save" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #11443B;background:#11443B;color:#fff;font-size:14px;font-weight:500;cursor:pointer;">Start watching</button>'
     + '</div>'
     + '<div style="font-size:11px;color:#8A8170;text-align:center;margin-top:12px;">You can pause or stop any watch anytime in Settings.</div>';
 
@@ -20979,7 +20979,7 @@ function promptNewRecordsWatchOptIn(personId, hospitalName) {
 
   sheet.innerHTML = ''
     + '<div style="display:flex;align-items:flex-start;gap:12px;margin-bottom:14px;">'
-    +   '<div style="width:38px;height:38px;border-radius:12px;background:#EDF3EE;color:#2F4A3A;display:flex;align-items:center;justify-content:center;flex-shrink:0;">'
+    +   '<div style="width:38px;height:38px;border-radius:12px;background:#EDF3EE;color:#11443B;display:flex;align-items:center;justify-content:center;flex-shrink:0;">'
     +     '<i data-lucide="bell" style="width:18px;height:18px;"></i>'
     +   '</div>'
     +   '<div style="flex:1;min-width:0;">'
@@ -20988,12 +20988,12 @@ function promptNewRecordsWatchOptIn(personId, hospitalName) {
     +   '</div>'
     + '</div>'
     + '<label style="display:flex;align-items:center;gap:10px;padding:12px 14px;background:#fff;border:1px solid #E5DFD2;border-radius:12px;margin-bottom:16px;cursor:pointer;-webkit-tap-highlight-color:transparent;">'
-    +   '<input type="checkbox" id="nr-watch-cb" checked style="width:18px;height:18px;accent-color:#2F4A3A;flex-shrink:0;">'
+    +   '<input type="checkbox" id="nr-watch-cb" checked style="width:18px;height:18px;accent-color:#11443B;flex-shrink:0;">'
     +   '<span style="font-size:14px;color:#1F2A22;">Notify me when new records arrive</span>'
     + '</label>'
     + '<div style="display:flex;gap:10px;">'
-    +   '<button type="button" id="nr-watch-skip" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #C9D5CD;background:transparent;color:#2F4A3A;font-size:14px;font-weight:500;cursor:pointer;-webkit-tap-highlight-color:transparent;">Not now</button>'
-    +   '<button type="button" id="nr-watch-ok" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #2F4A3A;background:#2F4A3A;color:#fff;font-size:14px;font-weight:500;cursor:pointer;-webkit-tap-highlight-color:transparent;">Got it</button>'
+    +   '<button type="button" id="nr-watch-skip" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #C9D5CD;background:transparent;color:#11443B;font-size:14px;font-weight:500;cursor:pointer;-webkit-tap-highlight-color:transparent;">Not now</button>'
+    +   '<button type="button" id="nr-watch-ok" style="flex:1;padding:12px 14px;border-radius:11px;border:1px solid #11443B;background:#11443B;color:#fff;font-size:14px;font-weight:500;cursor:pointer;-webkit-tap-highlight-color:transparent;">Got it</button>'
     + '</div>'
     + '<div style="font-size:11px;color:#8A8170;text-align:center;margin-top:12px;">You can change this anytime under Settings \u203A What I\u2019m watching.</div>';
 

--- a/index.html
+++ b/index.html
@@ -49,24 +49,24 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 <link rel="stylesheet" href="/assets/wellet.css?v=20260527-1815">
-<link rel="stylesheet" href="/assets/editorial-foundation.css">
+<link rel="stylesheet" href="/assets/editorial-foundation.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-auth.css?v=20260507-1515">
 <link rel="stylesheet" href="/assets/editorial-updates.css">
-<link rel="stylesheet" href="/assets/editorial-records.css?v=20260520-0320">
-<link rel="stylesheet" href="/assets/editorial-ask.css?v=20260501-1635">
+<link rel="stylesheet" href="/assets/editorial-records.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-ask.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-sheets.css">
-<link rel="stylesheet" href="/assets/editorial-er.css">
-<link rel="stylesheet" href="/assets/editorial-people.css">
-<link rel="stylesheet" href="/assets/editorial-people-view.css?v=20260501-1610">
-<link rel="stylesheet" href="/assets/editorial-signals-view.css?v=20260514-1900">
-<link rel="stylesheet" href="/assets/editorial-resources-view.css?v=20260501-1505">
-<link rel="stylesheet" href="/assets/editorial-reimbursements.css?v=20260610-1200">
-<link rel="stylesheet" href="/assets/editorial-timeline.css?v=20260514-1620">
-<link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260531-dismiss">
-<link rel="stylesheet" href="/assets/editorial-upcoming.css">
+<link rel="stylesheet" href="/assets/editorial-er.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-people.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-people-view.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-signals-view.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-resources-view.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-reimbursements.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-timeline.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-upcoming.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-connect-progress.css?v=20260528-1418">
-<link rel="stylesheet" href="/assets/wellet-v2-tokens.css">
-<link rel="stylesheet" href="/assets/try-flow.css">
+<link rel="stylesheet" href="/assets/wellet-v2-tokens.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/try-flow.css?v=20260623-v201">
 </head>
 <body>
 <div class="page-wrap">


### PR DESCRIPTION
## Why

PR #141 fixed editorial-*.css fallback drift, but the person-switcher on the Home/Summary surface still rendered v1 warm-tan + sage in production. Audit revealed three gaps the original sweep missed.

## Gaps closed

### 1. try-flow.css (19 fallback replacements)
Same drift pattern as editorial-*.css. Was excluded from PR #141's `editorial-*.css` glob. Now normalized via the same sweep.

### 2. Bare-hex sage stragglers (5 sites)
Five inline `#2F4A3A` (old sage moss-deep) hexes not behind any token, routed through `var(--moss-deep, #11443B)`:
- `editorial-ask.css` 604, 653 (.watch-row-icon, .watch-row-status-active)
- `editorial-signals-view.css` 186 (.watch-row-status-active)
- `editorial-signals-view.css` 379 (.cs-aw-card:checked)
- `editorial-signals-view.css` 426 (.cs-aw-params input:focus)

### 3. wellet.js inline-style sage (9 sites)
Bulk replace `#2F4A3A` → `#11443B` inside JS-rendered modal markup (add-watch button, new-record watch button). Background tints (`#EDF3EE`, `#F5FAF6`, `#C9D5CD`) intentionally kept — they're Mint-family washes that work against Stone canvas.

### 4. reimb-confidence fallback refresh
`--reimb-confidence-medium` fallback `#3C362F` → `#2D2A24` (ink-7 canon)
`--reimb-confidence-low` fallback `#8A8278` → `#7E796F` (ink-4 canon)
Plus matching `rgba()` shadows updated to neutral values.

### 5. `--core-color-walnut` typo fix
`wellet-v2-tokens.css` line 38: `#552d27` → `#B8392B` (canonical Walnut per brand kit). The wrong value would render as a dark burgundy instead of the soft alert tone.

### 6. CRITICAL — Cache-bust string sync
**The actual user-visible bug right now.** Bumped `?v=` strings on every CSS file touched in PR #141 + this PR to `?v=20260623-v201`. Without this, browsers serve stale CSS from cache and the v2.01 fix never reaches users until they hard-refresh.

Touched: `editorial-foundation`, `editorial-records`, `editorial-ask`, `editorial-er`, `editorial-people`, `editorial-people-view`, `editorial-signals-view`, `editorial-resources-view`, `editorial-reimbursements`, `editorial-timeline`, `editorial-caresignals`, `editorial-upcoming`, `wellet-v2-tokens`, `try-flow` (14 strings).

## Expected visual outcome

Every surface — Home/Summary, CareSignals, Records, Updates, Timeline, ER, Ask, Reimbursements, Resources, Upcoming, People — now renders Forest underline on the active person tab, neutral ink-9 on the active name, cool ink-5 on inactive. Brand v2.01 fully consistent across the app on next page load (no hard-refresh required).

## What did NOT change

- No structural CSS/JS changes
- No new selectors or rules
- `wellet.css` (legacy token file) untouched
- No new `!important` declarations

50 insertions / 50 deletions across 7 files.

— Mabel