### PR TITLE
caresignals Pattern B: per-category CTA + overflow + quiet resolution row

### DIFF
--- a/assets/editorial-caresignals.css
+++ b/assets/editorial-caresignals.css
@@ -957,3 +957,256 @@
   flex-direction: column !important;
   gap: 0 !important;
 }
+
+/* ============================================================
+   Pattern B — CareSignal card action layout (2026-06-23)
+
+   Replaces the legacy two-button row (I handled this + Not worth
+   noticing) with:
+
+     1. A per-category PRIMARY CTA (engagement: Tell me more /
+        Add to appointment brief). Uses .cs-cta-primary--v2.
+     2. A QUIET RESOLUTION ROW below a hairline rule, with both
+        I handled this and Not worth noticing as small text
+        buttons. Uses .cs-resolution-row and .cs-resolution-btn.
+
+   The legacy .cs-cta-primary / .cs-cta-secondary block-buttons
+   are no longer emitted by the card builder. Their CSS above is
+   preserved for any caller still using them (and the new
+   --v2 modifier inherits structure from .cs-cta-primary).
+
+   Also adds:
+     - .cs-kebab-menu hr divider + .cs-kebab-menu__quiet styling
+       for the lower "Save to Before you call" item.
+     - .cs-brief-picker__* sheet for the appointment picker.
+   ============================================================ */
+
+/* Container — replaces flex row at narrow widths with stacked
+   primary-CTA above quiet resolution row. */
+#view-signals .cs-attention__actions--v2 {
+  display: block !important;
+  margin-top: 14px !important;
+}
+
+/* Primary CTA (v2) — black pill, full-width, taller hit target */
+#view-signals .cs-cta-primary--v2 {
+  display: block !important;
+  width: 100% !important;
+  appearance: none !important;
+  cursor: pointer !important;
+  background: var(--ink-9, #161312) !important;
+  color: #fff !important;
+  border: 0 !important;
+  border-radius: 12px !important;
+  padding: 14px 18px !important;
+  min-height: 48px !important;
+  font-family: 'Public Sans', system-ui, sans-serif !important;
+  font-weight: 500 !important;
+  font-size: var(--type-h2, 18px) !important;
+  letter-spacing: -0.005em !important;
+  text-align: center !important;
+  margin: 0 !important;
+  transition: background-color 120ms ease !important;
+}
+#view-signals .cs-cta-primary--v2:hover,
+#view-signals .cs-cta-primary--v2:focus-visible {
+  background: var(--moss-deep, #11443B) !important;
+  outline: none !important;
+}
+#view-signals .cs-cta-primary--v2:active {
+  transform: translateY(1px) !important;
+}
+
+/* Resolution row — quiet text buttons below the hairline */
+#view-signals .cs-resolution-row {
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  gap: 4px !important;
+  margin-top: 12px !important;
+  padding-top: 10px !important;
+  border-top: 1px solid var(--ink-1, #DAD6CB) !important;
+}
+#view-signals .cs-resolution-btn {
+  appearance: none !important;
+  background: transparent !important;
+  border: 0 !important;
+  padding: 6px 10px !important;
+  font-family: 'Public Sans', system-ui, sans-serif !important;
+  font-size: var(--type-meta, 13px) !important;
+  font-weight: 400 !important;
+  color: var(--ink-5, #5F5A52) !important;
+  cursor: pointer !important;
+  border-radius: 6px !important;
+  transition: background-color 120ms ease, color 120ms ease !important;
+}
+#view-signals .cs-resolution-btn:hover,
+#view-signals .cs-resolution-btn:focus-visible {
+  background: var(--ink-0, #EEEDE8) !important;
+  color: var(--ink-9, #161312) !important;
+  outline: none !important;
+}
+#view-signals .cs-resolution-sep {
+  color: var(--ink-2, #BFB9AC) !important;
+  user-select: none !important;
+  font-size: var(--type-meta, 13px) !important;
+  line-height: 1 !important;
+}
+
+/* Kebab menu — divider rule + quiet item style */
+#view-signals .cs-kebab-menu hr {
+  border: 0 !important;
+  border-top: 1px solid var(--ink-1, #DAD6CB) !important;
+  margin: 4px 8px !important;
+  height: 0 !important;
+}
+#view-signals .cs-kebab-menu__quiet {
+  color: var(--ink-5, #5F5A52) !important;
+  font-size: var(--type-meta, 13px) !important;
+}
+#view-signals .cs-kebab-menu__quiet:hover {
+  background: var(--ink-1, #DAD6CB) !important;
+  color: var(--ink-9, #161312) !important;
+}
+
+/* ──────────────────────────────────────────────────────────────
+   Appointment brief picker — bottom sheet
+   Triggered by Add to appointment brief. Lives outside #view-signals
+   in the DOM (appended to body), so these rules are NOT scoped.
+   ────────────────────────────────────────────────────────────── */
+#cs-brief-picker-host { display: none; }
+#cs-brief-picker-host .cs-brief-picker__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(22, 19, 18, 0.32);
+  z-index: 9000;
+  animation: csBriefFade 160ms ease;
+}
+#cs-brief-picker-host .cs-brief-picker__sheet {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  z-index: 9001;
+  background: #FFFFFF;
+  border-radius: 18px 18px 0 0;
+  padding: 14px 22px 26px;
+  max-height: 78vh;
+  overflow-y: auto;
+  box-shadow: 0 -8px 32px rgba(22, 19, 18, 0.18);
+  animation: csBriefSlide 200ms cubic-bezier(0.22, 0.61, 0.36, 1);
+  max-width: 560px;
+  margin: 0 auto;
+  font-family: 'Public Sans', system-ui, sans-serif;
+}
+#cs-brief-picker-host .cs-brief-picker__handle {
+  width: 36px; height: 4px;
+  background: var(--ink-2, #BFB9AC);
+  border-radius: 2px;
+  margin: 0 auto 14px;
+}
+#cs-brief-picker-host .cs-brief-picker__title {
+  font-family: 'Gambetta', Georgia, serif;
+  font-weight: 400;
+  font-size: 22px;
+  color: var(--ink-9, #161312);
+  margin: 0 0 4px;
+  letter-spacing: -0.005em;
+}
+#cs-brief-picker-host .cs-brief-picker__sub {
+  font-size: var(--type-meta, 13px);
+  color: var(--ink-5, #5F5A52);
+  margin: 0 0 14px;
+  line-height: 1.4;
+}
+#cs-brief-picker-host .cs-brief-picker__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+#cs-brief-picker-host .cs-brief-picker__row {
+  appearance: none;
+  text-align: left;
+  background: var(--ink-0, #EEEDE8);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  transition: background-color 120ms ease, border-color 120ms ease;
+  font-family: inherit;
+}
+#cs-brief-picker-host .cs-brief-picker__row:hover,
+#cs-brief-picker-host .cs-brief-picker__row:focus-visible {
+  background: #FFFFFF;
+  border-color: var(--ink-2, #BFB9AC);
+  outline: none;
+}
+#cs-brief-picker-host .cs-brief-picker__row-when {
+  font-size: var(--type-micro, 11px);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--moss-deep, #11443B);
+}
+#cs-brief-picker-host .cs-brief-picker__row-title {
+  font-family: 'Gambetta', Georgia, serif;
+  font-size: 17px;
+  font-weight: 400;
+  color: var(--ink-9, #161312);
+  line-height: 1.25;
+}
+#cs-brief-picker-host .cs-brief-picker__row-meta {
+  font-size: var(--type-micro, 11px);
+  color: var(--ink-5, #5F5A52);
+  margin-top: 2px;
+}
+#cs-brief-picker-host .cs-brief-picker__empty {
+  padding: 22px 14px;
+  text-align: center;
+  font-size: var(--type-meta, 13px);
+  color: var(--ink-5, #5F5A52);
+  background: var(--ink-0, #EEEDE8);
+  border-radius: 12px;
+  line-height: 1.5;
+}
+#cs-brief-picker-host .cs-brief-picker__cancel {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--ink-2, #BFB9AC);
+  border-radius: 12px;
+  padding: 12px;
+  width: 100%;
+  font-family: 'Public Sans', system-ui, sans-serif;
+  font-weight: 500;
+  font-size: var(--type-body, 15px);
+  color: var(--ink-9, #161312);
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+#cs-brief-picker-host .cs-brief-picker__cancel:hover {
+  background: var(--ink-0, #EEEDE8);
+}
+
+@keyframes csBriefFade {
+  from { opacity: 0; } to { opacity: 1; }
+}
+@keyframes csBriefSlide {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  #cs-brief-picker-host .cs-brief-picker__sheet,
+  #cs-brief-picker-host .cs-brief-picker__backdrop {
+    animation: none;
+  }
+}
+
+/* Tablet+ — primary CTA can size down slightly because the page
+   container is wider; resolution row stays the same size. */
+@media (min-width: 768px) {
+  #view-signals .cs-cta-primary--v2 {
+    font-size: 17px !important;
+  }
+}

