### PR TITLE
GET-33: migrate generate-weekly-digest to Azure OpenAI adapter

### DIFF
--- a/supabase/functions/generate-weekly-digest/index.ts
+++ b/supabase/functions/generate-weekly-digest/index.ts
@@ -21,11 +21,15 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { SMTPClient } from "https://deno.land/x/denomailer@1.6.0/mod.ts";
 import { getCorsHeaders } from "../_shared/cors.ts";
+import { aiChat } from "../_shared/azureOpenAI.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
-const OPENAI_KEY = Deno.env.get("OPENAI_API_KEY") || "";
+// AI vendor + keys are now owned by ../_shared/azureOpenAI.ts.
+// PHI-touching summaries route through Azure OpenAI (BAA-covered) with
+// phi:true. The deterministic buildFallbackSummary path below stays as the
+// safety net if the adapter call fails for any reason.
 const SMTP_HOST = Deno.env.get("BREVO_SMTP_HOST") || "smtp-relay.brevo.com";
 // Hardcoded to 465 (implicit TLS / SMTPS). denomailer 1.6 + tls:true on 587
 // produces InvalidContentType (587 expects STARTTLS, not implicit TLS).
@@ -245,15 +249,16 @@ async function runForUser(
     return { status: "skipped_empty", reason: "no_activity_this_week" };
   }
 
-  // Summarize via OpenAI (falls back to deterministic copy if key not set).
+  // Summarize via Azure OpenAI (falls back to deterministic copy on any
+  // adapter error — network, vendor guardrail trip, deployment misconfig).
+  // The fallback path is what keeps the Sunday digest sending even if AI is
+  // briefly unavailable, so do not remove it.
   let summaryText = "";
-  if (OPENAI_KEY) {
-    try {
-      summaryText = await generateAISummary(ctx);
-    } catch (e) {
-      console.error("AI summary failed, falling back:", e);
-      summaryText = "";
-    }
+  try {
+    summaryText = await generateAISummary(ctx);
+  } catch (e) {
+    console.error("AI summary failed, falling back to deterministic:", e);
+    summaryText = "";
   }
   if (!summaryText) {
     summaryText = buildFallbackSummary(ctx);
@@ -413,28 +418,21 @@ Rules:
 - Close with one concrete next step (e.g., "Might be worth asking about X at the next visit") — frame as a question for the care team, never instructions.
 - Never recommend specific medications, dosages, or clinical actions.`;
 
-  const resp = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${OPENAI_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: context },
-      ],
-      temperature: 0.3,
-      max_tokens: 500,
-    }),
+  // PHI: weekly digest summarizes a loved one's health events, labs, meds,
+  // and vitals. phi:true engages the adapter's assertVendorAllowedForPhi
+  // guardrail — if WELLET_AI_VENDOR is ever flipped away from azure, this
+  // call throws and the caller falls back to buildFallbackSummary.
+  const result = await aiChat({
+    model: "gpt-4o-mini",
+    temperature: 0.3,
+    max_tokens: 500,
+    phi: true,
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: context },
+    ],
   });
-
-  if (!resp.ok) {
-    throw new Error(`OpenAI ${resp.status}: ${await resp.text()}`);
-  }
-  const data = await resp.json();
-  return (data.choices?.[0]?.message?.content || "").trim();
+  return (result.content || "").trim();
 }
 
 function esc(s: string): string {


### PR DESCRIPTION
## GET-33: migrate `generate-weekly-digest` to Azure OpenAI adapter

Second migration in the [GET-28](https://linear.app/getwellet/issue/GET-28) bundle. This one preserves the deterministic-fallback path (the safety net that keeps the Sunday digest sending even when AI is unavailable).

Refs: [GET-33](https://linear.app/getwellet/issue/GET-33) · parent [GET-28](https://linear.app/getwellet/issue/GET-28)

### What changes
1. Import `aiChat` from `../_shared/azureOpenAI.ts`
2. Drop the direct `OPENAI_API_KEY` env read — the adapter owns vendor selection
3. Rewrite the AI call inside `generateAISummary()` to use `aiChat({ ..., phi: true })`. The `phi: true` flag engages `assertVendorAllowedForPhi`.
4. Simplify the call-site guard: previously `if (OPENAI_KEY) { try { ... } catch }`, now always `try { ... } catch` because the adapter is always present in the codebase. **The deterministic fallback is unchanged.**

### Deterministic fallback — preserved exactly
`buildFallbackSummary(ctx)` is untouched (lines 344–359 of the current file). The caller still falls through to it whenever `generateAISummary` returns `""` or throws. Behavior matrix:

| Scenario | Old behavior | New behavior |
|---|---|---|
| AI succeeds | AI copy | AI copy |
| AI throws | Fallback copy | Fallback copy |
| OPENAI_API_KEY missing | Fallback copy (skipped AI) | Adapter throws (missing Azure key) → fallback copy |
| WELLET_AI_VENDOR flipped to non-BAA | n/a | Adapter throws via `assertVendorAllowedForPhi` → fallback copy |

Net effect: same-or-better. Deploys with a missing env no longer silently skip AI — they log the adapter error and still send the deterministic digest.

### What does NOT change
- Cron, preview, and single-user mode logic
- Service-role auth gate for cron/single mode
- 7-day data window and `last_weekly_digest_sent_at` 6-day dedup
- Per-person data pulls (events, labs, meds, vitals — all unchanged)
- The full system prompt including the "no medical advice / no dosing flags / no monitoring language" guardrails
- Model: `gpt-4o-mini` · Temperature: `0.3` · `max_tokens: 500`
- Brevo SMTP send path, subject builder, HTML template
- `weekly_digest_log` row shape (`status`, `events_count`, `summary_preview`, etc.)

Response unwraps as `result.content` instead of `data.choices[0].message.content`. That is the only call-site shape change.

### Verification plan
- [ ] Invoke in `mode: "preview"` against a test user with 2+ people and 5+ events in the last 7 days → confirm the 2–4 paragraph AI summary renders
- [ ] Invoke in `mode: "preview"` after temporarily unsetting `AZURE_OPENAI_API_KEY` → confirm the deterministic fallback bullet summary renders (no 500, email still sends)
- [ ] Flip `WELLET_AI_VENDOR=openai_direct` in staging and invoke → confirm `assertVendorAllowedForPhi` throws, fallback renders, email still sends
- [ ] Confirm Supabase function logs show `vendor: "azure"` on AI success
- [ ] `weekly_digest_log` row written with status="sent" in all three above

### Privacy policy follow-up
Closing GET-28 (this PR + GET-29, GET-30, GET-31, GET-32) flips the `getwellet.com/privacy` BAA disclosure across the board.
