### PR TITLE
Brand v2.01: strip color from italic emphasis (#3)

### DIFF
--- a/assets/editorial-auth.css
+++ b/assets/editorial-auth.css
@@ -92,7 +92,6 @@
 #auth-screen[data-editorial="auth"] .auth-headline h1 em {
   font-family: var(--serif);
   font-style: italic;
-  color: var(--moss-deep);
   font-variation-settings: "opsz" 36, "SOFT" 75, "WONK" 0;
 }
 @media (min-width: 768px) {

--- a/assets/editorial-records.css
+++ b/assets/editorial-records.css
@@ -396,12 +396,11 @@
   background: var(--signal-warm);
 }
 
-/* EHR provenance — small caption */
+/* EHR provenance — small caption (italic, inherits color) */
 #view-records[data-editorial="records"] .ehr-provider-badge {
   background: transparent !important;
   border: 0 !important;
   border-radius: 0 !important;
-  color: var(--moss-deep) !important;
   font-family: var(--serif) !important;
   font-style: italic !important;
   font-weight: 400 !important;

--- a/assets/editorial-updates.css
+++ b/assets/editorial-updates.css
@@ -109,7 +109,6 @@
   font-family: var(--serif);
   font-weight: 400;
   font-style: italic;
-  color: var(--moss-deep);
   font-variation-settings: "opsz" 14, "SOFT" 75;
 }
 
@@ -503,9 +502,8 @@
   font-variant-numeric: tabular-nums;
   margin: 0;
 }
-/* Inner span "From Duke Health (Epic)" — keep moss-deep italic */
+/* Inner span "From Duke Health (Epic)" — italic emphasis, inherits color */
 #view-home[data-editorial="updates"] .tl-card-date span {
-  color: var(--moss-deep) !important;
   font-style: italic;
   font-family: var(--serif);
   font-weight: 400 !important;