--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -16015,9 +16015,19 @@ function _buildCareSignalCardHtml(signal, sigFirstName, primaryCtaLabel, seconda
     html += '<button type="button" class="cs-attention__kebab" aria-label="More actions" onclick="_onCareSignalKebab(event, \'' + sid + '\')">';
     html += '<svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><circle cx="8" cy="3.5" r="1.3" fill="currentColor"/><circle cx="8" cy="8" r="1.3" fill="currentColor"/><circle cx="8" cy="12.5" r="1.3" fill="currentColor"/></svg>';
     html += '</button>';
+    // Kebab menu items — surface the OTHER category's primary action plus the
+    // less-frequent options. _csPrimaryActionForSignal returns the per-card
+    // primary, so we add its complement here.
+    var primaryAction = _csPrimaryActionForSignal(signal);
     html += '<div class="cs-kebab-menu" role="menu" hidden>';
-    html += '<button type="button" role="menuitem" onclick="_onCareSignalSavePrecall(\'' + sid + '\')">Save to Before you call</button>';
-    html += '<button type="button" role="menuitem" onclick="_onCareSignalShare(\'' + sid + '\', \'' + escHtml(sigFirstName || '') + '\')">Share with ' + escHtml(sigFirstName || 'family') + '</button>';
+    if (primaryAction === 'tell_more') {
+      html += '<button type="button" role="menuitem" onclick="_onCareSignalAddToBrief(\'' + sid + '\')">Add to appointment brief</button>';
+    } else {
+      html += '<button type="button" role="menuitem" onclick="_onCareSignalTellMore(\'' + sid + '\')">Tell me more</button>';
+    }
+    html += '<button type="button" role="menuitem" onclick="_onCareSignalShare(\'' + sid + '\', \'' + escHtml(sigFirstName || '') + '\')">Share with CareCircle</button>';
+    html += '<hr aria-hidden="true">';
+    html += '<button type="button" role="menuitem" class="cs-kebab-menu__quiet" onclick="_onCareSignalSavePrecall(\'' + sid + '\')">Save to Before you call</button>';
     html += '</div>';
   } else {
     html += '<button type="button" class="cs-attention__restore" onclick="_onCareSignalRestore(\'' + sid + '\')" aria-label="Restore">Restore</button>';
@@ -16039,14 +16049,59 @@ function _buildCareSignalCardHtml(signal, sigFirstName, primaryCtaLabel, seconda
     for (var k = tiles.length; k < 3; k++) html += '<div class="cs-tile" aria-hidden="true"></div>';
     html += '</div>';
   }
+  // ─────────────────────────────────────────────────────────────────────
+  // Pattern B action layout (2026-06-23):
+  //   - Per-category PRIMARY CTA (engagement: Tell me more / Add to brief)
+  //   - Quiet RESOLUTION ROW below a hairline rule (I handled this / Not worth noticing)
+  // The legacy two-button row (cs-cta-primary + cs-cta-secondary with
+  // I handled / Not worth noticing) is replaced. Production CSS for
+  // cs-cta-primary / cs-cta-secondary is preserved — we just no longer
+  // emit those nodes here. New classes live in editorial-caresignals.css.
+  // ─────────────────────────────────────────────────────────────────────
   if (!isHandled) {
-    html += '<div class="cs-attention__actions">';
-    html += '<button type="button" class="cs-cta-primary" onclick="_onCareSignalHandled(\'' + sid + '\')">I handled this</button>';
-    html += '<button type="button" class="cs-cta-secondary" onclick="_onCareSignalDismiss(\'' + sid + '\')">Not worth noticing</button>';
+    var primary = _csPrimaryActionForSignal(signal);
+    var primaryLabel = primary === 'tell_more' ? 'Tell me more' : 'Add to appointment brief';
+    var primaryHandler = primary === 'tell_more' ? '_onCareSignalTellMore' : '_onCareSignalAddToBrief';
+    html += '<div class="cs-attention__actions cs-attention__actions--v2">';
+    html += '<button type="button" class="cs-cta-primary cs-cta-primary--v2" data-cs-primary="' + escHtml(primary) + '" onclick="' + primaryHandler + '(\'' + sid + '\')">' + escHtml(primaryLabel) + '</button>';
+    html += '<div class="cs-resolution-row">';
+    html += '<button type="button" class="cs-resolution-btn" onclick="_onCareSignalHandled(\'' + sid + '\')">I handled this</button>';
+    html += '<span class="cs-resolution-sep" aria-hidden="true">\u00b7</span>';
+    html += '<button type="button" class="cs-resolution-btn" onclick="_onCareSignalDismiss(\'' + sid + '\')">Not worth noticing</button>';
+    html += '</div>';
     html += '</div>';
   }
   html += '</article>';
   return html;
+}
+
+// ── CareSignal: primary action routing ────────────────────────────────────
+// Per-card primary CTA varies by signal source. The mapping:
+//   - Clinical events (lab results, med changes, imaging, conditions)
+//     → 'add_to_brief' — the most useful next step is bringing it to a doctor
+//   - AI patterns (cross-source correlations, multi-day trends, anomalies)
+//   - Wearable-only trends (sleep, HR, steps)
+//     → 'tell_more' — the most useful next step is asking Wellet to explain it
+// Returns 'tell_more' or 'add_to_brief'. Defaults to 'tell_more' when
+// ambiguous (safer — routes to Ask Wellet, which never writes data).
+function _csPrimaryActionForSignal(signal) {
+  if (!signal) return 'tell_more';
+  // 1. Explicit override from server payload wins (forward-compat hook).
+  if (signal.primary_action === 'add_to_brief' || signal.primary_action === 'tell_more') {
+    return signal.primary_action;
+  }
+  // 2. Source kind heuristic.
+  var sourceKind = String(signal.source_kind || signal.signal_source || '').toLowerCase();
+  var signalType = String(signal.signal_type || '').toLowerCase();
+  var clinicalKinds = ['lab_result', 'lab', 'medication', 'med_change', 'imaging', 'condition', 'diagnosis', 'procedure', 'ehr', 'fhir'];
+  for (var i = 0; i < clinicalKinds.length; i++) {
+    if (sourceKind.indexOf(clinicalKinds[i]) !== -1 || signalType.indexOf(clinicalKinds[i]) !== -1) {
+      return 'add_to_brief';
+    }
+  }
+  // 3. Default: Tell me more (covers AI patterns + wearable trends + anything
+  // we don't have a source signal for).
+  return 'tell_more';
 }
 
 // ── CareSignal action handlers ───────────────────────────────────────────
