### PR TITLE
GET-29: migrate generate-visit-questions to Azure OpenAI adapter

### DIFF
--- a/supabase/functions/generate-visit-questions/index.ts
+++ b/supabase/functions/generate-visit-questions/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { getCorsHeaders } from "../_shared/cors.ts";
+import { aiChat } from "../_shared/azureOpenAI.ts";
 
 serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
@@ -11,7 +12,8 @@ serve(async (req) => {
   try {
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const openaiKey = Deno.env.get("OPENAI_API_KEY")!;
+    // AI vendor + keys are owned by ../_shared/azureOpenAI.ts. PHI-touching
+    // calls route through Azure OpenAI (BAA-covered) with phi:true.
 
     // Authenticate the caller
     const authHeader = req.headers.get("Authorization");
@@ -119,23 +121,20 @@ serve(async (req) => {
       });
     }
 
-    // Call OpenAI to generate visit questions
-    const aiResponse = await fetch(
-      "https://api.openai.com/v1/chat/completions",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${openaiKey}`,
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-mini",
-          temperature: 0.4,
-          max_tokens: 500,
-          messages: [
-            {
-              role: "system",
-              content: `You are a helpful health assistant for family caregivers. Based on the patient data provided, generate 3-5 thoughtful questions that a caregiver should ask the doctor at the next appointment.
+    // PHI: caregiver-side question generation from the loved one's meds,
+    // conditions, and recent events. phi:true engages the adapter's
+    // assertVendorAllowedForPhi guardrail — Azure OpenAI under BAA only.
+    let raw: string;
+    try {
+      const result = await aiChat({
+        model: "gpt-4o-mini",
+        temperature: 0.4,
+        max_tokens: 500,
+        phi: true,
+        messages: [
+          {
+            role: "system",
+            content: `You are a helpful health assistant for family caregivers. Based on the patient data provided, generate 3-5 thoughtful questions that a caregiver should ask the doctor at the next appointment.
 
 Rules:
 - Questions should be specific and relevant to the patient's current health data
@@ -145,18 +144,16 @@ Rules:
 - Do NOT diagnose or suggest treatments
 - Return ONLY a JSON array of strings, no other text
 - Example format: ["Question one?", "Question two?", "Question three?"]`,
-            },
-            {
-              role: "user",
-              content: `Generate doctor visit questions for this patient:\n\n${context}`,
-            },
-          ],
-        }),
-      }
-    );
-
-    if (!aiResponse.ok) {
-      console.error("OpenAI error:", await aiResponse.text());
+          },
+          {
+            role: "user",
+            content: `Generate doctor visit questions for this patient:\n\n${context}`,
+          },
+        ],
+      });
+      raw = result.content || "[]";
+    } catch (aiErr) {
+      console.error("Azure OpenAI error:", aiErr);
       return new Response(
         JSON.stringify({ error: "AI generation failed" }),
         {
@@ -165,9 +162,6 @@ Rules:
         }
       );
     }
-
-    const aiData = await aiResponse.json();
-    const raw = aiData.choices?.[0]?.message?.content || "[]";
 
     // Parse the JSON array from the response
     let questions: string[];


### PR DESCRIPTION
## GET-29: migrate `generate-visit-questions` to Azure OpenAI adapter

Third migration in the [GET-28](https://linear.app/getwellet/issue/GET-28) bundle.

Refs: [GET-29](https://linear.app/getwellet/issue/GET-29) · parent [GET-28](https://linear.app/getwellet/issue/GET-28)

### What changes
1. Import `aiChat` from `../_shared/azureOpenAI.ts`
2. Drop the direct `OPENAI_API_KEY` env read
3. Swap the raw `fetch("https://api.openai.com/...")` for `aiChat({..., phi: true})`. Wrap in `try/catch`; on adapter error, return the same 500 shape as before.

### What does NOT change
- Supabase data pulls (person profile, active meds, last 90 days of events) — untouched
- Context-building logic — untouched
- Model: `gpt-4o-mini` · Temperature: `0.4` · `max_tokens: 500`
- System prompt including the "do NOT diagnose or suggest treatments" guardrail
- JSON-array parsing logic (both the direct `JSON.parse` path and the regex-fallback path)
- Response shape: `{ questions }` or `{ error }`

Response unwraps as `result.content` instead of `aiData.choices[0].message.content`. That is the only call-site shape change.

### Verification plan
- [ ] Invoke locally / in staging with a person who has active meds + recent events → confirm 3–5 questions returned as a JSON array
- [ ] Test with a person who has minimal data (just name + DOB) → confirm questions still generated
- [ ] Confirm Supabase function logs show `vendor: "azure"` on success
- [ ] Flip `WELLET_AI_VENDOR=openai_direct` in staging and confirm 500 with `assertVendorAllowedForPhi`