@@ -702,7 +700,6 @@ body:has(#view-home[data-editorial="updates"]) #header-tab-bar.tab-bar .tab.acti
   font-family: var(--serif, "Gambetta", Georgia, serif);
   font-weight: 400;
   font-style: italic;
-  color: var(--moss-deep, #11443B);
   font-variation-settings: "opsz" 14, "SOFT" 75;
 }
 
@@ -721,7 +718,6 @@ body:has(#view-home[data-editorial="updates"]) #header-tab-bar.tab-bar .tab.acti
   font-family: var(--serif, "Gambetta", Georgia, serif);
   font-weight: 400;
   font-style: italic;
-  color: var(--moss-deep, #11443B);
   font-variation-settings: "opsz" 14, "SOFT" 75;
 }
 

--- a/assets/wellet.css
+++ b/assets/wellet.css
@@ -61,7 +61,7 @@
 
   .auth-headline { padding: 12px 28px 0; }
   .auth-headline h1 { font-family: var(--serif); font-size: var(--type-display); line-height: 1.15; font-weight: 400; color: #2C2A26; margin: 0; }
-  .auth-headline h1 em { font-family: var(--serif); font-style: italic; color: #11443B; }
+  .auth-headline h1 em { font-family: var(--serif); font-style: italic; }
   .auth-description { padding: 10px 28px 0; font-size: var(--type-body); line-height: 1.5; color: #5A5A5A; font-weight: 300; }
   .auth-signals { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; padding: 14px 28px 0; }
   .auth-signal-card { background: white; border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
@@ -288,7 +288,6 @@
   }
   .manifesto-statement em {
     font-style: italic;
-    color: var(--moss-dark, #3D6B58);
   }
   @media (min-width: 720px) {
     .manifesto-band { padding: 36px 32px 38px; }
@@ -1331,7 +1330,7 @@
   /* ── P7: FRAUNCES TYPOGRAPHY CARRY-THROUGH ── */
   /* Note: getwellet.com marketing site Gambetta update assumed shipped per brief instructions */
   .auth-headline h1       { font-family: var(--font-display); font-variation-settings: 'opsz' 72; }
-  .auth-headline h1 em    { font-family: var(--font-display); font-style: italic; color: var(--moss); font-variation-settings: 'opsz' 72; }
+  .auth-headline h1 em    { font-family: var(--font-display); font-style: italic; font-variation-settings: 'opsz' 72; }
   .view-title             { font-family: var(--font-display); font-variation-settings: 'opsz' 36; }
   .notif-panel-title      { font-family: var(--font-display); font-variation-settings: 'opsz' 36; }
   .settings-title         { font-family: var(--font-display); font-variation-settings: 'opsz' 36; }
@@ -1932,7 +1931,6 @@
     font-family: var(--serif), 'Gambetta', serif;
     font-style: italic;
     font-size: var(--type-meta, 13px);
-    color: var(--moss-dark, #3F6356);
     margin: 0 0 14px;
     line-height: 1.5;
   }
@@ -1994,7 +1992,6 @@
     padding: 4px;
     background: transparent;
     border: none;
-    color: var(--moss-dark, #3F6356);
     font-family: 'Public Sans', sans-serif;
     font-size: var(--type-meta, 13px);
     font-style: italic;
@@ -2628,7 +2625,6 @@
   }
   .connect-data-headline em {
     font-style: italic;
-    color: #11443B;
     font-weight: 400;
   }
   .connect-data-sub {
@@ -3112,7 +3108,6 @@ input.story-input[type="date"]::-webkit-calendar-picker-indicator {
   font-family: var(--serif, 'Lora'), serif;
   font-style: italic;
   font-size: var(--type-meta);
-  color: var(--moss-dark, #3F6A52);
   line-height: 1.5;
   margin-bottom: 4px;
   text-align: center;
@@ -3207,7 +3202,6 @@ input.story-input[type="date"]::-webkit-calendar-picker-indicator {
   font-family: var(--serif, 'Lora'), serif;
   font-style: italic;
   font-size: var(--type-micro);
-  color: var(--moss-dark, #3F6A52);
 }
 
 .story-output-actions {

--- a/index.html
+++ b/index.html
@@ -48,11 +48,11 @@
 <script src="/lucide.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-<link rel="stylesheet" href="/assets/wellet.css?v=20260623-brand201b">
+<link rel="stylesheet" href="/assets/wellet.css?v=20260623-brand201c">
 <link rel="stylesheet" href="/assets/editorial-foundation.css?v=20260623-v201">
-<link rel="stylesheet" href="/assets/editorial-auth.css?v=20260507-1515">
-<link rel="stylesheet" href="/assets/editorial-updates.css?v=20260623-brand201b">
-<link rel="stylesheet" href="/assets/editorial-records.css?v=20260623-v201">
+<link rel="stylesheet" href="/assets/editorial-auth.css?v=20260623-brand201c">
+<link rel="stylesheet" href="/assets/editorial-updates.css?v=20260623-brand201c">
+<link rel="stylesheet" href="/assets/editorial-records.css?v=20260623-brand201c">
 <link rel="stylesheet" href="/assets/editorial-ask.css?v=20260623-v201">
 <link rel="stylesheet" href="/assets/editorial-sheets.css">
 <link rel="stylesheet" href="/assets/editorial-er.css?v=20260623-v201">


### PR DESCRIPTION
Resolves audit item #3 from the brand v2.01 consistency audit.

**Rule:** No italic color accent. Italic is allowed; pairing it with Forest / Moss-Dark / Moss-Deep to create emphasis is not.

## Audit

Searched all CSS in /assets/ for rules with both `font-style: italic` and a `color:` declaration.

| Total found | Violate | Keep |
|---|---|---|
| 29 | 14 | 15 |

The 15 KEEP rules pair italic with neutral ink-tier or muted-secondary text colors (var(--ink-5), var(--text-muted), Moss-Quiet) — that is secondary text, not color accent. Left alone.

## Changed

- `assets/wellet.css` — 8 rules
- `assets/editorial-updates.css` — 4 rules (includes the 'Things are consistent' verdict italic Betsy flagged)
- `assets/editorial-records.css` — 1 rule (.ehr-provider-badge)
- `assets/editorial-auth.css` — 1 rule (.auth-headline h1 em)
- `index.html` — cache-bust to `?v=20260623-brand201c` on the 4 touched CSS files

## Visual effect

Italic emphasis remains italic and Gambetta (or system serif). Color now inherits from the parent — typically ink. The 'Things are consistent' line on the summary card no longer reads as a colored accent; same for the auth headline `<em>` words.

## Out of scope

The 15 KEEP rules. Full classification: workspace/wellet_italic_color_audit.md.

— Mabel