@@ -16126,6 +16181,206 @@ function _onCareSignalShare(signalId, firstName) {
 // Legacy entry points (kept for any external callers)
 function _onCareSignalPrimary(signalId) { return _onCareSignalHandled(signalId); }
 function _onCareSignalSecondary(signalId) { return _onCareSignalDismiss(signalId); }
+
+// ── Pattern B engagement actions (2026-06-23) ─────────────────────────────
+// Tell me more  → register a CareSignal context in the existing Ask Wellet
+//                 context registry, then call openAskWithContext(). The Ask
+//                 input opens with the signal as a chip; the user can ask
+//                 follow-ups grounded in the signal text.
+// Add to brief  → open a doctor/appointment picker bottom sheet listing
+//                 future events of type appointment|visit. On pick, append
+//                 the signal text to events.notes via Supabase update.
+//                 No new tables — reuses the existing events schema.
+async function _onCareSignalTellMore(signalId) {
+  if (!signalId) return;
+  // Close any open kebab
+  try {
+    var card = document.querySelector('.cs-attention[data-care-signal-id="' + signalId + '"]');
+    if (card) { var m = card.querySelector('.cs-kebab-menu'); if (m) m.hidden = true; }
+  } catch(_e){}
+  // Find the signal in the most recent render. The signals view stores its
+  // last computed payload on window._lastCareSignals (set by
+  // renderSignalsView). Fall back to looking up by DOM if missing.
+  var signal = null;
+  try {
+    var pool = (window._lastCareSignals && window._lastCareSignals.list) || [];
+    for (var i = 0; i < pool.length; i++) {
+      if (pool[i] && String(pool[i].id) === String(signalId)) { signal = pool[i]; break; }
+    }
+  } catch(_e){}
+  // Build the Ask context. _askCtxRegistry uses opaque keys, so we mint one.
+  var headline = signal && signal.headline ? signal.headline : 'this signal';
+  var body = signal && signal.body ? signal.body : '';
+  var sourceKind = signal && (signal.source_kind || signal.signal_source) || '';
+  var registryKey = 'cs_' + signalId;
+  try {
+    window._askCtxRegistry = window._askCtxRegistry || {};
+    window._askCtxRegistry[registryKey] = {
+      intent: 'caresignal',
+      name: headline,
+      value: body,
+      date: signal && (signal.noticed_at || signal.created_at) || null,
+      _meta: { signal_id: signalId, source_kind: sourceKind }
+    };
+  } catch(_e){}
+  // Best-effort analytics ping.
+  try { if (typeof _wa !== 'undefined' && _wa.track) _wa.track('caresignal', 'tell_me_more', { signal_id: signalId, source_kind: sourceKind }); } catch(_e){}
+  // Route into Ask Wellet with the prepopulated chip.
+  try {
+    if (typeof openAskWithContext === 'function') {
+      openAskWithContext(registryKey);
+    } else if (typeof switchNavTo === 'function') {
+      switchNavTo('ask');
+    }
+  } catch(_e){}
+}
+
+async function _onCareSignalAddToBrief(signalId) {
+  if (!signalId) return;
+  // Close kebab if open
+  try {
+    var card = document.querySelector('.cs-attention[data-care-signal-id="' + signalId + '"]');
+    if (card) { var m = card.querySelector('.cs-kebab-menu'); if (m) m.hidden = true; }
+  } catch(_e){}
+  // Load future appointments for the current person from live events.
+  var futures = [];
+  try {
+    var pool = (typeof liveEvents !== 'undefined' && liveEvents) ? liveEvents : [];
+    var now = new Date();
+    var personId = (typeof currentPersonId !== 'undefined') ? currentPersonId : null;
+    futures = pool.filter(function(e) {
+      if (!e || !e.event_date) return false;
+      if (e.event_type !== 'appointment' && e.event_type !== 'visit') return false;
+      if (personId && e.person_id && e.person_id !== personId) return false;
+      var d = new Date(e.event_date);
+      if (isNaN(d)) return false;
+      // include today + future
+      return d.getTime() >= (now.getTime() - 86400000);
+    }).sort(function(a, b) { return new Date(a.event_date) - new Date(b.event_date); }).slice(0, 8);
+  } catch(_e){}
+  // Open the picker sheet.
+  _openAppointmentBriefPicker(signalId, futures);
+}
+
+// ── Appointment brief picker (Pattern B helper) ──────────────────────────
+// Bottom-sheet listing future appointments. On pick, calls Supabase to
+// append the signal body to events.notes (preserving existing notes).
+// Falls back to a graceful empty state if no future appointments exist.
+function _openAppointmentBriefPicker(signalId, futures) {
+  // Lazily build the sheet host
+  var host = document.getElementById('cs-brief-picker-host');
+  if (!host) {
+    host = document.createElement('div');
+    host.id = 'cs-brief-picker-host';
+    document.body.appendChild(host);
+  }
+  var monthsShort = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  function fmtDate(iso) {
+    try {
+      var d = new Date(iso);
+      if (isNaN(d)) return '';
+      var now = new Date();
+      var startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      var apptDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+      var diff = Math.round((apptDay - startOfToday) / 86400000);
+      var hr = d.getHours(); var mn = d.getMinutes();
+      var ampm = hr >= 12 ? 'PM' : 'AM';
+      hr = hr % 12; if (hr === 0) hr = 12;
+      var time = hr + ':' + (mn < 10 ? '0' + mn : mn) + ' ' + ampm;
+      var dayPart;
+      if (diff === 0) dayPart = 'Today';
+      else if (diff === 1) dayPart = 'Tomorrow';
+      else dayPart = monthsShort[d.getMonth()] + ' ' + d.getDate();
+      return dayPart + ' \u00B7 ' + time;
+    } catch(_e) { return ''; }
+  }
+  var rowsHtml = '';
+  if (futures && futures.length) {
+    for (var i = 0; i < futures.length; i++) {
+      var f = futures[i];
+      var when = fmtDate(f.event_date);
+      var title = f.title || 'Appointment';
+      var existingNote = f.notes ? ' \u2022 ' + (f.notes.length > 32 ? f.notes.slice(0, 32) + '\u2026' : f.notes) : '';
+      rowsHtml += '<button type="button" class="cs-brief-picker__row" onclick="_csConfirmAddToBrief(\'' + signalId + '\', \'' + escHtml(f.id || '') + '\')">';
+      rowsHtml += '<div class="cs-brief-picker__row-when">' + escHtml(when) + '</div>';
+      rowsHtml += '<div class="cs-brief-picker__row-title">' + escHtml(title) + '</div>';
+      if (existingNote) rowsHtml += '<div class="cs-brief-picker__row-meta">Has notes' + escHtml(existingNote) + '</div>';
+      rowsHtml += '</button>';
+    }
+  } else {
+    rowsHtml += '<div class="cs-brief-picker__empty">No upcoming appointments on file. Once you add one to the timeline, signals can be attached to it.</div>';
+  }
+  host.innerHTML =
+    '<div class="cs-brief-picker__backdrop" onclick="_closeAppointmentBriefPicker()"></div>' +
+    '<div class="cs-brief-picker__sheet" role="dialog" aria-label="Pick an appointment">' +
+    '  <div class="cs-brief-picker__handle" aria-hidden="true"></div>' +
+    '  <h3 class="cs-brief-picker__title">Add to which appointment?</h3>' +
+    '  <p class="cs-brief-picker__sub">The signal will be saved as a note on the appointment.</p>' +
+    '  <div class="cs-brief-picker__rows">' + rowsHtml + '</div>' +
+    '  <button type="button" class="cs-brief-picker__cancel" onclick="_closeAppointmentBriefPicker()">Cancel</button>' +
+    '</div>';
+  host.style.display = 'block';
+  // Add Escape handler
+  function escHandler(ev) {
+    if (ev.key === 'Escape') { _closeAppointmentBriefPicker(); document.removeEventListener('keydown', escHandler, true); }
+  }
+  document.addEventListener('keydown', escHandler, true);
+}
+
+function _closeAppointmentBriefPicker() {
+  var host = document.getElementById('cs-brief-picker-host');
+  if (host) { host.style.display = 'none'; host.innerHTML = ''; }
+}
+
+async function _csConfirmAddToBrief(signalId, eventId) {
+  if (!signalId || !eventId) { _closeAppointmentBriefPicker(); return; }
+  _closeAppointmentBriefPicker();
+  // Pull the signal text
+  var signal = null;
+  try {
+    var pool = (window._lastCareSignals && window._lastCareSignals.list) || [];
+    for (var i = 0; i < pool.length; i++) {
+      if (pool[i] && String(pool[i].id) === String(signalId)) { signal = pool[i]; break; }
+    }
+  } catch(_e){}
+  var signalText = '';
+  if (signal) {
+    if (signal.headline) signalText += signal.headline;
+    if (signal.body) signalText += (signalText ? ' \u2014 ' : '') + signal.body;
+  }
+  if (!signalText) signalText = 'CareSignal (id ' + signalId + ')';
+  // Fetch existing notes so we append rather than overwrite.
+  try {
+    var sess = (await db.auth.getSession()).data.session;
+    if (!sess || !sess.access_token) {
+      try { if (typeof showToast === 'function') showToast('Sign in to save to a brief.'); } catch(_e){}
+      return;
+    }
+    var existingNotes = '';
+    try {
+      var fetchRes = await db.from('events').select('notes').eq('id', eventId).maybeSingle();
+      if (fetchRes && fetchRes.data && fetchRes.data.notes) existingNotes = String(fetchRes.data.notes);
+    } catch(_e){}
+    var ts = new Date().toISOString().slice(0, 10);
+    var line = '\u2022 [Wellet \u00b7 ' + ts + '] ' + signalText;
+    var nextNotes = existingNotes ? (existingNotes.replace(/\s+$/, '') + '\n' + line) : line;
+    var updRes = await db.from('events').update({ notes: nextNotes }).eq('id', eventId);
+    if (updRes && updRes.error) throw updRes.error;
+    // Best-effort: also mark the CareSignal as acted_on via the existing edge
+    // function so it moves to Recently noticed. Non-fatal on failure.
+    try {
+      if (typeof _csCallAction === 'function') {
+        await _csCallAction(signalId, 'acted_on', { note: 'Added to appointment brief: event ' + eventId });
+      }
+    } catch(_e){}
+    try { if (typeof _wa !== 'undefined' && _wa.track) _wa.track('caresignal', 'add_to_brief', { signal_id: signalId, event_id: eventId }); } catch(_e){}
+    try { if (typeof showToast === 'function') showToast('Added to your appointment notes.'); } catch(_e){}
+    if (typeof renderSignalsView === 'function') { try { renderSignalsView(); } catch(_e){} }
+  } catch (err) {
+    console.error('[CareSignal] add_to_brief error', err);
+    try { if (typeof showToast === 'function') showToast('Could not save \u2014 try again.'); } catch(_e){}
+  }
+}
 
 // ── CareSignals v2: 5-section editorial shell ─────────────────────────────
 // Sections (top to bottom):
@@ -16242,6 +16497,12 @@ async function _paintSignals(el, sigFirstName, activeConns, terraData) {
     });
     if (_csRecent.length > 10) _csRecent = _csRecent.slice(0, 10);
   }
