### PR TITLE
fix(auth): auto-send OTP when arriving from getwellet.com hero

### DIFF
--- a/assets/wellet.js
+++ b/assets/wellet.js
@@ -13451,15 +13451,33 @@ function showAuthScreen() {
   // Pre-fill email from ?email= URL param (from getwellet.com inline signup).
   // Falls back to localStorage if no URL param. Does not overwrite a value
   // the user has already typed in the field.
+  var _autoSendFromHero = false;
   try {
     var emailInput = document.getElementById('auth-email');
     if (emailInput && !emailInput.value) {
-      var urlEmail = null;
-      try {
-        urlEmail = new URLSearchParams(window.location.search).get('email');
-      } catch (_e) {}
+      var _params = null;
+      try { _params = new URLSearchParams(window.location.search); } catch (_e) {}
+      var urlEmail = _params ? _params.get('email') : null;
       if (urlEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(urlEmail)) {
         emailInput.value = urlEmail.trim().toLowerCase();
+        // Auto-send bridge: when the caregiver committed on getwellet.com
+        // (hero, hero bottom, /me hero, or pricing CTA) and the email is
+        // already valid, skip the extra "Send 6-digit code" click and go
+        // straight to the code-entry screen. Other signup_locations (or a
+        // bare ?email= link) still require the manual click, so a random
+        // paste of an email URL never auto-sends.
+        var _sloc = _params ? (_params.get('signup_location') || '').toLowerCase() : '';
+        // signup_location values getwellet.com emits today:
+        //   'hero'     — top hero form on any page
+        //   'bottom'   — bottom-of-page CTA form
+        //   'me_hero'  — top hero form on /me (self-use landing)
+        // Any of these are explicit caregiver commit signals from our own
+        // site, safe to auto-send. A bare ?email= link with no signup_location
+        // (or any other value) falls through to the manual click flow.
+        var _autoSendLocations = ['hero','bottom','me_hero'];
+        if (_autoSendLocations.indexOf(_sloc) !== -1) {
+          _autoSendFromHero = true;
+        }
       } else {
         var stored = null;
         try { stored = localStorage.getItem('wellet_last_signin_email'); } catch (_e) {}
@@ -13469,6 +13487,37 @@ function showAuthScreen() {
   } catch (_e) {}
   window.scrollTo(0, 0);
   initIcons();
+  // If we detected an auto-send bridge from getwellet.com, hide the form
+  // state during send so the user goes straight from getwellet.com to the
+  // "Check your email" screen with no flicker of the intermediate form.
+  // On send success, sendMagicLink() itself reveals #auth-sent-state. On
+  // failure, we restore #auth-form-state so the user can retry manually.
+  if (_autoSendFromHero && typeof sendMagicLink === 'function') {
+    try {
+      var _formState = document.getElementById('auth-form-state');
+      var _sentState = document.getElementById('auth-sent-state');
+      var _sentEmailEl = document.getElementById('auth-sent-email');
+      if (_formState) _formState.style.display = 'none';
+      if (_sentEmailEl) _sentEmailEl.textContent = (document.getElementById('auth-email') || {}).value || '';
+      if (_sentState) _sentState.style.display = 'block';
+      // Kick sendMagicLink after paint so the sent-state renders first.
+      setTimeout(function () {
+        try {
+          var _r = sendMagicLink();
+          if (_r && typeof _r.catch === 'function') {
+            _r.catch(function () {
+              // Restore form state on error; sendMagicLink already toasted.
+              if (_formState) _formState.style.display = 'block';
+              if (_sentState) _sentState.style.display = 'none';
+            });
+          }
+        } catch (_e) {
+          if (_formState) _formState.style.display = 'block';
+          if (_sentState) _sentState.style.display = 'none';
+        }
+      }, 0);
+    } catch (_e) {}
+  }
 }
 
 function enterDemoMode() {


### PR DESCRIPTION
## What this fixes

Betsy flagged the getwellet.com → mywellet.com signup handoff as **very clunky**. Walked the flow:

1. User types email on getwellet.com hero → clicks **Start free →**
2. Redirects to `mywellet.com/?email=…&signup_location=hero`
3. **Bug:** mywellet.com re-pitches the product (headline, subhead, another CTA) and requires a second click on **Send 6-digit code** before the code is actually sent
4. Only then does the user land on the "Check your email" screen

That's two rounds of marketing copy + one extra click between "I want to try this" and "code sent."

## What this PR does

`showAuthScreen()` already prefills `#auth-email` from the `?email=` URL param. This PR adds an **auto-send bridge** on top:

- If the URL has a valid `?email=` AND `signup_location` ∈ `{hero, bottom, me_hero}` (the getwellet-owned commit signals), we:
  1. Prefill the email input (existing behavior)
  2. Hide `#auth-form-state`, prefill `#auth-sent-email`, and show `#auth-sent-state` immediately — no flicker of the intermediate form
  3. Call `sendMagicLink()` after paint (via `setTimeout(…, 0)`) so the sent-state renders first
  4. On send failure, restore `#auth-form-state` so the user can retry manually (Supabase error toast already fires)

- Any other signup_location value, or a bare `?email=` with no signup_location, falls through to the existing manual-click flow. A random paste of an email URL never auto-sends.

## Files

`assets/wellet.js` — `showAuthScreen()` only. +53/-4.

## Not touched

- `sendMagicLink()` itself — reused as-is
- Attribution capture (`_buildSignupAttribution`, `wellet_signup_attribution`)
- OTP verification (`verifyAuthCode`)
- RLS, Supabase auth config, session handling
- No new secrets, keys, or third-party calls
- No copy changes user-facing except reusing the existing "Check your email" screen sooner

## Manual test plan

1. Open `https://mywellet.com/?email=test@example.com&signup_location=hero` → should land directly on "Check your email" with `test@example.com` prefilled, code already sent (check inbox in staging)
2. Open `https://mywellet.com/?email=test@example.com` (no signup_location) → should show the form with email prefilled, "Send 6-digit code" required
3. Open `https://mywellet.com/` → normal manual flow, no changes
4. Type an email + click Send → normal manual flow, no changes
5. Force a send error (bad domain) with `?signup_location=hero` → sent-state hides, form-state restores, toast fires

## Related

Follow-on work Betsy asked about but out of scope for this PR:
- Pricing page audit (separate thread)
- Reviewing the mywellet.com landing copy — the re-pitch above the auth card. Some caregivers may still see it via other entry paths (email links, direct visits). Leaving copy alone in this PR.