### PR TITLE
Brand v2.01: Forest summary stripe, retire amber/terra fossils

### DIFF
--- a/assets/editorial-updates.css
+++ b/assets/editorial-updates.css
@@ -605,11 +605,14 @@ body:has(#view-home[data-editorial="updates"]) #header-tab-bar.tab-bar .tab.acti
   font-weight: 500;
 }
 
-/* ---- 2. Update summary card: Option B (white + Mint hairline) ---- */
+/* ---- 2. Update summary card: white + Forest structural hairline ----
+   Mint is an accent, never structural. Switched 3px left rule from Mint
+   (--signal-fresh) to Forest (--moss-deep) so the card reads calm against
+   Stone instead of candy-bright. */
 #view-home[data-editorial="updates"] .update-summary-card {
   background: #FFFFFF;
   border: 1px solid var(--ink-1, #DAD6CB);
-  border-left: 3px solid var(--signal-fresh, #9ECF90);
+  border-left: 3px solid var(--moss-deep, #11443B);
   border-radius: 14px;
   padding: 18px 20px 14px;
   margin: 4px 0 18px;

--- a/assets/wellet.css
+++ b/assets/wellet.css
@@ -709,7 +709,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: var(--amber, #E8A020);
+    background: var(--amber);
     border: 1.5px solid white;
   }
   /* Detail view back bar + content */
@@ -815,13 +815,13 @@
   .update-meta { font-size: var(--type-micro); color: var(--text-muted); margin-top: 10px; display: flex; align-items: center; gap: 6px; }
   .update-meta a { color: var(--moss); font-weight: 500; text-decoration: none; cursor: pointer; }
 
-  .visit-prep-card { display:flex; align-items:center; gap:12px; margin:12px 20px 0; padding:13px 14px; background:var(--amber-bg); border:1px solid rgba(201,123,44,0.2); border-radius:12px; }
-  .visit-prep-icon { width:32px; height:32px; border-radius:8px; background:rgba(201,123,44,0.15); display:flex; align-items:center; justify-content:center; color:var(--amber); flex-shrink:0; }
+  .visit-prep-card { display:flex; align-items:center; gap:12px; margin:12px 20px 0; padding:13px 14px; background:var(--amber-bg); border:1px solid var(--border-medium); border-radius:12px; }
+  .visit-prep-icon { width:32px; height:32px; border-radius:8px; background:rgba(17,68,59,0.10); display:flex; align-items:center; justify-content:center; color:var(--amber); flex-shrink:0; }
   .visit-prep-title { font-size:var(--type-meta); font-weight:600; color:var(--text-primary); }
   .visit-prep-sub { font-size:var(--type-micro); color:var(--amber-text); margin-top:2px; line-height:1.4; }
   .visit-prep-btn { margin-left:auto; flex-shrink:0; background:var(--amber); color:white; border:none; border-radius:8px; padding:7px 12px; font-size:var(--type-meta); font-weight:600; font-family:'Public Sans',sans-serif; cursor:pointer; }
 
-  .alert-banner { margin: 12px 20px 0; background: var(--amber-bg); border: 1px solid rgba(201,123,44,0.25); border-radius: 10px; padding: 12px 14px; display: flex; gap: 10px; align-items: flex-start; }
+  .alert-banner { margin: 12px 20px 0; background: var(--amber-bg); border: 1px solid var(--border-medium); border-radius: 10px; padding: 12px 14px; display: flex; gap: 10px; align-items: flex-start; }
   .alert-icon { color: var(--amber); flex-shrink: 0; margin-top: 1px; display: flex; }
   .alert-title { font-size: var(--type-meta); font-weight: 500; color: var(--amber-text); margin-bottom: 2px; }
   .alert-body { font-size: var(--type-meta); color: var(--text-secondary); line-height: 1.5; }
@@ -1412,7 +1412,7 @@
   @keyframes spin { to { transform: rotate(360deg); } }
 
   /* ── DEMO BADGE ── */
-  .demo-badge { background: var(--amber-bg); border: 1px solid rgba(201,123,44,0.3); color: var(--amber-text); font-size: var(--type-micro); font-weight: 500; padding: 2px 8px; border-radius: 10px; }
+  .demo-badge { background: var(--amber-bg); border: 1px solid var(--border-medium); color: var(--amber-text); font-size: var(--type-micro); font-weight: 500; padding: 2px 8px; border-radius: 10px; }
 
   /* ── DOCUMENT LIST ── */
   .doc-row { display: flex; align-items: center; gap: 12px; padding: 11px 14px; background: white; border: 1px solid var(--border); border-radius: 10px; margin-bottom: 6px; cursor: pointer; transition: border-color 0.15s; }
@@ -2193,13 +2193,15 @@
   .plan-card-meta { font-size: var(--type-meta); color: var(--text-secondary); line-height: 1.5; margin-bottom: 10px; }
   .plan-card-action { display: inline-flex; align-items: center; gap: 5px; font-size: var(--type-meta); font-weight: 500; color: var(--moss-text); background: none; border: none; font-family: 'Public Sans', sans-serif; cursor: pointer; padding: 0; }
   .plan-card-action:hover { text-decoration: underline; }
-  /* Founding Member plan card — amber-tinted, more celebratory */
+  /* Founding Member plan card — Stone→Mint gradient, Forest accents.
+     v2.01 has no Terra; celebratory tone comes from the Mint-soft tint
+     and the Forest icon, not from a warm-orange palette. */
   .plan-card--founding {
-    background: linear-gradient(135deg, var(--color-amber-light, #f5e6d8) 0%, var(--mint) 100%);
-    border: 1px solid rgba(192, 112, 40, 0.25);
+    background: linear-gradient(135deg, var(--stone) 0%, var(--mint) 100%);
+    border: 1px solid var(--border-medium);
   }
   .plan-card-icon--founding {
-    background: var(--color-amber, #C07028);
+    background: var(--forest);
     color: white;
   }
   .founding-pill {
@@ -2210,22 +2212,22 @@
     padding: 3px 9px;
     border-radius: 11px;
     background: white;
-    color: var(--color-amber, #C07028);
+    color: var(--forest);
     font-size: var(--type-micro);
     font-weight: 600;
     line-height: 1.2;
-    border: 1px solid rgba(192, 112, 40, 0.25);
+    border: 1px solid var(--border-medium);
     font-family: 'Public Sans', sans-serif;
   }
   [data-theme="dark"] .plan-card--founding,
   body.dark .plan-card--founding {
-    background: linear-gradient(135deg, rgba(192, 112, 40, 0.2) 0%, rgba(61, 107, 94, 0.25) 100%);
-    border-color: rgba(192, 112, 40, 0.4);
+    background: linear-gradient(135deg, rgba(17,68,59,0.20) 0%, rgba(158,207,144,0.25) 100%);
+    border-color: rgba(17,68,59,0.40);
   }
   [data-theme="dark"] .founding-pill,
   body.dark .founding-pill {
     background: rgba(0,0,0,0.25);
-    border-color: rgba(192, 112, 40, 0.5);
+    border-color: rgba(17,68,59,0.50);
   }
 
   /* ── OFFLINE BANNER ── */

--- a/index.html
+++ b/index.html
@@ -48,10 +48,10 @@
 <script src="/lucide.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-<link rel="stylesheet" href="/assets/wellet.css?v=20260623-brand201">
+<link rel="stylesheet" href="/assets/wellet.css?v=20260623-brand201b">
 <link rel="stylesheet" href="/assets/editorial-foundation.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-auth.css?v=20260507-1515">
-<link rel="stylesheet" href="/assets/editorial-updates.css?v=20260623-v201-home">
+<link rel="stylesheet" href="/assets/editorial-updates.css?v=20260623-brand201b">
 <link rel="stylesheet" href="/assets/editorial-records.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-ask.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-sheets.css">


### PR DESCRIPTION
## Why

From Betsy on the home Summary card: "i don't think this color of green on the summary is on brand."

She was right — the left rule was Mint accent (`var(--signal-fresh, #9ECF90)`) doing a structural job. Mint is a v2.01 accent, never a 3px stripe. On Stone it reads candy-bright. Same pattern as the Terra ribbon: an accent color used as structure.

While in the codebase, swept the remaining warm-orange fossils that PR #149 didn't reach (audit items #6 and #7).

## What

### Summary stripe — Forest hairline (Option B from the mock)

`assets/editorial-updates.css:609-618` — `.update-summary-card` left rule now `var(--moss-deep)` Forest instead of Mint. Card reads calm against Stone.

### Fix #6 — `--amber` fossils

The `--amber`, `--amber-bg`, `--amber-text` tokens were already remapped to Mint/Stone/Forest at the top of the file, but four call sites still carried raw amber/terra rgba literals. Swept:

| File:line | Before | After |
|---|---|---|
| `wellet.css:712` (records-tile-dot) | `var(--amber, #E8A020)` | `var(--amber)` |
| `wellet.css:818` (visit-prep-card border) | `rgba(201,123,44,0.2)` | `var(--border-medium)` |
| `wellet.css:819` (visit-prep-icon bg) | `rgba(201,123,44,0.15)` | `rgba(17,68,59,0.10)` |
| `wellet.css:824` (alert-banner border) | `rgba(201,123,44,0.25)` | `var(--border-medium)` |
| `wellet.css:1415` (demo-badge border) | `rgba(201,123,44,0.3)` | `var(--border-medium)` |

### Fix #7 — Dark-mode terra remnant

`.plan-card--founding` (Founding Member card) was still a warm-orange gradient in both light and dark mode. Rebuilt against v2.01:

- light: `linear-gradient(135deg, var(--stone) 0%, var(--mint) 100%)`, border `var(--border-medium)`
- icon bg `var(--forest)`, pill text `var(--forest)`
- dark: gradient now Forest+Mint rgba alphas, borders Forest rgba

`var(--color-amber)` and `var(--color-amber-light)` were never defined anywhere in the repo — those were dead variable references with `#C07028` / `#f5e6d8` fallbacks. Gone.

## Cache-bust

- `wellet.css` → `?v=20260623-brand201b`
- `editorial-updates.css` → `?v=20260623-brand201b`

## Verification

```
grep -nE "rgba\(201|rgba\(192, ?112|#C07028|f5e6d8|signal-fresh.*9ECF90" assets/wellet.css assets/editorial-updates.css
→ no matches
```

Diff stat: 3 files, +23 / −18.

## Still deferred

- **Fix #3** italic-with-color sweep — 27 rules, needs your call on strict-no-color-italic vs no-italic-as-accent. The summary card's "Things are consistent" italic Forest verdict is in this bucket.
- **Fix #8** hex-literal consolidation — 263 hits, mostly the legitimate ink scale, but worth a careful pass with its own PR.
- **Ask Wellet 400** — diagnosed but not fixed. Edge function v38 is a pre-person-centric fossil, queries tables that don't exist. Needs a structural rewrite, not a patch. Held until after AARP per your call.

— Mabel