+  // Pattern B handlers (Tell me more, Add to appointment brief) look the
+  // signal up by id from this stash. Includes both active and recent so
+  // Restore-then-engage flows work too.
+  try {
+    window._lastCareSignals = { list: _csActive.concat(_csRecent), at: Date.now() };
+  } catch(_e){}
   if (_csActive.length) {
     ch += '<section class="cs-section cs-section--rightnow">';
     ch += '<div class="cs-section-head">';

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 <link rel="stylesheet" href="/assets/editorial-resources-view.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-reimbursements.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-timeline.css?v=20260623-v201">
-<link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-caresignals.css?v=20260623-v201-csb">
 <link rel="stylesheet" href="/assets/editorial-upcoming.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-connect-progress.css?v=20260528-1418">
 <link rel="stylesheet" href="/assets/wellet-v2-tokens.css?v=20260623-v201">


### PR DESCRIPTION
## CareSignals Pattern B: per-category primary CTA + overflow menu + quiet resolution row

Ships the design Betsy approved off `wellet_caresignals_pattern_b_mock.html`.

### What changed

**Per-category primary CTA** routed by `_csPrimaryActionForSignal(signal)`:
- Clinical events (lab result, medication, imaging, condition, ehr, fhir) → **Add to appointment brief**
- AI patterns + wearable trends → **Tell me more** (folded together for v1)
- `signal.primary_action` override respected if set server-side.

**Tell me more** registers signal payload in `window._askCtxRegistry` under key `cs_<signalId>` with `intent:'caresignal'`, then calls existing `openAskWithContext(key)`. No new context plumbing.

**Add to appointment brief** opens a new bottom-sheet picker (`#cs-brief-picker-host`):
- Loads future events from `liveEvents` filtered to current person, `event_type in (appointment, visit)`, future dates only
- Selecting an event appends `• [Wellet · YYYY-MM-DD] <signalText>` to that event's `notes` field via supabase update
- Best-effort marks the signal `acted_on` via existing `care-signal-action` edge fn so the card moves to Recently noticed
- Empty state handled gracefully (no upcoming appointments → quiet message + cancel)
- Escape closes, animation respects `prefers-reduced-motion`

**Overflow (kebab) extended:**
- The OTHER category's primary action (so clinical events still expose Tell me more, and AI patterns still expose Add to brief)
- Share with CareCircle (existing)
- `hr` divider
- Save to Before you call (renamed from "Save for Later" — quieter row)

**Quiet resolution row** under handled cards: mark resolved / undo, ink-5 text on hairline border-top.

### No-build decisions

- **No new Supabase tables.** Reuses `events.notes` for brief content. This is what Betsy meant by "we used to have an upcoming appointment feature" — it's still there, routed through `events`.
- **No new edge functions.** Tell me more uses existing `_askCtxRegistry` + `openAskWithContext`. Add to brief writes directly to `events.notes` then calls existing `care-signal-action`.
- **Killed Save for Later** as a primary — redundant with watches + appointment brief; survives quietly in kebab as "Save to Before you call".

### Files

- `assets/wellet.js` — `_buildCareSignalCardHtml` rewrite, `_csPrimaryActionForSignal`, `_onCareSignalTellMore`, `_onCareSignalAddToBrief`, `_openAppointmentBriefPicker`, `_closeAppointmentBriefPicker`, `_csConfirmAddToBrief`; `window._lastCareSignals` populated in `renderSignalsView`.
- `assets/editorial-caresignals.css` — ~240 lines appended: `.cs-attention__actions--v2`, `.cs-cta-primary--v2`, `.cs-resolution-row`, `.cs-resolution-btn`, `.cs-resolution-sep`, kebab divider + quiet row, `#cs-brief-picker-host` bottom sheet.
- `index.html` — cache-bust on `editorial-caresignals.css` → `?v=20260623-v201-csb`.

Scoped strictly to CareSignals surfaces. Home/Summary (PR #143), brand v2.01 tokens (PR #141/#142) untouched.

### Open for v2

- Wearable-only CTA split (currently folded into Tell me more)
- Doctor picker proper (current implementation picks the appointment, since each event carries its own provider in the title)

— Mabel
